### PR TITLE
Fix PSScriptAnalyzer workflow

### DIFF
--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |
+          Import-Module PSScriptAnalyzer
           Invoke-ScriptAnalyzer -Path . -Recurse -Severity Warning,Error |
             ConvertTo-Sarif | Set-Content -Path PSScriptAnalyzerResults.sarif
       - name: Upload lint results


### PR DESCRIPTION
## Summary
- ensure the PSScriptAnalyzer module is imported before running lint step

## Testing
- `pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684359ece92c832c9abc38a9de0f741a