### PR TITLE
Fix tests for Pester 5

### DIFF
--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -13,8 +13,12 @@ if ($env:SPTOOLS_CLIENT_ID) { $SharePointToolsSettings.ClientId = $env:SPTOOLS_C
 if ($env:SPTOOLS_TENANT_ID) { $SharePointToolsSettings.TenantId = $env:SPTOOLS_TENANT_ID }
 if ($env:SPTOOLS_CERT_PATH) { $SharePointToolsSettings.CertPath = $env:SPTOOLS_CERT_PATH }
 
-# Load required module once at module scope
-Import-Module PnP.PowerShell -ErrorAction Stop
+# Load required module once at module scope if available
+try {
+    Import-Module PnP.PowerShell -ErrorAction Stop
+} catch {
+    Write-Verbose "PnP.PowerShell module not available. Some commands may fail."
+}
 
 function Write-SPToolsHacker {
     param([string]$Message)

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -15,17 +15,17 @@ Describe 'ServiceDeskTools Module' {
 
     Context 'Request routing' {
         It 'Get-SDTicket calls Invoke-SDRequest' {
-            Mock Invoke-SDRequest {}
+            Mock Invoke-SDRequest -ModuleName ServiceDeskTools {}
             Get-SDTicket -Id 1
             Assert-MockCalled Invoke-SDRequest -ParameterFilter { $Method -eq 'GET' -and $Path -eq '/incidents/1.json' } -Times 1
         }
         It 'New-SDTicket calls Invoke-SDRequest' {
-            Mock Invoke-SDRequest {}
+            Mock Invoke-SDRequest -ModuleName ServiceDeskTools {}
             New-SDTicket -Subject 'S' -Description 'D' -RequesterEmail 'a@b.com'
             Assert-MockCalled Invoke-SDRequest -ParameterFilter { $Method -eq 'POST' -and $Path -eq '/incidents.json' } -Times 1
         }
         It 'Set-SDTicket calls Invoke-SDRequest' {
-            Mock Invoke-SDRequest {}
+            Mock Invoke-SDRequest -ModuleName ServiceDeskTools {}
             Set-SDTicket -Id 2 -Fields @{status='Open'}
             Assert-MockCalled Invoke-SDRequest -ParameterFilter { $Method -eq 'PUT' -and $Path -eq '/incidents/2.json' } -Times 1
         }

--- a/tests/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools.Tests.ps1
@@ -57,7 +57,7 @@ Describe 'SharePointTools Module' {
 
         foreach ($m in $maps) {
             It "$($m.Fn) calls $($m.Target)" {
-                Mock $m.Target {}
+                Mock $m.Target -ModuleName SharePointTools {}
                 & $m.Fn
                 Assert-MockCalled $m.Target -ParameterFilter { $SiteName -eq $m.Site } -Times 1
             }
@@ -69,7 +69,7 @@ Describe 'SharePointTools Module' {
             $SharePointToolsSettings.Sites.Clear()
             $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso.sharepoint.com/sites/a'
             $SharePointToolsSettings.Sites['SiteB'] = 'https://contoso.sharepoint.com/sites/b'
-            Mock Get-SPToolsLibraryReport {}
+            Mock Get-SPToolsLibraryReport -ModuleName SharePointTools {}
             Get-SPToolsAllLibraryReports
             Assert-MockCalled Get-SPToolsLibraryReport -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
             Assert-MockCalled Get-SPToolsLibraryReport -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1
@@ -80,7 +80,7 @@ Describe 'SharePointTools Module' {
             $SharePointToolsSettings.Sites.Clear()
             $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso.sharepoint.com/sites/a'
             $SharePointToolsSettings.Sites['SiteB'] = 'https://contoso.sharepoint.com/sites/b'
-            Mock Get-SPToolsRecycleBinReport {}
+            Mock Get-SPToolsRecycleBinReport -ModuleName SharePointTools {}
             Get-SPToolsAllRecycleBinReports
             Assert-MockCalled Get-SPToolsRecycleBinReport -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
             Assert-MockCalled Get-SPToolsRecycleBinReport -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1
@@ -91,7 +91,7 @@ Describe 'SharePointTools Module' {
             $SharePointToolsSettings.Sites.Clear()
             $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso.sharepoint.com/sites/a'
             $SharePointToolsSettings.Sites['SiteB'] = 'https://contoso.sharepoint.com/sites/b'
-            Mock Get-SPToolsPreservationHoldReport {}
+            Mock Get-SPToolsPreservationHoldReport -ModuleName SharePointTools {}
             Get-SPToolsAllPreservationHoldReports
             Assert-MockCalled Get-SPToolsPreservationHoldReport -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
             Assert-MockCalled Get-SPToolsPreservationHoldReport -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -58,7 +58,7 @@ Describe 'SupportTools Module' {
 
         foreach ($entry in $map.GetEnumerator()) {
             It "$($entry.Key) calls Invoke-ScriptFile" {
-                Mock Invoke-ScriptFile {}
+                Mock Invoke-ScriptFile -ModuleName SupportTools {}
                 & $entry.Key.ToString().Replace('_','-')
                 Assert-MockCalled Invoke-ScriptFile -ParameterFilter { $Name -eq $entry.Value } -Times 1
             }
@@ -68,7 +68,7 @@ Describe 'SupportTools Module' {
     Context 'Add-UsersToGroup output passthrough' {
         It 'returns the object produced by the script' {
             $expected = [pscustomobject]@{ GroupName = 'MyGroup'; AddedUsers = @('a'); SkippedUsers = @('b') }
-            Mock Invoke-ScriptFile { $expected }
+            Mock Invoke-ScriptFile -ModuleName SupportTools { $expected }
             $result = Add-UsersToGroup -CsvPath 'users.csv' -GroupName 'MyGroup'
             $result | Should -Be $expected
         }


### PR DESCRIPTION
## Summary
- prevent SharePointTools from failing when `PnP.PowerShell` isn't available
- update `Mock` calls in tests to specify module names

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration @{ Run = @{ Path = 'tests' } }"` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_684352721310832c869c36b6a4e35c55