### PR TITLE
Fix Pester mocks

### DIFF
--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -15,19 +15,19 @@ Describe 'ServiceDeskTools Module' {
 
     Context 'Request routing' {
         It 'Get-SDTicket calls Invoke-SDRequest' {
-            Mock Invoke-SDRequest {}
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Get-SDTicket -Id 1
-            Assert-MockCalled Invoke-SDRequest -ParameterFilter { $Method -eq 'GET' -and $Path -eq '/incidents/1.json' } -Times 1
+            Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter { $Method -eq 'GET' -and $Path -eq '/incidents/1.json' } -Times 1
         }
         It 'New-SDTicket calls Invoke-SDRequest' {
-            Mock Invoke-SDRequest {}
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             New-SDTicket -Subject 'S' -Description 'D' -RequesterEmail 'a@b.com'
-            Assert-MockCalled Invoke-SDRequest -ParameterFilter { $Method -eq 'POST' -and $Path -eq '/incidents.json' } -Times 1
+            Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter { $Method -eq 'POST' -and $Path -eq '/incidents.json' } -Times 1
         }
         It 'Set-SDTicket calls Invoke-SDRequest' {
-            Mock Invoke-SDRequest {}
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Set-SDTicket -Id 2 -Fields @{status='Open'}
-            Assert-MockCalled Invoke-SDRequest -ParameterFilter { $Method -eq 'PUT' -and $Path -eq '/incidents/2.json' } -Times 1
+            Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter { $Method -eq 'PUT' -and $Path -eq '/incidents/2.json' } -Times 1
         }
     }
 }

--- a/tests/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools.Tests.ps1
@@ -57,9 +57,9 @@ Describe 'SharePointTools Module' {
 
         foreach ($m in $maps) {
             It "$($m.Fn) calls $($m.Target)" {
-                Mock $m.Target {}
+                Mock $m.Target {} -ModuleName SharePointTools
                 & $m.Fn
-                Assert-MockCalled $m.Target -ParameterFilter { $SiteName -eq $m.Site } -Times 1
+                Assert-MockCalled $m.Target -ModuleName SharePointTools -ParameterFilter { $SiteName -eq $m.Site } -Times 1
             }
         }
     }
@@ -69,10 +69,10 @@ Describe 'SharePointTools Module' {
             $SharePointToolsSettings.Sites.Clear()
             $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso.sharepoint.com/sites/a'
             $SharePointToolsSettings.Sites['SiteB'] = 'https://contoso.sharepoint.com/sites/b'
-            Mock Get-SPToolsLibraryReport {}
+            Mock Get-SPToolsLibraryReport {} -ModuleName SharePointTools
             Get-SPToolsAllLibraryReports
-            Assert-MockCalled Get-SPToolsLibraryReport -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
-            Assert-MockCalled Get-SPToolsLibraryReport -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1
+            Assert-MockCalled Get-SPToolsLibraryReport -ModuleName SharePointTools -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
+            Assert-MockCalled Get-SPToolsLibraryReport -ModuleName SharePointTools -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1
         }
     }
     Context 'Recycle bin reporting wrapper' {
@@ -80,10 +80,10 @@ Describe 'SharePointTools Module' {
             $SharePointToolsSettings.Sites.Clear()
             $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso.sharepoint.com/sites/a'
             $SharePointToolsSettings.Sites['SiteB'] = 'https://contoso.sharepoint.com/sites/b'
-            Mock Get-SPToolsRecycleBinReport {}
+            Mock Get-SPToolsRecycleBinReport {} -ModuleName SharePointTools
             Get-SPToolsAllRecycleBinReports
-            Assert-MockCalled Get-SPToolsRecycleBinReport -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
-            Assert-MockCalled Get-SPToolsRecycleBinReport -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1
+            Assert-MockCalled Get-SPToolsRecycleBinReport -ModuleName SharePointTools -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
+            Assert-MockCalled Get-SPToolsRecycleBinReport -ModuleName SharePointTools -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1
         }
     }
     Context 'Preservation hold reporting wrapper' {
@@ -91,10 +91,10 @@ Describe 'SharePointTools Module' {
             $SharePointToolsSettings.Sites.Clear()
             $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso.sharepoint.com/sites/a'
             $SharePointToolsSettings.Sites['SiteB'] = 'https://contoso.sharepoint.com/sites/b'
-            Mock Get-SPToolsPreservationHoldReport {}
+            Mock Get-SPToolsPreservationHoldReport {} -ModuleName SharePointTools
             Get-SPToolsAllPreservationHoldReports
-            Assert-MockCalled Get-SPToolsPreservationHoldReport -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
-            Assert-MockCalled Get-SPToolsPreservationHoldReport -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1
+            Assert-MockCalled Get-SPToolsPreservationHoldReport -ModuleName SharePointTools -ParameterFilter { $SiteName -eq 'SiteA' } -Times 1
+            Assert-MockCalled Get-SPToolsPreservationHoldReport -ModuleName SharePointTools -ParameterFilter { $SiteName -eq 'SiteB' } -Times 1
         }
     }
 }

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -58,9 +58,9 @@ Describe 'SupportTools Module' {
 
         foreach ($entry in $map.GetEnumerator()) {
             It "$($entry.Key) calls Invoke-ScriptFile" {
-                Mock Invoke-ScriptFile {}
+                Mock Invoke-ScriptFile {} -ModuleName SupportTools
                 & $entry.Key.ToString().Replace('_','-')
-                Assert-MockCalled Invoke-ScriptFile -ParameterFilter { $Name -eq $entry.Value } -Times 1
+                Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -ParameterFilter { $Name -eq $entry.Value } -Times 1
             }
         }
     }
@@ -68,7 +68,7 @@ Describe 'SupportTools Module' {
     Context 'Add-UsersToGroup output passthrough' {
         It 'returns the object produced by the script' {
             $expected = [pscustomobject]@{ GroupName = 'MyGroup'; AddedUsers = @('a'); SkippedUsers = @('b') }
-            Mock Invoke-ScriptFile { $expected }
+            Mock Invoke-ScriptFile { $expected } -ModuleName SupportTools
             $result = Add-UsersToGroup -CsvPath 'users.csv' -GroupName 'MyGroup'
             $result | Should -Be $expected
         }


### PR DESCRIPTION
## Summary
- use `-ModuleName` when mocking module internals so tests don't execute real code

## Testing
- `Install-PSResource Pester` *(fails: 403 from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684354c6bf68832c96ac3ec61fd795eb