### PR TITLE
Add linting via PSScriptAnalyzer

### DIFF
--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -1,0 +1,30 @@
+name: PowerShell Lint
+
+on:
+  push:
+    paths:
+      - '**/*.ps1'
+      - '.github/workflows/psscriptanalyzer.yml'
+  pull_request:
+    paths:
+      - '**/*.ps1'
+      - '.github/workflows/psscriptanalyzer.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Invoke-ScriptAnalyzer -Path . -Recurse -Severity Warning,Error -OutFile PSScriptAnalyzerResults.sarif -ReportSummary
+      - name: Upload lint results
+        uses: actions/upload-artifact@v3
+        with:
+          name: PSScriptAnalyzerResults
+          path: PSScriptAnalyzerResults.sarif

--- a/README.md
+++ b/README.md
@@ -116,3 +116,5 @@ Potential areas for improvement and extension include:
 8. ~~**Configuration Guidance**
    Document a recommended workflow for securely storing credentials.~~ - Example
 workflow added ([docs/CredentialStorage.md](docs/CredentialStorage.md)).
+9. ~~**Linting and Code Quality**
+   Check scripts with PSScriptAnalyzer on each commit.~~ - Linting automated via GitHub Actions.


### PR DESCRIPTION
## Summary
- add a new GitHub Action to run PSScriptAnalyzer
- document linting workflow in the roadmap

## Testing
- `pwsh -Command "Invoke-Pester -Path tests -CI"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434b0eb010832c88041491fc0b9ec3