### PR TITLE
Fix module import failure when PnP.PowerShell missing

### DIFF
--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -14,7 +14,11 @@ if ($env:SPTOOLS_TENANT_ID) { $SharePointToolsSettings.TenantId = $env:SPTOOLS_T
 if ($env:SPTOOLS_CERT_PATH) { $SharePointToolsSettings.CertPath = $env:SPTOOLS_CERT_PATH }
 
 # Load required module once at module scope
-Import-Module PnP.PowerShell -ErrorAction Stop
+try {
+    Import-Module PnP.PowerShell -ErrorAction Stop
+} catch {
+    Write-Warning 'PnP.PowerShell module not found. SharePoint functions may not work until it is installed.'
+}
 
 function Write-SPToolsHacker {
     param([string]$Message)


### PR DESCRIPTION
## Summary
- handle missing PnP.PowerShell so module load does not fail

## Testing
- `pwsh -c 'Invoke-Pester -Path tests -CI'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684352daf9d8832cb46afd63a6b8dd5b