### PR TITLE
Automate help generation

### DIFF
--- a/.github/workflows/generate-help.yml
+++ b/.github/workflows/generate-help.yml
@@ -1,0 +1,45 @@
+name: Generate Markdown Help
+
+on:
+  push:
+    paths:
+      - 'src/**'
+      - '.github/workflows/generate-help.yml'
+  pull_request:
+    paths:
+      - 'src/**'
+      - '.github/workflows/generate-help.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install platyPS
+        shell: pwsh
+        run: |
+          Install-Module platyPS -Force -Scope CurrentUser
+      - name: Generate Markdown help
+        shell: pwsh
+        run: |
+          $modules = Get-ChildItem -Path ./src -Directory
+          foreach ($module in $modules) {
+            $modulePath = Join-Path $module.FullName "$($module.Name).psd1"
+            $outputFolder = Join-Path './docs' $module.Name
+            if (Test-Path $outputFolder) {
+              Update-MarkdownHelp -Path $outputFolder -Module $modulePath -Force
+            } else {
+              New-MarkdownHelp -OutputFolder $outputFolder -Module $modulePath
+            }
+          }
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Update markdown help
+          branch: ${{ github.head_ref }}
+          file_pattern: docs/**


### PR DESCRIPTION
## Summary
- generate documentation from comment-based help via platyPS

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Path tests -CI"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684355005804832cafd20be3c6383544