### PR TITLE
Fix PSScriptAnalyzer workflow

### DIFF
--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -19,10 +19,15 @@ jobs:
         shell: pwsh
         run: |
           Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+      - name: Install SARIF conversion module
+        shell: pwsh
+        run: |
+          Install-Module Microsoft.PowerShell.Sarif -Force -Scope CurrentUser
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |
           Import-Module PSScriptAnalyzer
+          Import-Module Microsoft.PowerShell.Sarif
           Invoke-ScriptAnalyzer -Path . -Recurse -Severity Warning,Error |
             ConvertTo-Sarif | Set-Content -Path PSScriptAnalyzerResults.sarif
       - name: Upload lint results


### PR DESCRIPTION
## Summary
- install Microsoft.PowerShell.Sarif module in the lint workflow
- import the SARIF module before converting results

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68435ff48d5c832c826262bf5930656d