### PR TITLE
Fix SharePointTools manifest comma

### DIFF
--- a/src/SharePointTools/SharePointTools.psd1
+++ b/src/SharePointTools/SharePointTools.psd1
@@ -32,6 +32,6 @@
         'Get-SPPermissionsReport',
         'Clean-SPVersionHistory',
         'Find-OrphanedSPFiles',
-        'List-OneDriveUsage',
+        'List-OneDriveUsage'
     )
 }


### PR DESCRIPTION
## Summary
- fix trailing comma in SharePointTools manifest

## Testing
- `Invoke-Pester -Path tests -CI` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435701ab10832c8405e84a607774bc