### PR TITLE
Add recycle bin reporting functions

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -59,11 +59,17 @@ Invoke-YFArchiveCleanup -Verbose
 # Manage the site list
 Add-SPToolsSite -Name 'ContosoHR' -Url 'https://contoso.sharepoint.com/sites/HR'
 
+# Generate a document library report for all configured sites
+Get-SPToolsAllLibraryReports | Format-Table
+# Review recycle bin usage for all sites
+Get-SPToolsAllRecycleBinReports | Format-Table
+# Clear both recycle bin stages for a site
+Clear-SPToolsRecycleBin -SiteName 'ContosoHR' -SecondStage
 # Configure auto-reply on a shared mailbox
 $start = Get-Date '2025-06-02T00:00:00'
 $end   = Get-Date '2025-06-09T23:59:59'
-Set-SharedMailboxAutoReply -MailboxIdentity 'team@contoso.com' \ 
-    -StartTime $start -EndTime $end \ 
+Set-SharedMailboxAutoReply -MailboxIdentity 'team@contoso.com' \
+    -StartTime $start -EndTime $end \
     -InternalMessage 'Out of office' \ 
     -ExternalMessage 'Out of office' \ 
     -AdminUser 'admin@contoso.com'

--- a/src/SharePointTools/SharePointTools.psd1
+++ b/src/SharePointTools/SharePointTools.psd1
@@ -21,6 +21,11 @@
         'Get-SPToolsSiteUrl',
         'Add-SPToolsSite',
         'Set-SPToolsSite',
-        'Remove-SPToolsSite'
+        'Remove-SPToolsSite',
+        'Get-SPToolsLibraryReport',
+        'Get-SPToolsAllLibraryReports',
+        'Get-SPToolsRecycleBinReport',
+        'Clear-SPToolsRecycleBin',
+        'Get-SPToolsAllRecycleBinReports'
     )
 }

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -337,4 +337,102 @@ function Invoke-MexCentralFilesSharingLinkCleanup {
 }
 
 
-Export-ModuleMember -Function 'Invoke-YFArchiveCleanup','Invoke-IBCCentralFilesArchiveCleanup','Invoke-MexCentralFilesArchiveCleanup','Invoke-ArchiveCleanup','Invoke-YFFileVersionCleanup','Invoke-IBCCentralFilesFileVersionCleanup','Invoke-MexCentralFilesFileVersionCleanup','Invoke-FileVersionCleanup','Invoke-SharingLinkCleanup','Invoke-YFSharingLinkCleanup','Invoke-IBCCentralFilesSharingLinkCleanup','Invoke-MexCentralFilesSharingLinkCleanup','Get-SPToolsSettings','Get-SPToolsSiteUrl','Add-SPToolsSite','Set-SPToolsSite','Remove-SPToolsSite'
+function Get-SPToolsLibraryReport {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$SiteName,
+        [string]$SiteUrl,
+        [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [string]$TenantId = $SharePointToolsSettings.TenantId,
+        [string]$CertPath = $SharePointToolsSettings.CertPath
+    )
+
+    if (-not $SiteUrl) { $SiteUrl = Get-SPToolsSiteUrl -SiteName $SiteName }
+
+    Import-Module PnP.PowerShell -ErrorAction Stop
+    Connect-PnPOnline -Url $SiteUrl -ClientId $ClientId -Tenant $TenantId -CertificatePath $CertPath
+
+    $lists = Get-PnPList | Where-Object { $_.BaseTemplate -eq 101 }
+    $report = foreach ($list in $lists) {
+        [pscustomobject]@{
+            SiteName     = $SiteName
+            LibraryName  = $list.Title
+            ItemCount    = $list.ItemCount
+            LastModified = $list.LastItemUserModifiedDate
+        }
+    }
+
+    Disconnect-PnPOnline
+    $report
+}
+
+function Get-SPToolsAllLibraryReports {
+    [CmdletBinding()]
+    param()
+
+    foreach ($entry in $SharePointToolsSettings.Sites.GetEnumerator()) {
+        Get-SPToolsLibraryReport -SiteName $entry.Key -SiteUrl $entry.Value
+    }
+}
+
+function Get-SPToolsRecycleBinReport {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SiteName,
+        [string]$SiteUrl,
+        [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [string]$TenantId = $SharePointToolsSettings.TenantId,
+        [string]$CertPath = $SharePointToolsSettings.CertPath
+    )
+
+    if (-not $SiteUrl) { $SiteUrl = Get-SPToolsSiteUrl -SiteName $SiteName }
+
+    Import-Module PnP.PowerShell -ErrorAction Stop
+    Connect-PnPOnline -Url $SiteUrl -ClientId $ClientId -Tenant $TenantId -CertificatePath $CertPath
+
+    $items = Get-PnPRecycleBinItem
+    $totalSize = ($items | Measure-Object -Property Size -Sum).Sum
+    $report = [pscustomobject]@{
+        SiteName    = $SiteName
+        ItemCount   = $items.Count
+        TotalSizeMB = [math]::Round($totalSize / 1MB, 2)
+    }
+
+    Disconnect-PnPOnline
+    $report
+}
+
+function Clear-SPToolsRecycleBin {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SiteName,
+        [string]$SiteUrl,
+        [switch]$SecondStage,
+        [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [string]$TenantId = $SharePointToolsSettings.TenantId,
+        [string]$CertPath = $SharePointToolsSettings.CertPath
+    )
+
+    if (-not $SiteUrl) { $SiteUrl = Get-SPToolsSiteUrl -SiteName $SiteName }
+
+    Import-Module PnP.PowerShell -ErrorAction Stop
+    Connect-PnPOnline -Url $SiteUrl -ClientId $ClientId -Tenant $TenantId -CertificatePath $CertPath
+
+    if ($SecondStage) {
+        Clear-PnPRecycleBinItem -SecondStage -Force
+    } else {
+        Clear-PnPRecycleBinItem -FirstStage -Force
+    }
+
+    Disconnect-PnPOnline
+}
+
+function Get-SPToolsAllRecycleBinReports {
+    [CmdletBinding()]
+    param()
+    foreach ($entry in $SharePointToolsSettings.Sites.GetEnumerator()) {
+        Get-SPToolsRecycleBinReport -SiteName $entry.Key -SiteUrl $entry.Value
+    }
+}
+Export-ModuleMember -Function 'Invoke-YFArchiveCleanup','Invoke-IBCCentralFilesArchiveCleanup','Invoke-MexCentralFilesArchiveCleanup','Invoke-ArchiveCleanup','Invoke-YFFileVersionCleanup','Invoke-IBCCentralFilesFileVersionCleanup','Invoke-MexCentralFilesFileVersionCleanup','Invoke-FileVersionCleanup','Invoke-SharingLinkCleanup','Invoke-YFSharingLinkCleanup','Invoke-IBCCentralFilesSharingLinkCleanup','Invoke-MexCentralFilesSharingLinkCleanup','Get-SPToolsSettings','Get-SPToolsSiteUrl','Add-SPToolsSite','Set-SPToolsSite','Remove-SPToolsSite','Get-SPToolsLibraryReport','Get-SPToolsAllLibraryReports','Get-SPToolsRecycleBinReport','Clear-SPToolsRecycleBin','Get-SPToolsAllRecycleBinReports'

--- a/tests/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools.Tests.ps1
@@ -21,7 +21,12 @@ Describe 'SharePointTools Module' {
             'Get-SPToolsSiteUrl',
             'Add-SPToolsSite',
             'Set-SPToolsSite',
-            'Remove-SPToolsSite'
+            'Remove-SPToolsSite',
+            'Get-SPToolsLibraryReport',
+            'Get-SPToolsAllLibraryReports',
+            'Get-SPToolsRecycleBinReport',
+            'Clear-SPToolsRecycleBin',
+            'Get-SPToolsAllRecycleBinReports'
         )
         $exported = (Get-Command -Module SharePointTools).Name
         foreach ($cmd in $expected) {
@@ -50,6 +55,29 @@ Describe 'SharePointTools Module' {
                 & $m.Fn
                 Assert-MockCalled $m.Target -ParameterFilter { $SiteName -eq $m.Site } -Times 1
             }
+        }
+    }
+
+    Context 'Library reporting wrapper' {
+        It 'calls Get-SPToolsLibraryReport for each site' {
+            $SharePointToolsSettings.Sites.Clear()
+            $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso.sharepoint.com/sites/a'
+            $SharePointToolsSettings.Sites['SiteB'] = 'https://contoso.sharepoint.com/sites/b'
+            Mock Get-SPToolsLibraryReport {}
+            Get-SPToolsAllLibraryReports
+            Assert-MockCalled Get-SPToolsLibraryReport -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
+            Assert-MockCalled Get-SPToolsLibraryReport -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1
+        }
+    }
+    Context 'Recycle bin reporting wrapper' {
+        It 'calls Get-SPToolsRecycleBinReport for each site' {
+            $SharePointToolsSettings.Sites.Clear()
+            $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso.sharepoint.com/sites/a'
+            $SharePointToolsSettings.Sites['SiteB'] = 'https://contoso.sharepoint.com/sites/b'
+            Mock Get-SPToolsRecycleBinReport {}
+            Get-SPToolsAllRecycleBinReports
+            Assert-MockCalled Get-SPToolsRecycleBinReport -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
+            Assert-MockCalled Get-SPToolsRecycleBinReport -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1
         }
     }
 }


### PR DESCRIPTION
## Summary
- add new recycle bin helper commands to SharePointTools
- document recycle bin report and clean up usage
- export new functions in module manifest
- cover new commands in Pester tests

## Testing
- `pwsh -NoProfile -NonInteractive -Command "Invoke-Pester -Output Detailed"` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684333af2ee0832cbc6c488405ee36ef