### PR TITLE
Add retro console messages

### DIFF
--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -16,5 +16,13 @@ function Invoke-ScriptFile {
     )
     $Path = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath '..' | Join-Path -ChildPath "scripts/$Name"
     if (-not (Test-Path $Path)) { throw "Script '$Name' not found." }
+
+    Write-Host "[***] EXECUTING $Name" -ForegroundColor Green -BackgroundColor Black
+    if ($Args) {
+        Write-Host "       ARGS: $($Args -join ' ')" -ForegroundColor DarkGreen -BackgroundColor Black
+    }
+
     & $Path @Args
+
+    Write-Host "[***] COMPLETED $Name" -ForegroundColor Green -BackgroundColor Black
 }

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -5,3 +5,16 @@ Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
 Export-ModuleMember -Function 'Add-UsersToGroup','Clear-ArchiveFolder','Convert-ExcelToCsv','Get-CommonSystemInfo','Get-FailedLogins','Get-NetworkShares','Get-UniquePermissions','Install-Fonts','Invoke-PostInstall','Export-ProductKey','Invoke-DeploymentTemplate','Search-ReadMe','Set-ComputerIPAddress','Set-NetAdapterMetering','Set-TimeZoneEasternStandardTime','Start-Countdown','Update-Sysmon','Set-SharedMailboxAutoReply','Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement'
+
+function Show-SupportToolsBanner {
+    $lines = @(
+        '=======================================',
+        '=    SUPPORTTOOLS MODULE ACTIVATED    =',
+        '=======================================')
+    foreach ($line in $lines) {
+        Write-Host $line -ForegroundColor Black -BackgroundColor Green
+    }
+    Write-Host '>> Welcome operator. Run ''Get-Command -Module SupportTools'' to view available tools.' -ForegroundColor Green -BackgroundColor Black
+}
+
+Show-SupportToolsBanner


### PR DESCRIPTION
## Summary
- display a 90s style banner when the SupportTools module loads
- add hacker-style execution messages in Invoke-ScriptFile

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Configuration @{ Run=@{ Path='tests' }}"` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843420fdf74832c82b2b41034a32bc1