### PR TITLE
Add SharePointTools configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Import-Module ./src/SupportTools/SupportTools.psd1
 Import-Module ./src/SharePointTools/SharePointTools.psd1
 ```
 
+Before running any SharePoint cleanup commands, execute the configuration script
+once to store your tenant details:
+
+```powershell
+./scripts/Configure-SharePointTools.ps1
+```
+
 Example command:
 
 ```powershell

--- a/config/SharePointToolsSettings.psd1
+++ b/config/SharePointToolsSettings.psd1
@@ -1,0 +1,5 @@
+@{
+    ClientId = ''
+    TenantId = ''
+    CertPath = ''
+}

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -37,6 +37,12 @@ Import-Module ./src/SupportTools/SupportTools.psd1
 Import-Module ./src/SharePointTools/SharePointTools.psd1
 ```
 
+Run the configuration script once to store your SharePoint application details:
+
+```powershell
+./scripts/Configure-SharePointTools.ps1
+```
+
 You can place these commands in your profile or deployment scripts so the functions are available in each session.
 
 ## Running Commands

--- a/scripts/Configure-SharePointTools.ps1
+++ b/scripts/Configure-SharePointTools.ps1
@@ -1,0 +1,27 @@
+param()
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$settingsPath = Join-Path $repoRoot 'config/SharePointToolsSettings.psd1'
+
+if (Test-Path $settingsPath) {
+    try {
+        $settings = Import-PowerShellDataFile $settingsPath
+    } catch {
+        $settings = @{ ClientId=''; TenantId=''; CertPath='' }
+    }
+} else {
+    $settings = @{ ClientId=''; TenantId=''; CertPath='' }
+}
+
+Write-Host 'Enter SharePoint application settings. Leave blank to keep existing values.' -ForegroundColor Cyan
+$clientId = Read-Host "Client ID (current: $($settings.ClientId))"
+if ($clientId) { $settings.ClientId = $clientId }
+
+$tenantId = Read-Host "Tenant ID (current: $($settings.TenantId))"
+if ($tenantId) { $settings.TenantId = $tenantId }
+
+$certPath = Read-Host "Certificate Path (current: $($settings.CertPath))"
+if ($certPath) { $settings.CertPath = $certPath }
+
+$settings | Out-File -FilePath $settingsPath -Encoding utf8
+Write-Host "Settings saved to $settingsPath" -ForegroundColor Green

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,3 +23,4 @@ The following table provides a brief description of each script.
 | **SimpleCountdown.ps1** | Outputs a simple countdown from 10 to 1. |
 | **Update-Sysmon.ps1** | Reinstalls Sysmon from a removable drive and verifies it is running. |
 | **SS_DEPLOYMENT_TEMPLATE.ps1** | Template for sneaker net deployments that installs agents and configures a system. |
+| **Configure-SharePointTools.ps1** | Prompts for SharePoint application values and saves them to a settings file. |

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -1,5 +1,13 @@
 # SharePoint cleanup helpers
 
+# Load configuration values if available
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
+$settingsFile = Join-Path $repoRoot 'config/SharePointToolsSettings.psd1'
+$SharePointToolsSettings = @{ ClientId=''; TenantId=''; CertPath='' }
+if (Test-Path $settingsFile) {
+    try { $SharePointToolsSettings = Import-PowerShellDataFile $settingsFile } catch {}
+}
+
 
 function Invoke-YFArchiveCleanup {
     [CmdletBinding()]
@@ -36,9 +44,9 @@ function Invoke-ArchiveCleanup {
         [Parameter(Mandatory)]
         [string]$SiteUrl,
         [string]$LibraryName = 'Shared Documents',
-        [string]$ClientId = '<CLIENT-ID>',
-        [string]$TenantId = '<TENANT-ID>',
-        [string]$CertPath = '<PATH-TO-CERTIFICATE>'
+        [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [string]$TenantId = $SharePointToolsSettings.TenantId,
+        [string]$CertPath = $SharePointToolsSettings.CertPath
     )
 
     Import-Module PnP.PowerShell -ErrorAction Stop
@@ -143,9 +151,9 @@ function Invoke-FileVersionCleanup {
         [string]$SiteName,
         [string]$SiteUrl,
         [string]$LibraryName = 'Shared Documents',
-        [string]$ClientId = '<CLIENT-ID>',
-        [string]$TenantId = '<TENANT-ID>',
-        [string]$CertPath = '<PATH-TO-CERTIFICATE>',
+        [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [string]$TenantId = $SharePointToolsSettings.TenantId,
+        [string]$CertPath = $SharePointToolsSettings.CertPath,
         [string]$ReportPath = 'exportedReport.csv'
     )
 
@@ -194,9 +202,9 @@ function Invoke-SharingLinkCleanup {
         [string]$SiteUrl,
         [string]$LibraryName = 'Shared Documents',
         [string]$FolderName,
-        [string]$ClientId = '<CLIENT-ID>',
-        [string]$TenantId = '<TENANT-ID>',
-        [string]$CertPath = '<PATH-TO-CERTIFICATE>'
+        [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [string]$TenantId = $SharePointToolsSettings.TenantId,
+        [string]$CertPath = $SharePointToolsSettings.CertPath
     )
 
     Import-Module PnP.PowerShell -ErrorAction Stop


### PR DESCRIPTION
## Summary
- introduce `Configure-SharePointTools.ps1` helper for saving SharePoint app settings
- keep module defaults in `config/SharePointToolsSettings.psd1`
- read the configuration in `SharePointTools.psm1`
- mention configuration step in documentation

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester" tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684322166018832cad87184048ab511c