### PR TITLE
Add error handling for script execution

### DIFF
--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -22,7 +22,16 @@ function Invoke-ScriptFile {
         Write-Host "       ARGS: $($Args -join ' ')" -ForegroundColor DarkGreen -BackgroundColor Black
     }
 
-    & $Path @Args
+    $oldPref = $ErrorActionPreference
+    $ErrorActionPreference = 'Stop'
+    try {
+        & $Path @Args
+    } catch {
+        Write-Error "Execution of '$Name' failed: $_"
+        throw
+    } finally {
+        $ErrorActionPreference = $oldPref
+    }
 
     Write-Host "[***] COMPLETED $Name" -ForegroundColor Green -BackgroundColor Black
 }


### PR DESCRIPTION
## Summary
- show `Write-Error` message when a called script fails

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Output Detailed"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684343f40254832cbafd4f255475d8e6