### PR TITLE
Add missing help and unify variable naming

### DIFF
--- a/scripts/PostInstallScript.ps1
+++ b/scripts/PostInstallScript.ps1
@@ -14,6 +14,13 @@
 # Functions listed here
 
 function MSStoreAppInstallerUpdate {
+    <#
+    .SYNOPSIS
+        Opens the Microsoft Store page for the App Installer.
+    .DESCRIPTION
+        Launches the Store page to allow the user to update the App Installer
+        application.
+    #>
     Start-Process ms-windows-store://pdp/?ProductId=9NBLGGH4NNS1
     if (!$LASTEXITCODE)
     {
@@ -27,10 +34,14 @@ function MSStoreAppInstallerUpdate {
 
 
 function Install-Chrome {
+    <#
+    .SYNOPSIS
+        Installs the Google Chrome browser using winget.
+    #>
     Write-Host 'Installing: Google Chrome'
 
-    $package_id = 'Google.Chrome'
-    winget install -e --id $package_id --scope machine --accept-source-agreements --silent
+    $PackageId = 'Google.Chrome'
+    winget install -e --id $PackageId --scope machine --accept-source-agreements --silent
 
     # validate install
     if (!$LASTEXITCODE) {
@@ -43,10 +54,14 @@ function Install-Chrome {
 
 
 function Install-AdobeAcrobatReader {
+    <#
+    .SYNOPSIS
+        Installs Adobe Acrobat Reader via winget.
+    #>
     Write-Host 'Installing: Adobe Acrobat Reader'
 
-    $package_id = 'Adobe.Acrobat.Reader.64-bit'
-    winget install -e --id $package_id --scope machine --accept-source-agreements --silent
+    $PackageId = 'Adobe.Acrobat.Reader.64-bit'
+    winget install -e --id $PackageId --scope machine --accept-source-agreements --silent
 
     # validate install
     if (!$LASTEXITCODE) {
@@ -59,10 +74,14 @@ function Install-AdobeAcrobatReader {
 
 
 function Install-ExcelMobile {
+    <#
+    .SYNOPSIS
+        Installs the Excel Mobile application via winget.
+    #>
     Write-Host 'Installing: Excel Mobile'
 
-    $package_id = '9WZDNCRFJBH3'
-    winget install -e --id $package_id --scope machine --accept-source-agreements --silent
+    $PackageId = '9WZDNCRFJBH3'
+    winget install -e --id $PackageId --scope machine --accept-source-agreements --silent
 
     # validate install
     if (!$LASTEXITCODE)
@@ -76,6 +95,10 @@ function Install-ExcelMobile {
 
 
 function Enable-NetFramework {
+    <#
+    .SYNOPSIS
+        Enables the .NET Framework 3.5 feature.
+    #>
     Write-Host ".NET 3.5 Framework: Enabling..."
     Enable-WindowsOptionalFeature -Online -FeatureName "NetFx3" -All -NoRestart -ErrorAction Stop > $null
 
@@ -89,68 +112,91 @@ function Enable-NetFramework {
 }
 
 
-function Get-ComputerName
-{
+function Get-ComputerName {
+    <#
+    .SYNOPSIS
+        Prompts the user for a computer name until the value is confirmed.
+    .OUTPUTS
+        System.String
+    #>
     # pipe the string returned to Rename-Computer
     # EX: Get-ComputerName | 
-    $unconfirmed = $true
-    while ($unconfirmed)
+    $Unconfirmed = $true
+    while ($Unconfirmed)
     {
-        $computerNameOne = Read-Host -Prompt 'What would you like to name this computer?'
+        $ComputerNameOne = Read-Host -Prompt 'What would you like to name this computer?'
 
-        $computerNameTwo = Read-Host -Prompt 'Re-enter the computer name previously entered'
+        $ComputerNameTwo = Read-Host -Prompt 'Re-enter the computer name previously entered'
 
-        if ($computerNameOne -eq $computerNameTwo)
+        if ($ComputerNameOne -eq $ComputerNameTwo)
         {
-            $unconfirmed = $false
+            $Unconfirmed = $false
         }
         else 
         {
             Write-Warning -Message "Computer names do not match up. Try again."
         }
     }
-    $computerNameOne
+    $ComputerNameOne
 }
 
 
 function Get-DriveLetter {
+    <#
+    .SYNOPSIS
+        Returns the drive letter containing installation media.
+    .OUTPUTS
+        System.String
+    #>
         # get the correct drive letter
-        $driveLetters = @("D", "E", "F", "G")
-        foreach ($driverLetter in $driveLetters)
+        $DriveLetters = @("D", "E", "F", "G")
+        foreach ($DriverLetter in $DriveLetters)
         {
-            $drivePath = "$($driverLetter):\"
-            $isDrivePathValid = Test-Path $drivePath
-            if ($isDrivePathValid)
+            $DrivePath = "$($DriverLetter):\"
+            $IsDrivePathValid = Test-Path $DrivePath
+            if ($IsDrivePathValid)
             {
-                return $drivePath
+                return $DrivePath
             }
         }
 }
 
 
 function Get-AgentPath {
+    <#
+    .SYNOPSIS
+        Retrieves the installation path for a specified agent.
+    .PARAMETER Agent
+        Name of the agent to locate.
+    .PARAMETER USB
+        Look for the agent on attached USB media.
+    .PARAMETER Local
+        Look for the agent in the local assets folder.
+    .OUTPUTS
+        System.String
+    #>
     param (
-        [string] $Agent,
-        [switch] $USB,
-        [switch] $Local
+        [string]$Agent,
+        [switch]$USB,
+        [switch]$Local
     )
 
-    $driveLetter = Get-DriveLetter
+    $DriveLetter = Get-DriveLetter
     if ($USB)
     {
     
         if ($Agent -eq "[REDACTED]")
         {
-            $agentPath = "$($driveLetter)assets\agents\[REDACTED]\[REDACTED].exe"
+            $AgentPath = "$($DriveLetter)assets\agents\[REDACTED]\[REDACTED].exe"
         }
         elseif ($Agent -eq "[REDACTED]") {
-            $agentPath = "$($driveLetter)assets\agents\[REDACTED]\[REDACTED].msi"
+            $AgentPath = "$($DriveLetter)assets\agents\[REDACTED]\[REDACTED].msi"
         }
         elseif ($Agent -eq "[REDACTED]") {
-            $agentPath = "$($driveLetter)assets\agents\[REDACTED]\[REDACTED].exe"
+            $AgentPath = "$($DriveLetter)assets\agents\[REDACTED]\[REDACTED].exe"
         }
         elseif ($Agent -eq "[REDACTED]") {
-            $agentPath = "$($driveLetter)assets\agents\[REDACTED]\[REDACTED].exe"
+            $AgentPath = "$($DriveLetter)assets\agents\[REDACTED]\[REDACTED].exe"
         }
     }
 
@@ -158,25 +204,28 @@ function Get-AgentPath {
     {
         if ($Agent -eq "[REDACTED]")
         {
-            $agentPath = ".\assets\agents\[REDACTED]\[REDACTED].exe"
+            $AgentPath = ".\assets\agents\[REDACTED]\[REDACTED].exe"
         }
         elseif ($Agent -eq "[REDACTED]") {
-            $agentPath = "$.\assets\agents\[REDACTED]\[REDACTED].msi"
+            $AgentPath = "$.\assets\agents\[REDACTED]\[REDACTED].msi"
         }
         elseif ($Agent -eq "Sysmon") {
-            $agentPath = ".\assets\agents\SysmonAgent\Sysmon64.exe"
+            $AgentPath = ".\assets\agents\SysmonAgent\Sysmon64.exe"
         }
         elseif ($Agent -eq "[REDACTED]") {
-            $agentPath = ".\assets\agents\[REDACTED]\[REDACTED].exe"
+            $AgentPath = ".\assets\agents\[REDACTED]\[REDACTED].exe"
         }
     }
 
-    return $agentPath
+    return $AgentPath
 
 }
 
-function Install-[REDACTED]
-{
+function Install-[REDACTED] {
+    <#
+    .SYNOPSIS
+        Copies a license key to the clipboard and launches the installer.
+    #>
     param (
         [switch] $USB,
         [switch] $Local
@@ -185,8 +234,8 @@ function Install-[REDACTED]
     if ($USB)
     {
         # copy key.txt to clipboard
-        $driveLetter = Get-DriveLetter
-        Get-Content "$($driveLetter)assets\agents\[REDACTED]\key.txt" | Set-Clipboard
+        $DriveLetter = Get-DriveLetter
+        Get-Content "$($DriveLetter)assets\agents\[REDACTED]\key.txt" | Set-Clipboard
     }
 
     if ($Local)
@@ -202,30 +251,46 @@ function Install-[REDACTED]
 }
 
 
-function Install-[REDACTED]
-{
+function Install-[REDACTED] {
+    <#
+    .SYNOPSIS
+        Launches the [REDACTED] installer from USB media.
+    #>
     # open [REDACTED]
     $Path = Get-AgentPath -Agent "[REDACTED]" -USB
     Start-Process $Path
 }
 
-function Install-[REDACTED]
-{
+function Install-[REDACTED] {
+    <#
+    .SYNOPSIS
+        Installs Sysmon using predefined arguments.
+    #>
     # Install Sysmon64.exe
     $Path = Get-AgentPath -Agent "[REDACTED]" -USB
 
     & $Path -i -accepteula
 }
 
-function Install-[REDACTED] 
-{
+function Install-[REDACTED] {
+    <#
+    .SYNOPSIS
+        Launches the ManageEngine agent installer.
+    #>
     # open ManageEngineAgentInstaller
     $Path = Get-AgentPath -Agent "[REDACTED]" -USB
     Start-Process $Path
 }
 
-function Copy-Files
-{
+function Copy-Files {
+    <#
+    .SYNOPSIS
+        Copies administration shortcuts from installation media to the public desktop.
+    .PARAMETER USB
+        Indicates the files should be copied from a USB drive.
+    .PARAMETER Local
+        Indicates the files should be copied from the local assets folder.
+    #>
     param (
         [switch] $USB,
         [switch] $Local
@@ -234,17 +299,17 @@ function Copy-Files
     if ($USB)
     {
     # Copy admin shortcut files from DesktopTools to public desktop
-    $driveLetter = Get-DriveLetter
-    $adminShortcuts = Get-ChildItem "$($driveLetter)assets\Tools\DesktopTools" 
+    $DriveLetter = Get-DriveLetter
+    $AdminShortcuts = Get-ChildItem "$($DriveLetter)assets\Tools\DesktopTools" 
     }
 
     if ($Local)
     {
-        $adminShortcuts = Get-ChildItem ".\assets\Tools\DesktopTools" 
+        $AdminShortcuts = Get-ChildItem ".\assets\Tools\DesktopTools" 
     }
 
 
-    foreach ($shortcut in $adminShortcuts)
+    foreach ($shortcut in $AdminShortcuts)
     {
         Copy-Item -Path $shortcut.Fullname -Destination "C:\Users\Public\Desktop\"
     }
@@ -254,7 +319,7 @@ function Copy-Files
     # Copy printer drivers to public desktop
     if ($USB)
     {
-        Copy-Item -Path "$($driveLetter)assets\PrinterDrivers" -Destination "C:\Users\Public\Desktop" -Recurse
+        Copy-Item -Path "$($DriveLetter)assets\PrinterDrivers" -Destination "C:\Users\Public\Desktop" -Recurse
     }
 
     if ($Local)
@@ -265,14 +330,20 @@ function Copy-Files
 
 
 function Set-PowerPlan {
-    # set power plan to high performance
-    $high_performance_guid = '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
-    $balanced_guid = '381b4222-f694-41f0-9685-ff5bb260df2e'
-    $power_saver_guid = 'a1841308-3541-4fab-bc81-f71556f20b4a'
+    <#
+    .SYNOPSIS
+        Configures the system power plan for performance.
+    .DESCRIPTION
+        Sets High Performance as the active plan and removes the Balanced and
+        Power Saver plans.
+    #>
+    $HighPerformanceGuid = '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
+    $BalancedGuid = '381b4222-f694-41f0-9685-ff5bb260df2e'
+    $PowerSaverGuid = 'a1841308-3541-4fab-bc81-f71556f20b4a'
 
     # set power plan to high performance
     Write-Host "Setting Power Plan: High Performance"
-    powercfg.exe /S $high_performance_guid
+    powercfg.exe /S $HighPerformanceGuid
     if (!$LASTEXITCODE) {
         Write-Host "Set Power Plan: High Performance"
     }
@@ -282,7 +353,7 @@ function Set-PowerPlan {
 
     # remove balanced power plan
     Write-Host "Deleting Power Plan: Balanced"
-    powercfg.exe /D $balanced_guid
+    powercfg.exe /D $BalancedGuid
     if (!$LASTEXITCODE) {
         Write-Host "Deleted Power Plan: Balanced"
     }
@@ -292,7 +363,7 @@ function Set-PowerPlan {
 
     # remove power saver power plan
     Write-Host "Deleting Power Plan: Power Saver"
-    powercfg.exe /D $power_saver_guid
+    powercfg.exe /D $PowerSaverGuid
     if (!$LASTEXITCODE) {
         Write-Host "Deleted Power Plan: Power Saver"
     }
@@ -301,8 +372,15 @@ function Set-PowerPlan {
     }
 }
 
-function Main
-{
+function Main {
+    <#
+    .SYNOPSIS
+        Executes the full post-installation workflow.
+    .DESCRIPTION
+        Installs required agents and applications, copies administrative files,
+        enables .NET Framework and sets the power plan before joining the
+        computer to the domain.
+    #>
     # install agents
     Write-Information -MessageData "Executing Agent Installers" -InformationAction Continue
     Install-[REDACTED] -USB
@@ -334,12 +412,12 @@ function Main
 
     # name computer
     Write-Information -MessageData "Renaming Computer..." -InformationAction Continue
-    $newComputerName = Get-ComputerName
-    Rename-Computer -NewName $newComputerName -Force
+    $NewComputerName = Get-ComputerName
+    Rename-Computer -NewName $NewComputerName -Force
 
     # add computer to domain
     Write-Warning "Adding Computer to domain...Press [CTRL] + [C] to abort..."
-    Add-Computer -NewName $newComputerName -DomainName "myus.local" -DomainCredential (Get-Credential) -Force
+    Add-Computer -NewName $NewComputerName -DomainName "myus.local" -DomainCredential (Get-Credential) -Force
 
     Write-Information -MessageData "Restart computer to apply changes..."
 

--- a/scripts/SS_DEPLOYMENT_TEMPLATE.ps1
+++ b/scripts/SS_DEPLOYMENT_TEMPLATE.ps1
@@ -24,6 +24,16 @@
 
 
 function Install-Something {
+    <#
+    .SYNOPSIS
+        Installs a package from a server share.
+    .PARAMETER ServerSharePath
+        UNC path to the deployment share.
+    .PARAMETER FilePath
+        Relative path to the installer file.
+    .PARAMETER Arguments
+        Additional arguments to pass to Start-Process.
+    #>
     param (
         [Parameter()]
         [string]
@@ -42,6 +52,12 @@ function Install-Something {
 }
 
 function Confirm-ServiceRunning {
+    <#
+    .SYNOPSIS
+        Confirms required services are running.
+    .PARAMETER ServiceList
+        Names of additional services to check.
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]
@@ -76,6 +92,16 @@ function Confirm-ServiceRunning {
 }
 
 function Export-Client {
+    <#
+    .SYNOPSIS
+        Exports client system information to an XML file on a share.
+    .PARAMETER ServerSharePath
+        UNC path to the deployment share.
+    .PARAMETER ScriptBlockArray
+        Additional script blocks whose output will be included.
+    .PARAMETER UpdateVersion
+        Version identifier for the deployment.
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]
@@ -126,6 +152,14 @@ function Export-Client {
 }
 
 function Get-WHVersions {
+    <#
+    .SYNOPSIS
+        Checks file versions for deployment validation.
+    .PARAMETER Shipping
+        Validate versions for shipping files.
+    .PARAMETER Login
+        Validate versions for login files.
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]
@@ -206,6 +240,14 @@ function Get-WHVersions {
 }
 
 function Get-ServerSharePath {
+    <#
+    .SYNOPSIS
+        Returns the UNC path to the deployment server.
+    .PARAMETER Login
+        Retrieve the share path for login files.
+    .PARAMETER Ship
+        Retrieve the share path for shipping files.
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]
@@ -226,6 +268,14 @@ function Get-ServerSharePath {
 }
 
 function Get-UpdateVersion {
+    <#
+    .SYNOPSIS
+        Generates a string representing the deployment version.
+    .PARAMETER Login
+        Create a version for login deployments.
+    .PARAMETER Ship
+        Create a version for shipping deployments.
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]
@@ -247,13 +297,19 @@ function Get-UpdateVersion {
 }
 
 function Set-Signoff {
+    <#
+    .SYNOPSIS
+        Displays a completion image at the end of deployment.
+    .PARAMETER ServerSharePath
+        UNC path to the deployment share containing assets.
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]
         [string]
         $ServerSharePath
     )
-    $filePath = "\\$($serverSharePath)\assets\mermaidMan.jpg"
+    $filePath = "\\$($ServerSharePath)\assets\mermaidMan.jpg"
     [void][reflection.assembly]::LoadWithPartialName("System.Windows.Forms")
 
     $file = (get-item $filePath)
@@ -274,7 +330,7 @@ function Set-Signoff {
     $form.ShowDialog()    
 }
 
-$serverSharePath = Get-ServerSharePath -Login -Ship
+$ServerSharePath = Get-ServerSharePath -Login -Ship
 $updateVersion = Get-UpdateVersion -Login -Ship
 
 

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -9,14 +9,28 @@ if (Test-Path $settingsFile) {
 }
 
 function Save-SPToolsSettings {
+    <#
+    .SYNOPSIS
+        Persists SharePoint Tools configuration to disk.
+    #>
     $SharePointToolsSettings | Out-File -FilePath $settingsFile -Encoding utf8
 }
 
 function Get-SPToolsSettings {
+    <#
+    .SYNOPSIS
+        Retrieves the current SharePoint Tools settings.
+    #>
     $SharePointToolsSettings
 }
 
 function Get-SPToolsSiteUrl {
+    <#
+    .SYNOPSIS
+        Gets the site URL mapped to a given name.
+    .PARAMETER SiteName
+        Friendly name of the site.
+    #>
     param([Parameter(Mandatory)][string]$SiteName)
     $url = $SharePointToolsSettings.Sites[$SiteName]
     if (-not $url) { throw "Site '$SiteName' not found in settings." }
@@ -24,6 +38,14 @@ function Get-SPToolsSiteUrl {
 }
 
 function Add-SPToolsSite {
+    <#
+    .SYNOPSIS
+        Adds a new SharePoint site entry to the settings file.
+    .PARAMETER Name
+        Key used to reference the site.
+    .PARAMETER Url
+        Full URL of the SharePoint site.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Name,
@@ -34,6 +56,14 @@ function Add-SPToolsSite {
 }
 
 function Set-SPToolsSite {
+    <#
+    .SYNOPSIS
+        Updates an existing SharePoint site entry.
+    .PARAMETER Name
+        Key used to reference the site.
+    .PARAMETER Url
+        New URL to set for the site.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Name,
@@ -44,6 +74,12 @@ function Set-SPToolsSite {
 }
 
 function Remove-SPToolsSite {
+    <#
+    .SYNOPSIS
+        Removes a SharePoint site entry from the settings file.
+    .PARAMETER Name
+        Key of the site to remove.
+    #>
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$Name)
     [void]$SharePointToolsSettings.Sites.Remove($Name)
@@ -52,6 +88,10 @@ function Remove-SPToolsSite {
 
 
 function Invoke-YFArchiveCleanup {
+    <#
+    .SYNOPSIS
+        Removes archive items from the YF site.
+    #>
     [CmdletBinding()]
     param()
 
@@ -59,6 +99,10 @@ function Invoke-YFArchiveCleanup {
 }
 
 function Invoke-IBCCentralFilesArchiveCleanup {
+    <#
+    .SYNOPSIS
+        Removes archive items from the IBCCentralFiles site.
+    #>
     [CmdletBinding()]
     param()
 
@@ -66,6 +110,10 @@ function Invoke-IBCCentralFilesArchiveCleanup {
 }
 
 function Invoke-MexCentralFilesArchiveCleanup {
+    <#
+    .SYNOPSIS
+        Removes archive items from the MexCentralFiles site.
+    #>
     [CmdletBinding()]
     param()
 
@@ -162,6 +210,10 @@ function Invoke-ArchiveCleanup {
 }
 
 function Invoke-YFFileVersionCleanup {
+    <#
+    .SYNOPSIS
+        Removes old file versions from the YF site.
+    #>
     [CmdletBinding()]
     param()
 
@@ -169,6 +221,10 @@ function Invoke-YFFileVersionCleanup {
 }
 
 function Invoke-IBCCentralFilesFileVersionCleanup {
+    <#
+    .SYNOPSIS
+        Removes old file versions from the IBCCentralFiles site.
+    #>
     [CmdletBinding()]
     param()
 
@@ -176,6 +232,10 @@ function Invoke-IBCCentralFilesFileVersionCleanup {
 }
 
 function Invoke-MexCentralFilesFileVersionCleanup {
+    <#
+    .SYNOPSIS
+        Removes old file versions from the MexCentralFiles site.
+    #>
     [CmdletBinding()]
     param()
 
@@ -316,6 +376,10 @@ function Invoke-SharingLinkCleanup {
 }
 
 function Invoke-YFSharingLinkCleanup {
+    <#
+    .SYNOPSIS
+        Removes sharing links from the YF site.
+    #>
     [CmdletBinding()]
     param()
 
@@ -323,6 +387,10 @@ function Invoke-YFSharingLinkCleanup {
 }
 
 function Invoke-IBCCentralFilesSharingLinkCleanup {
+    <#
+    .SYNOPSIS
+        Removes sharing links from the IBCCentralFiles site.
+    #>
     [CmdletBinding()]
     param()
 
@@ -330,6 +398,10 @@ function Invoke-IBCCentralFilesSharingLinkCleanup {
 }
 
 function Invoke-MexCentralFilesSharingLinkCleanup {
+    <#
+    .SYNOPSIS
+        Removes sharing links from the MexCentralFiles site.
+    #>
     [CmdletBinding()]
     param()
 

--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -1,4 +1,12 @@
 function Invoke-ScriptFile {
+    <#
+    .SYNOPSIS
+        Executes a script from the repository's scripts folder.
+    .PARAMETER Name
+        Name of the script file to execute.
+    .PARAMETER Args
+        Additional arguments to pass to the script.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
@@ -6,7 +14,7 @@ function Invoke-ScriptFile {
         [Parameter(ValueFromRemainingArguments=$true)]
         [object[]]$Args
     )
-    $path = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath '..' | Join-Path -ChildPath "scripts/$Name"
-    if (-not (Test-Path $path)) { throw "Script '$Name' not found." }
-    & $path @Args
+    $Path = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath '..' | Join-Path -ChildPath "scripts/$Name"
+    if (-not (Test-Path $Path)) { throw "Script '$Name' not found." }
+    & $Path @Args
 }

--- a/src/SupportTools/Public/Add-UsersToGroup.ps1
+++ b/src/SupportTools/Public/Add-UsersToGroup.ps1
@@ -1,4 +1,15 @@
 function Add-UsersToGroup {
+    <#
+    .SYNOPSIS
+        Adds users from a CSV file to a Microsoft 365 group.
+    .DESCRIPTION
+        Wraps the AddUsersToGroup.ps1 script located in the repository's scripts
+        folder. Parameters are passed directly through to the script file.
+    .PARAMETER CsvPath
+        Path to the CSV file containing user principal names.
+    .PARAMETER GroupName
+        Name of the Microsoft 365 group to modify.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipelineByPropertyName=$true)]

--- a/src/SupportTools/Public/Clear-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Clear-ArchiveFolder.ps1
@@ -1,4 +1,11 @@
 function Clear-ArchiveFolder {
+    <#
+    .SYNOPSIS
+        Removes files and folders from the archived SharePoint directory.
+    .DESCRIPTION
+        This function wraps the CleanupArchive.ps1 script in the scripts folder.
+        All parameters are forwarded to that script.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Convert-ExcelToCsv.ps1
+++ b/src/SupportTools/Public/Convert-ExcelToCsv.ps1
@@ -1,4 +1,11 @@
 function Convert-ExcelToCsv {
+    <#
+    .SYNOPSIS
+        Converts an Excel workbook to CSV.
+    .DESCRIPTION
+        Wrapper for the Convert-ExcelToCsv.ps1 script contained in the scripts
+        directory. Any arguments provided are passed to the script.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Export-ProductKey.ps1
+++ b/src/SupportTools/Public/Export-ProductKey.ps1
@@ -1,4 +1,11 @@
 function Export-ProductKey {
+    <#
+    .SYNOPSIS
+        Retrieves the Windows product key.
+    .DESCRIPTION
+        Executes the ProductKey.ps1 script located in the scripts directory.
+        Any arguments are forwarded to that script.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Get-CommonSystemInfo.ps1
+++ b/src/SupportTools/Public/Get-CommonSystemInfo.ps1
@@ -1,4 +1,11 @@
 function Get-CommonSystemInfo {
+    <#
+    .SYNOPSIS
+        Returns common system information such as OS and hardware details.
+    .DESCRIPTION
+        Wraps the Get-CommonSystemInfo.ps1 script in the scripts folder and
+        forwards any provided arguments.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Get-FailedLogins.ps1
+++ b/src/SupportTools/Public/Get-FailedLogins.ps1
@@ -1,4 +1,11 @@
 function Get-FailedLogins {
+    <#
+    .SYNOPSIS
+        Retrieves failed login attempts from the Security event log.
+    .DESCRIPTION
+        Calls the Get-FailedLogins.ps1 script in the scripts folder and returns
+        its output.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Get-NetworkShares.ps1
+++ b/src/SupportTools/Public/Get-NetworkShares.ps1
@@ -1,4 +1,11 @@
 function Get-NetworkShares {
+    <#
+    .SYNOPSIS
+        Lists network shares on a specified computer.
+    .DESCRIPTION
+        Executes the Get-NetworkShares.ps1 script from the scripts folder and
+        returns its results.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Get-UniquePermissions.ps1
+++ b/src/SupportTools/Public/Get-UniquePermissions.ps1
@@ -1,4 +1,11 @@
 function Get-UniquePermissions {
+    <#
+    .SYNOPSIS
+        Returns items with unique permissions in a SharePoint site.
+    .DESCRIPTION
+        Calls the Get-UniquePermissions.ps1 script contained in the scripts
+        directory and outputs its results.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Install-Fonts.ps1
+++ b/src/SupportTools/Public/Install-Fonts.ps1
@@ -1,4 +1,11 @@
 function Install-Fonts {
+    <#
+    .SYNOPSIS
+        Installs font files for all users.
+    .DESCRIPTION
+        Simple wrapper for the Install-Fonts.ps1 script which performs the
+        installation work. Arguments are passed directly through.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Invoke-DeploymentTemplate.ps1
+++ b/src/SupportTools/Public/Invoke-DeploymentTemplate.ps1
@@ -1,4 +1,11 @@
 function Invoke-DeploymentTemplate {
+    <#
+    .SYNOPSIS
+        Runs the sample deployment template script.
+    .DESCRIPTION
+        This cmdlet executes SS_DEPLOYMENT_TEMPLATE.ps1 from the repository's
+        scripts folder with any additional arguments supplied.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -1,4 +1,11 @@
 function Invoke-ExchangeCalendarManager {
+    <#
+    .SYNOPSIS
+        Manages Exchange Online calendar permissions.
+    .DESCRIPTION
+        Wrapper around the ExchangeCalendarManager script which ensures the
+        ExchangeOnlineManagement module is installed before running.
+    #>
     [CmdletBinding()]
     param()
 

--- a/src/SupportTools/Public/Invoke-PostInstall.ps1
+++ b/src/SupportTools/Public/Invoke-PostInstall.ps1
@@ -1,4 +1,11 @@
 function Invoke-PostInstall {
+    <#
+    .SYNOPSIS
+        Executes the automated post installation script.
+    .DESCRIPTION
+        Runs PostInstallScript.ps1 from the scripts folder, forwarding any
+        arguments provided.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Search-ReadMe.ps1
+++ b/src/SupportTools/Public/Search-ReadMe.ps1
@@ -1,4 +1,11 @@
 function Search-ReadMe {
+    <#
+    .SYNOPSIS
+        Searches README files for a provided term.
+    .DESCRIPTION
+        Launches the Search-ReadMe.ps1 script from the scripts directory with
+        the specified arguments.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Set-ComputerIPAddress.ps1
+++ b/src/SupportTools/Public/Set-ComputerIPAddress.ps1
@@ -1,4 +1,10 @@
 function Set-ComputerIPAddress {
+    <#
+    .SYNOPSIS
+        Configures the IP address of a local or remote computer.
+    .DESCRIPTION
+        Wraps the Set-ComputerIPAddress.ps1 script, forwarding all arguments.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Set-NetAdapterMetering.ps1
+++ b/src/SupportTools/Public/Set-NetAdapterMetering.ps1
@@ -1,4 +1,11 @@
 function Set-NetAdapterMetering {
+    <#
+    .SYNOPSIS
+        Toggles the metered connection flag on a network adapter.
+    .DESCRIPTION
+        Invokes the Set-NetAdapterMetering.ps1 script with any supplied
+        arguments.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
+++ b/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
@@ -1,4 +1,11 @@
 function Set-SharedMailboxAutoReply {
+    <#
+    .SYNOPSIS
+        Configures automatic replies for a shared mailbox.
+    .DESCRIPTION
+        Wraps a script that manages Exchange Online auto-reply settings for a
+        shared mailbox. All specified parameters are forwarded to the script.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]

--- a/src/SupportTools/Public/Set-TimeZoneEasternStandardTime.ps1
+++ b/src/SupportTools/Public/Set-TimeZoneEasternStandardTime.ps1
@@ -1,4 +1,11 @@
 function Set-TimeZoneEasternStandardTime {
+    <#
+    .SYNOPSIS
+        Sets the system time zone to Eastern Standard Time.
+    .DESCRIPTION
+        Runs the Set-TimeZoneEasternStandardTime.ps1 script with any supplied
+        arguments.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Start-Countdown.ps1
+++ b/src/SupportTools/Public/Start-Countdown.ps1
@@ -1,4 +1,11 @@
 function Start-Countdown {
+    <#
+    .SYNOPSIS
+        Displays a countdown timer.
+    .DESCRIPTION
+        Executes the SimpleCountdown.ps1 script, passing through any provided
+        arguments.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/Public/Update-Sysmon.ps1
+++ b/src/SupportTools/Public/Update-Sysmon.ps1
@@ -1,4 +1,10 @@
 function Update-Sysmon {
+    <#
+    .SYNOPSIS
+        Updates the Sysmon installation on a computer.
+    .DESCRIPTION
+        Calls the Update-Sysmon.ps1 script with the supplied arguments.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -1,7 +1,7 @@
-$publicDir = Join-Path $PSScriptRoot 'Public'
-$privateDir = Join-Path $PSScriptRoot 'Private'
+$PublicDir = Join-Path $PSScriptRoot 'Public'
+$PrivateDir = Join-Path $PSScriptRoot 'Private'
 
-Get-ChildItem -Path "$privateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
-Get-ChildItem -Path "$publicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
+Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
+Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
 Export-ModuleMember -Function 'Add-UsersToGroup','Clear-ArchiveFolder','Convert-ExcelToCsv','Get-CommonSystemInfo','Get-FailedLogins','Get-NetworkShares','Get-UniquePermissions','Install-Fonts','Invoke-PostInstall','Export-ProductKey','Invoke-DeploymentTemplate','Search-ReadMe','Set-ComputerIPAddress','Set-NetAdapterMetering','Set-TimeZoneEasternStandardTime','Start-Countdown','Update-Sysmon','Set-SharedMailboxAutoReply','Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement'


### PR DESCRIPTION
## Summary
- add comment-based help to public wrapper cmdlets
- document helper functions in PostInstallScript and deployment template
- document SharePointTools functions
- standardize variable casing across scripts

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432e96d2d0832c84c030673685f06e