### PR TITLE
Fix Quickstart docs

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -22,10 +22,8 @@ This short guide shows the basic steps to start using the modules in this reposi
    ./scripts/Configure-SharePointTools.ps1
    ```
 5. **Load credentials** (optional)
-   ```powershell
-   # Example using SecretManagement
-   . ./docs/CredentialStorage.md
-   ```
+   Refer to [CredentialStorage.md](CredentialStorage.md) for a step‑by‑step
+   walkthrough of using SecretManagement to load environment variables.
 6. **Try a few common commands**
    ```powershell
    # System information


### PR DESCRIPTION
## Summary
- clarify Quickstart credential loading instructions

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests -CI"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843661ef9a4832c90803ba5d8e68a81