### PR TITLE
Fix SARIF module in lint workflow

### DIFF
--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -22,12 +22,12 @@ jobs:
       - name: Install SARIF conversion module
         shell: pwsh
         run: |
-          Install-Module Microsoft.PowerShell.Sarif -Force -Scope CurrentUser
+          Install-Module ConvertToSARIF -Force -Scope CurrentUser
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |
           Import-Module PSScriptAnalyzer
-          Import-Module Microsoft.PowerShell.Sarif
+          Import-Module ConvertToSARIF
           Invoke-ScriptAnalyzer -Path . -Recurse -Severity Warning,Error |
             ConvertTo-Sarif | Set-Content -Path PSScriptAnalyzerResults.sarif
       - name: Upload lint results


### PR DESCRIPTION
## Summary
- use ConvertToSARIF module for SARIF conversion in GitHub Actions

## Testing
- `Invoke-Pester -Configuration @{ Run = @{ Exit = $false } }` *(fails: RuntimeException: method on a null-valued expression)*

------
https://chatgpt.com/codex/tasks/task_e_684361d5e560832cb7ecea782cbf21e7