### PR TITLE
Fix script examples to use env computername

### DIFF
--- a/Examples/Example_Get-FailedLogins.ps1
+++ b/Examples/Example_Get-FailedLogins.ps1
@@ -1,2 +1,2 @@
 Import-Module ../src/SupportTools/SupportTools.psd1
-Get-FailedLogins -ComputerName 'SERVER1'
+Get-FailedLogins -ComputerName $env:COMPUTERNAME

--- a/Examples/Example_Get-NetworkShares.ps1
+++ b/Examples/Example_Get-NetworkShares.ps1
@@ -1,2 +1,2 @@
 Import-Module ../src/SupportTools/SupportTools.psd1
-Get-NetworkShares -ComputerName 'SERVER1'
+Get-NetworkShares -ComputerName $env:COMPUTERNAME


### PR DESCRIPTION
## Summary
- avoid hardcoded computer names in `Example_Get-FailedLogins.ps1` and `Example_Get-NetworkShares.ps1`

## Testing
- `Invoke-Pester -Path tests -CI` *(fails: CommandNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_68436373b794832c8fa8a040971bce19