### PR TITLE
Fix GitHub Actions test failures on Linux

### DIFF
--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -6,7 +6,8 @@ function Write-STLog {
         [ValidateSet('INFO','WARN','ERROR')]
         [string]$Level = 'INFO'
     )
-    $logDir = Join-Path $env:USERPROFILE 'SupportToolsLogs'
+    $userProfile = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
+    $logDir = Join-Path $userProfile 'SupportToolsLogs'
     if (-not (Test-Path $logDir)) {
         New-Item -Path $logDir -ItemType Directory -Force | Out-Null
     }

--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -14,7 +14,10 @@ function Invoke-ScriptFile {
         [Parameter(ValueFromRemainingArguments=$true)]
         [object[]]$Args
     )
-    $Path = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath '..' | Join-Path -ChildPath "scripts/$Name"
+    $Path = Join-Path $PSScriptRoot '..' |
+            Join-Path -ChildPath '..' |
+            Join-Path -ChildPath '..' |
+            Join-Path -ChildPath "scripts/$Name"
     if (-not (Test-Path $Path)) { throw "Script '$Name' not found." }
 
     Write-Host "[***] EXECUTING $Name" -ForegroundColor Green -BackgroundColor Black


### PR DESCRIPTION
## Summary
- make logging resilient when `$USERPROFILE` isn't set
- correct relative script path resolution in `Invoke-ScriptFile`

## Testing
- `Invoke-Pester -Path tests -CI` *(fails: You cannot call a method on a null-valued expression)*

------
https://chatgpt.com/codex/tasks/task_e_684359cba7ac832ca8135d33dc9ca424