### PR TITLE
Add CI workflow for Pester tests

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -1,0 +1,27 @@
+name: Pester Tests
+
+on:
+  push:
+    paths:
+      - '**.ps1'
+      - 'src/**'
+      - 'tests/**'
+  pull_request:
+    paths:
+      - '**.ps1'
+      - 'src/**'
+      - 'tests/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Pester
+        shell: pwsh
+        run: |
+          Install-Module Pester -Force -Scope CurrentUser
+      - name: Run Tests
+        shell: pwsh
+        run: |
+          Invoke-Pester -Path ./tests -Output Detailed

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ Potential areas for improvement and extension include:
 
 1. **Dependency Management**  
    Automate installation or checks for required modules to streamline setup.
-2. **Testing and Continuous Integration**  
-   Add more Pester tests and configure CI to run them automatically.
+2. **Testing and Continuous Integration**
+   Add more Pester tests. A GitHub Actions workflow now runs the test suite on
+   each commit.
 3. **Documentation**  
    Expand user guides and provide a quickstart summary for key commands.
 4. **Feature Enhancements**  


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Pester tests
- note test automation in the roadmap

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests"` *(fails: Invoke-Pester not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843463b735c832c924d62e42f9afd96