### PR TITLE
Fix workflow to generate markdown help

### DIFF
--- a/.github/workflows/generate-help.yml
+++ b/.github/workflows/generate-help.yml
@@ -31,12 +31,14 @@ jobs:
           $modules = Get-ChildItem -Path ./src -Directory
           foreach ($module in $modules) {
             $modulePath = Join-Path $module.FullName "$($module.Name).psd1"
+            Import-Module -Name $modulePath -Force
             $outputFolder = Join-Path './docs' $module.Name
             if (Test-Path $outputFolder) {
-              Update-MarkdownHelp -Path $outputFolder -Module $modulePath -Force
+              Update-MarkdownHelp -Path $outputFolder -Module $module.Name -Force
             } else {
-              New-MarkdownHelp -OutputFolder $outputFolder -Module $modulePath
+              New-MarkdownHelp -OutputFolder $outputFolder -Module $module.Name
             }
+            Remove-Module $module.Name
           }
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:


### PR DESCRIPTION
## Summary
- import each module before generating markdown help
- clean up module after documentation update

## Testing
- `pwsh -NoLogo -Command Invoke-Pester -Path tests -CI` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843572831b8832c86e6e974ae3edcec