### PR TITLE
Add customizable log path

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ module see [docs/CredentialStorage.md](docs/CredentialStorage.md).
 
 ## Centralized Logging
 
-Commands automatically record their activity to `%USERPROFILE%\SupportToolsLogs\supporttools.log`.
-Review this file with `Get-Content` when troubleshooting.
+Commands automatically record their activity to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default.
+Set the `ST_LOG_PATH` environment variable or use the `-Path` parameter of `Write-STLog` to write logs to a custom location.
+Review the resulting log file with `Get-Content` when troubleshooting.
 
 ## Roadmap
 

--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Write-STLog [-Message] <String> [[-Level] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Write-STLog [-Message] <String> [[-Level] <String>] [[-Path] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -56,6 +56,22 @@ Aliases:
 
 Required: True
 Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+Custom path to the log file. Overrides the default location and the `ST_LOG_PATH`
+environment variable.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/ModuleStyleGuide.md
+++ b/docs/ModuleStyleGuide.md
@@ -14,4 +14,6 @@ Include a message when starting work and another when the task completes so the
 operator can follow along as scripts run.
 
 Every message output through `Write-SPToolsHacker` is also written to
-`%USERPROFILE%\SupportToolsLogs\supporttools.log` for troubleshooting.
+`%USERPROFILE%\SupportToolsLogs\supporttools.log` by default. Set the `ST_LOG_PATH`
+environment variable or use `Write-STLog -Path` to log to a different file for
+troubleshooting.

--- a/src/Logging/Logging.psd1
+++ b/src/Logging/Logging.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'Logging.psm1'
-    ModuleVersion = '1.0.0'
+    ModuleVersion = '1.1.0'
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000010'
     Author = 'Contoso'
     Description = 'Provides centralized logging utilities for all modules.'

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -4,14 +4,22 @@ function Write-STLog {
         [Parameter(Mandatory)]
         [string]$Message,
         [ValidateSet('INFO','WARN','ERROR')]
-        [string]$Level = 'INFO'
+        [string]$Level = 'INFO',
+        [string]$Path
     )
     $userProfile = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
-    $logDir = Join-Path $userProfile 'SupportToolsLogs'
-    if (-not (Test-Path $logDir)) {
-        New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+    if ($Path) {
+        $logFile = $Path
+    } elseif ($env:ST_LOG_PATH) {
+        $logFile = $env:ST_LOG_PATH
+    } else {
+        $logDir = Join-Path $userProfile 'SupportToolsLogs'
+        $logFile = Join-Path $logDir 'supporttools.log'
     }
-    $logFile = Join-Path $logDir 'supporttools.log'
+    $dir = Split-Path -Path $logFile -Parent
+    if (-not (Test-Path $dir)) {
+        New-Item -Path $dir -ItemType Directory -Force | Out-Null
+    }
     $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
     "$timestamp [$Level] $Message" | Out-File -FilePath $logFile -Append -Encoding utf8
 }

--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -1,0 +1,27 @@
+Describe 'Logging Module' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
+    }
+
+    It 'writes to the path parameter' {
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            Write-STLog -Message 'path test' -Path $temp
+            (Get-Content $temp) | Should -Match 'path test'
+        } finally {
+            Remove-Item $temp -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'writes to ST_LOG_PATH when set' {
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            $env:ST_LOG_PATH = $temp
+            Write-STLog -Message 'env test'
+            (Get-Content $temp) | Should -Match 'env test'
+        } finally {
+            Remove-Item $temp -ErrorAction SilentlyContinue
+            Remove-Item env:ST_LOG_PATH
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow specifying a log file path for `Write-STLog`
- document the new `ST_LOG_PATH` environment variable
- bump Logging module version to 1.1.0
- add basic tests for `Write-STLog`

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package)*
- `Invoke-Pester -Path tests -CI` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843607a9640832c98de39774e626d1d