### PR TITLE
Add Preservation Hold Library reporting

### DIFF
--- a/Examples/Example_Get-SPToolsAllPreservationHoldReports.ps1
+++ b/Examples/Example_Get-SPToolsAllPreservationHoldReports.ps1
@@ -1,0 +1,2 @@
+Import-Module ../src/SharePointTools/SharePointTools.psd1
+Get-SPToolsAllPreservationHoldReports | Format-Table

--- a/Examples/Example_Get-SPToolsPreservationHoldReport.ps1
+++ b/Examples/Example_Get-SPToolsPreservationHoldReport.ps1
@@ -1,0 +1,2 @@
+Import-Module ../src/SharePointTools/SharePointTools.psd1
+Get-SPToolsPreservationHoldReport -SiteName 'Example' -SiteUrl 'https://contoso.sharepoint.com/sites/example'

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -63,6 +63,8 @@ Add-SPToolsSite -Name 'ContosoHR' -Url 'https://contoso.sharepoint.com/sites/HR'
 Get-SPToolsAllLibraryReports | Format-Table
 # Review recycle bin usage for all sites
 Get-SPToolsAllRecycleBinReports | Format-Table
+# Review Preservation Hold Library size for all sites
+Get-SPToolsAllPreservationHoldReports | Format-Table
 # Clear both recycle bin stages for a site
 Clear-SPToolsRecycleBin -SiteName 'ContosoHR' -SecondStage
 # Configure auto-reply on a shared mailbox

--- a/src/SharePointTools/SharePointTools.psd1
+++ b/src/SharePointTools/SharePointTools.psd1
@@ -26,10 +26,12 @@
         'Get-SPToolsAllLibraryReports',
         'Get-SPToolsRecycleBinReport',
         'Clear-SPToolsRecycleBin',
+        'Get-SPToolsAllRecycleBinReports',
+        'Get-SPToolsPreservationHoldReport',
+        'Get-SPToolsAllPreservationHoldReports',
         'Get-SPPermissionsReport',
         'Clean-SPVersionHistory',
         'Find-OrphanedSPFiles',
         'List-OneDriveUsage',
-        'Get-SPToolsAllRecycleBinReports',
     )
 }

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -507,6 +507,48 @@ function Get-SPToolsAllRecycleBinReports {
         Get-SPToolsRecycleBinReport -SiteName $entry.Key -SiteUrl $entry.Value
     }
 }
+
+function Get-SPToolsPreservationHoldReport {
+    <#
+    .SYNOPSIS
+        Reports the size of the Preservation Hold Library.
+    .NOTES
+        Uses PnP.PowerShell commands. See https://pnp.github.io/powershell/ for details.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SiteName,
+        [string]$SiteUrl,
+        [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [string]$TenantId = $SharePointToolsSettings.TenantId,
+        [string]$CertPath = $SharePointToolsSettings.CertPath
+    )
+
+    if (-not $SiteUrl) { $SiteUrl = Get-SPToolsSiteUrl -SiteName $SiteName }
+
+    Import-Module PnP.PowerShell -ErrorAction Stop
+    Connect-PnPOnline -Url $SiteUrl -ClientId $ClientId -Tenant $TenantId -CertificatePath $CertPath
+
+    $items = Get-PnPListItem -List 'Preservation Hold Library' -PageSize 2000
+    $files = foreach ($item in $items) { Get-PnPProperty -ClientObject $item -Property File }
+    $totalSize = ($files | Measure-Object -Property Length -Sum).Sum
+    $report = [pscustomobject]@{
+        SiteName    = $SiteName
+        ItemCount   = $files.Count
+        TotalSizeMB = [math]::Round($totalSize / 1MB, 2)
+    }
+
+    Disconnect-PnPOnline
+    $report
+}
+
+function Get-SPToolsAllPreservationHoldReports {
+    [CmdletBinding()]
+    param()
+    foreach ($entry in $SharePointToolsSettings.Sites.GetEnumerator()) {
+        Get-SPToolsPreservationHoldReport -SiteName $entry.Key -SiteUrl $entry.Value
+    }
+}
 function Get-SPPermissionsReport {
     [CmdletBinding()]
     param(
@@ -623,4 +665,4 @@ function List-OneDriveUsage {
     Disconnect-PnPOnline
     $report
 }
-Export-ModuleMember -Function 'Invoke-YFArchiveCleanup','Invoke-IBCCentralFilesArchiveCleanup','Invoke-MexCentralFilesArchiveCleanup','Invoke-ArchiveCleanup','Invoke-YFFileVersionCleanup','Invoke-IBCCentralFilesFileVersionCleanup','Invoke-MexCentralFilesFileVersionCleanup','Invoke-FileVersionCleanup','Invoke-SharingLinkCleanup','Invoke-YFSharingLinkCleanup','Invoke-IBCCentralFilesSharingLinkCleanup','Invoke-MexCentralFilesSharingLinkCleanup','Get-SPToolsSettings','Get-SPToolsSiteUrl','Add-SPToolsSite','Set-SPToolsSite','Remove-SPToolsSite','Get-SPToolsLibraryReport','Get-SPToolsAllLibraryReports','Get-SPToolsRecycleBinReport','Clear-SPToolsRecycleBin','Get-SPToolsAllRecycleBinReports','Get-SPPermissionsReport','Clean-SPVersionHistory','Find-OrphanedSPFiles','List-OneDriveUsage'
+Export-ModuleMember -Function 'Invoke-YFArchiveCleanup','Invoke-IBCCentralFilesArchiveCleanup','Invoke-MexCentralFilesArchiveCleanup','Invoke-ArchiveCleanup','Invoke-YFFileVersionCleanup','Invoke-IBCCentralFilesFileVersionCleanup','Invoke-MexCentralFilesFileVersionCleanup','Invoke-FileVersionCleanup','Invoke-SharingLinkCleanup','Invoke-YFSharingLinkCleanup','Invoke-IBCCentralFilesSharingLinkCleanup','Invoke-MexCentralFilesSharingLinkCleanup','Get-SPToolsSettings','Get-SPToolsSiteUrl','Add-SPToolsSite','Set-SPToolsSite','Remove-SPToolsSite','Get-SPToolsLibraryReport','Get-SPToolsAllLibraryReports','Get-SPToolsRecycleBinReport','Clear-SPToolsRecycleBin','Get-SPToolsAllRecycleBinReports','Get-SPToolsPreservationHoldReport','Get-SPToolsAllPreservationHoldReports','Get-SPPermissionsReport','Clean-SPVersionHistory','Find-OrphanedSPFiles','List-OneDriveUsage'

--- a/tests/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools.Tests.ps1
@@ -27,6 +27,8 @@ Describe 'SharePointTools Module' {
             'Get-SPToolsRecycleBinReport',
             'Clear-SPToolsRecycleBin',
             'Get-SPToolsAllRecycleBinReports',
+            'Get-SPToolsPreservationHoldReport',
+            'Get-SPToolsAllPreservationHoldReports',
             'Get-SPPermissionsReport',
             'Clean-SPVersionHistory',
             'Find-OrphanedSPFiles',
@@ -82,6 +84,17 @@ Describe 'SharePointTools Module' {
             Get-SPToolsAllRecycleBinReports
             Assert-MockCalled Get-SPToolsRecycleBinReport -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
             Assert-MockCalled Get-SPToolsRecycleBinReport -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1
+        }
+    }
+    Context 'Preservation hold reporting wrapper' {
+        It 'calls Get-SPToolsPreservationHoldReport for each site' {
+            $SharePointToolsSettings.Sites.Clear()
+            $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso.sharepoint.com/sites/a'
+            $SharePointToolsSettings.Sites['SiteB'] = 'https://contoso.sharepoint.com/sites/b'
+            Mock Get-SPToolsPreservationHoldReport {}
+            Get-SPToolsAllPreservationHoldReports
+            Assert-MockCalled Get-SPToolsPreservationHoldReport -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
+            Assert-MockCalled Get-SPToolsPreservationHoldReport -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `Get-SPToolsPreservationHoldReport` to measure Preservation Hold Library size
- support enumerating all sites via `Get-SPToolsAllPreservationHoldReports`
- export the new commands and document usage
- add examples and unit tests

## Testing
- `pwsh -Command "Invoke-Pester -Output Detailed"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684339a88678832cb26ee8190903e5ee