### PR TITLE
Improve secrets documentation and env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ Example scripts for every function can be found in the `/Examples` folder.
 
 For help using Microsoft Graph cmdlets, see the official [Microsoft Graph PowerShell documentation](https://learn.microsoft.com/en-us/powershell/microsoftgraph/get-started?view=graph-powershell-1.0).
 
+## Security Considerations
+
+### Secrets Management
+
+Avoid hardcoding credentials or certificate paths within scripts. The SharePoint tools module can read the following environment variables to provide connection details securely:
+
+```text
+SPTOOLS_CLIENT_ID
+SPTOOLS_TENANT_ID
+SPTOOLS_CERT_PATH
+```
+
+When set, these variables override values stored in `config/SharePointToolsSettings.psd1`.
+
 ## Roadmap
 
 Potential areas for improvement and extension include:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -79,6 +79,20 @@ Set-SharedMailboxAutoReply -MailboxIdentity 'team@contoso.com' \
 
 For descriptions of all scripts included in the SupportTools wrapper module see [scripts/README.md](../scripts/README.md). Example usage scripts are provided in the `Examples` folder.
 
+## Security Considerations
+
+### Secrets Management
+
+Do not store client IDs, tenant identifiers, or certificate paths directly in scripts. Instead, define the following environment variables before using the SharePoint tools module:
+
+```text
+SPTOOLS_CLIENT_ID
+SPTOOLS_TENANT_ID
+SPTOOLS_CERT_PATH
+```
+
+These values override settings from `config/SharePointToolsSettings.psd1` so credentials remain outside of source control.
+
 ## Updating
 
 If the repository is updated, pull the latest changes and re-import the modules. Incremented module versions are defined in the manifest files.

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -8,6 +8,11 @@ if (Test-Path $settingsFile) {
     try { $SharePointToolsSettings = Import-PowerShellDataFile $settingsFile } catch {}
 }
 
+# Override configuration with environment variables when provided
+if ($env:SPTOOLS_CLIENT_ID) { $SharePointToolsSettings.ClientId = $env:SPTOOLS_CLIENT_ID }
+if ($env:SPTOOLS_TENANT_ID) { $SharePointToolsSettings.TenantId = $env:SPTOOLS_TENANT_ID }
+if ($env:SPTOOLS_CERT_PATH) { $SharePointToolsSettings.CertPath = $env:SPTOOLS_CERT_PATH }
+
 function Save-SPToolsSettings {
     <#
     .SYNOPSIS


### PR DESCRIPTION
## Summary
- document environment variable overrides in the README
- add security considerations to the user guide
- allow SharePointTools to read credentials from environment variables

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester tests -Passthru"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433bf57a84832c91474e678ecd0f2f