### PR TITLE
Fix PSScriptAnalyzer install in workflow

### DIFF
--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install PSScriptAnalyzer
         shell: pwsh
         run: |
-          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser -RequiredVersion 1.23.0
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- install a specific PSScriptAnalyzer version in the workflow to ensure `-OutFile` is available

## Testing
- `Invoke-Pester -Path tests -CI` *(fails: `Invoke-Pester` not found)*
- `Install-Module PSScriptAnalyzer -RequiredVersion 1.23.0` *(fails: repository unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68434d0838dc832ca425f97e3064e5b3