### PR TITLE
Return custom object from AddUsersToGroup

### DIFF
--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -64,4 +64,13 @@ Describe 'SupportTools Module' {
             }
         }
     }
+
+    Context 'Add-UsersToGroup output passthrough' {
+        It 'returns the object produced by the script' {
+            $expected = [pscustomobject]@{ GroupName = 'MyGroup'; AddedUsers = @('a'); SkippedUsers = @('b') }
+            Mock Invoke-ScriptFile { $expected }
+            $result = Add-UsersToGroup -CsvPath 'users.csv' -GroupName 'MyGroup'
+            $result | Should -Be $expected
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- return a `[pscustomobject]` from AddUsersToGroup
- verify wrapper passes through script output in tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431d4a3690832ca36c684720d73449