### PR TITLE
Fix markdown help generation workflow

### DIFF
--- a/.github/workflows/generate-help.yml
+++ b/.github/workflows/generate-help.yml
@@ -30,8 +30,9 @@ jobs:
         run: |
           $modules = Get-ChildItem -Path ./src -Directory
           foreach ($module in $modules) {
+            # Import each module by path so platyPS can discover its commands
             $modulePath = Join-Path $module.FullName "$($module.Name).psd1"
-            Import-Module -Name $modulePath -Force
+            Import-Module -Name $modulePath -Force -ErrorAction Stop
             $outputFolder = Join-Path './docs' $module.Name
             if (Test-Path $outputFolder) {
               Update-MarkdownHelp -Path $outputFolder -Module $module.Name -Force


### PR DESCRIPTION
## Summary
- load each module before generating docs so platyPS recognizes the commands

## Testing
- `Invoke-Pester -Path ./tests -OutputFormat NUnitXml -OutputFile test-results.xml -PassThru` *(fails: Could not find Command)*

------
https://chatgpt.com/codex/tasks/task_e_68435c4fdd38832c8d7e9d961bda06ec