### PR TITLE
Fix markdown help workflow for platyPS 0.14

### DIFF
--- a/.github/workflows/generate-help.yml
+++ b/.github/workflows/generate-help.yml
@@ -34,7 +34,7 @@ jobs:
             $imported = Import-Module -Name $modulePath -Force -PassThru
             $outputFolder = Join-Path './docs' $module.Name
             if (Test-Path $outputFolder) {
-              Update-MarkdownHelp -Path $outputFolder -Module $imported -Force
+              Update-MarkdownHelp -Path $outputFolder -Force
             } else {
               New-MarkdownHelp -OutputFolder $outputFolder -Module $imported
             }


### PR DESCRIPTION
## Summary
- avoid passing the unsupported `-Module` parameter to `Update-MarkdownHelp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68435d152c14832cb34c4b3ddfc558af