### PR TITLE
Add centralized logging utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ When set, these variables override values stored in `config/SharePointToolsSetti
 For a step-by-step example of loading these variables from the SecretManagement
 module see [docs/CredentialStorage.md](docs/CredentialStorage.md).
 
+## Centralized Logging
+
+Commands automatically record their activity to `%USERPROFILE%\SupportToolsLogs\supporttools.log`.
+Review this file with `Get-Content` when troubleshooting.
+
 ## Roadmap
 
 Potential areas for improvement and extension include:
@@ -109,8 +114,8 @@ Potential areas for improvement and extension include:
 5. **Versioning and Distribution**
    Package the modules for easier updates via an internal feed and consider
    publishing them to an internal repository.
-6. **Centralized Logging**
-   Provide a consistent logging approach across all commands for easier troubleshooting.
+6. ~~**Centralized Logging**
+   Provide a consistent logging approach across all commands for easier troubleshooting.~~ - Commands now log to `%USERPROFILE%\SupportToolsLogs\supporttools.log`.
 7. **Error Handling**
    Add standardized error handling and optional transcript output.
 8. ~~**Configuration Guidance**

--- a/docs/ModuleStyleGuide.md
+++ b/docs/ModuleStyleGuide.md
@@ -12,3 +12,6 @@ Write-SPToolsHacker '>>> CLEANING FILES'
 
 Include a message when starting work and another when the task completes so the
 operator can follow along as scripts run.
+
+Every message output through `Write-SPToolsHacker` is also written to
+`%USERPROFILE%\SupportToolsLogs\supporttools.log` for troubleshooting.

--- a/src/Logging/Logging.psd1
+++ b/src/Logging/Logging.psd1
@@ -1,0 +1,8 @@
+@{
+    RootModule = 'Logging.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000010'
+    Author = 'Contoso'
+    Description = 'Provides centralized logging utilities for all modules.'
+    FunctionsToExport = @('Write-STLog')
+}

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -1,0 +1,18 @@
+function Write-STLog {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Message,
+        [ValidateSet('INFO','WARN','ERROR')]
+        [string]$Level = 'INFO'
+    )
+    $logDir = Join-Path $env:USERPROFILE 'SupportToolsLogs'
+    if (-not (Test-Path $logDir)) {
+        New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+    }
+    $logFile = Join-Path $logDir 'supporttools.log'
+    $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    "$timestamp [$Level] $Message" | Out-File -FilePath $logFile -Append -Encoding utf8
+}
+
+Export-ModuleMember -Function 'Write-STLog'

--- a/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
+++ b/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
@@ -13,10 +13,23 @@ function Invoke-SDRequest {
 
     $headers = @{ 'X-Samanage-Authorization' = "Bearer $token"; Accept = 'application/json' }
     $uri = $baseUri.TrimEnd('/') + $Path
+    Write-STLog "SDRequest $Method $uri"
     if ($Body) {
         $json = $Body | ConvertTo-Json -Depth 10
-        Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers -Body $json -ContentType 'application/json'
+        try {
+            Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers -Body $json -ContentType 'application/json'
+            Write-STLog "SUCCESS $Method $uri"
+        } catch {
+            Write-STLog "ERROR $Method $uri :: $_" -Level 'ERROR'
+            throw
+        }
     } else {
-        Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers
+        try {
+            Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers
+            Write-STLog "SUCCESS $Method $uri"
+        } catch {
+            Write-STLog "ERROR $Method $uri :: $_" -Level 'ERROR'
+            throw
+        }
     }
 }

--- a/src/ServiceDeskTools/Public/Get-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDTicket.ps1
@@ -8,5 +8,6 @@ function Get-SDTicket {
     [CmdletBinding()]
     param([Parameter(Mandatory)][int]$Id)
 
+    Write-STLog "Get-SDTicket $Id"
     Invoke-SDRequest -Method 'GET' -Path "/incidents/$Id.json"
 }

--- a/src/ServiceDeskTools/Public/New-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/New-SDTicket.ps1
@@ -16,6 +16,7 @@ function New-SDTicket {
         [Parameter(Mandatory)][string]$RequesterEmail
     )
 
+    Write-STLog "New-SDTicket $Subject"
     $body = @{ incident = @{ name = $Subject; description = $Description; requestor_email = $RequesterEmail } }
     Invoke-SDRequest -Method 'POST' -Path '/incidents.json' -Body $body
 }

--- a/src/ServiceDeskTools/Public/Set-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicket.ps1
@@ -13,6 +13,7 @@ function Set-SDTicket {
         [Parameter(Mandatory)][hashtable]$Fields
     )
 
+    Write-STLog "Set-SDTicket $Id"
     $body = @{ incident = $Fields }
     Invoke-SDRequest -Method 'PUT' -Path "/incidents/$Id.json" -Body $body
 }

--- a/src/ServiceDeskTools/ServiceDeskTools.psm1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psm1
@@ -1,5 +1,7 @@
 $PublicDir = Join-Path $PSScriptRoot 'Public'
 $PrivateDir = Join-Path $PSScriptRoot 'Private'
+$loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+Import-Module $loggingModule -ErrorAction SilentlyContinue
 
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -8,6 +8,9 @@ if (Test-Path $settingsFile) {
     try { $SharePointToolsSettings = Import-PowerShellDataFile $settingsFile } catch {}
 }
 
+$loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+Import-Module $loggingModule -ErrorAction SilentlyContinue
+
 # Override configuration with environment variables when provided
 if ($env:SPTOOLS_CLIENT_ID) { $SharePointToolsSettings.ClientId = $env:SPTOOLS_CLIENT_ID }
 if ($env:SPTOOLS_TENANT_ID) { $SharePointToolsSettings.TenantId = $env:SPTOOLS_TENANT_ID }
@@ -23,6 +26,7 @@ try {
 function Write-SPToolsHacker {
     param([string]$Message)
     Write-Host $Message -ForegroundColor Green -BackgroundColor Black
+    Write-STLog $Message
 }
 
 function Save-SPToolsSettings {

--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -18,8 +18,10 @@ function Invoke-ScriptFile {
     if (-not (Test-Path $Path)) { throw "Script '$Name' not found." }
 
     Write-Host "[***] EXECUTING $Name" -ForegroundColor Green -BackgroundColor Black
+    Write-STLog "EXECUTING $Name"
     if ($Args) {
         Write-Host "       ARGS: $($Args -join ' ')" -ForegroundColor DarkGreen -BackgroundColor Black
+        Write-STLog "ARGS: $($Args -join ' ')"
     }
 
     $oldPref = $ErrorActionPreference
@@ -28,10 +30,12 @@ function Invoke-ScriptFile {
         & $Path @Args
     } catch {
         Write-Error "Execution of '$Name' failed: $_"
+        Write-STLog "Execution of '$Name' failed: $_" -Level 'ERROR'
         throw
     } finally {
         $ErrorActionPreference = $oldPref
     }
 
     Write-Host "[***] COMPLETED $Name" -ForegroundColor Green -BackgroundColor Black
+    Write-STLog "COMPLETED $Name"
 }

--- a/src/SupportTools/Public/Invoke-CompanyPlaceManagement.ps1
+++ b/src/SupportTools/Public/Invoke-CompanyPlaceManagement.ps1
@@ -31,6 +31,7 @@ function Invoke-CompanyPlaceManagement {
     )
 
     Write-Host "[***] Invoke-CompanyPlaceManagement -Action $Action" -ForegroundColor Green -BackgroundColor Black
+    Write-STLog "Invoke-CompanyPlaceManagement -Action $Action"
     if (-not (Get-Command Get-PlaceV3 -ErrorAction SilentlyContinue)) {
         try {
             Import-Module MicrosoftPlaces -ErrorAction Stop
@@ -89,6 +90,7 @@ function Invoke-CompanyPlaceManagement {
     }
 
     Write-Host '[***] Invoke-CompanyPlaceManagement completed' -ForegroundColor Green -BackgroundColor Black
+    Write-STLog 'Invoke-CompanyPlaceManagement completed'
 }
 
 

--- a/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -10,6 +10,7 @@ function Invoke-ExchangeCalendarManager {
     param()
 
     Write-Host '[***] ExchangeCalendarManager launched' -ForegroundColor Green -BackgroundColor Black
+    Write-STLog 'ExchangeCalendarManager launched'
 
     if ($PSVersionTable.PSVersion.Major -lt 7) {
         throw 'This function requires PowerShell 7 or higher.'
@@ -77,4 +78,5 @@ function Invoke-ExchangeCalendarManager {
     Disconnect-ExchangeOnline -Confirm:$false
 
     Write-Host '[***] ExchangeCalendarManager finished' -ForegroundColor Green -BackgroundColor Black
+    Write-STLog 'ExchangeCalendarManager finished'
 }

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -1,5 +1,7 @@
 $PublicDir = Join-Path $PSScriptRoot 'Public'
 $PrivateDir = Join-Path $PSScriptRoot 'Private'
+$loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+Import-Module $loggingModule -ErrorAction SilentlyContinue
 
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
@@ -15,6 +17,7 @@ function Show-SupportToolsBanner {
         Write-Host $line -ForegroundColor Black -BackgroundColor Green
     }
     Write-Host '>> Welcome operator. Run ''Get-Command -Module SupportTools'' to view available tools.' -ForegroundColor Green -BackgroundColor Black
+    Write-STLog 'SupportTools module loaded'
 }
 
 Show-SupportToolsBanner


### PR DESCRIPTION
## Summary
- add new Logging module with `Write-STLog` function
- import logging module across ServiceDeskTools, SharePointTools and SupportTools
- log script executions, service desk requests and module banners
- document the log file in README and style guide

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests -CI"` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684357f379d8832cbe84c376b9b9a07f