### PR TITLE
Add scheduled mailbox auto reply helper

### DIFF
--- a/Examples/Example_SetSharedMailboxAutoReply.ps1
+++ b/Examples/Example_SetSharedMailboxAutoReply.ps1
@@ -1,0 +1,10 @@
+Import-Module ../src/SupportTools/SupportTools.psd1
+
+$start = Get-Date '2025-06-02T00:00:00'
+$end   = Get-Date '2025-06-09T23:59:59'
+
+Set-SharedMailboxAutoReply -MailboxIdentity 'parts@yellowfin.com' \ 
+    -StartTime $start -EndTime $end \ 
+    -InternalMessage 'Apologies, but I\'m out of the office from 6/2 - 6/9 and will return on 6/10. I will be responding to all emails and phone calls upon my return. If you need immediate assistance, please reach out to Jay Wagner at ext 312.' \ 
+    -ExternalMessage 'Apologies, but I\'m out of the office from 6/2 - 6/9 and will return on 6/10. I will be responding to all emails and phone calls upon my return. If you need immediate assistance, please reach out to Jay Wagner at ext 312.' \ 
+    -AdminUser 'youradmin@yourdomain.com'

--- a/README.md
+++ b/README.md
@@ -20,5 +20,8 @@ Example command:
 Get-CommonSystemInfo
 ```
 
+The module also provides `Set-SharedMailboxAutoReply` for configuring automatic
+out-of-office replies on a shared mailbox.
+
 For a list of the wrapped scripts and their descriptions see [scripts/README.md](scripts/README.md).
-Example scripts can be found in the /Examples folder.
+Example scripts can be found in the /Examples folder, including `Example_SetSharedMailboxAutoReply.ps1`.

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'SupportTools.psm1'
-    ModuleVersion = '1.1.0'
+    ModuleVersion = '1.2.0'
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000001'
     Author = 'Contoso'
     Description = 'Collection of helper functions wrapping existing scripts.'
@@ -22,6 +22,7 @@
         'Set-TimeZoneEasternStandardTime',
         'SimpleCountdown',
         'Update-Sysmon',
+        'Set-SharedMailboxAutoReply',
         'Invoke-ExchangeCalendarManager'
     )
 }

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -22,6 +22,7 @@ Describe 'SupportTools Module' {
             'Set-TimeZoneEasternStandardTime',
             'SimpleCountdown',
             'Update-Sysmon',
+            'Set-SharedMailboxAutoReply',
             'Invoke-ExchangeCalendarManager'
         )
 


### PR DESCRIPTION
## Summary
- add `Set-SharedMailboxAutoReply` function for scheduled OOF replies
- export the new function from SupportTools module
- bump module version to 1.2.0
- include example script and docs
- update tests for new command

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester"` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840600db6c0832cb83a5622560c1fe3