### PR TITLE
Fix lint workflow by using upload-artifact v4

### DIFF
--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           Invoke-ScriptAnalyzer -Path . -Recurse -Severity Warning,Error -OutFile PSScriptAnalyzerResults.sarif -ReportSummary
       - name: Upload lint results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: PSScriptAnalyzerResults
           path: PSScriptAnalyzerResults.sarif


### PR DESCRIPTION
## Summary
- use `actions/upload-artifact@v4` in the PSScriptAnalyzer workflow

## Testing
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68434bcfa34c832cad73156174355940