### PR TITLE
Fix Pester tests for wrapper functions

### DIFF
--- a/tests/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools.Tests.ps1
@@ -56,13 +56,11 @@ Describe 'SharePointTools Module' {
             @{ Fn = 'Invoke-MexCentralFilesSharingLinkCleanup'; Target = 'Invoke-SharingLinkCleanup'; Site = 'MexCentralFiles' }
         )
 
-        foreach ($m in $maps) {
-            $case = $m
-            It "$($case.Fn) calls $($case.Target)" {
-                Mock $case.Target {} -ModuleName SharePointTools
-                & $case.Fn
-                Assert-MockCalled $case.Target -ModuleName SharePointTools -ParameterFilter { $SiteName -eq $case.Site } -Times 1
-            }
+        It '<Fn> calls <Target>' -ForEach $maps {
+            param($Fn, $Target, $Site)
+            Mock $Target {} -ModuleName SharePointTools
+            & $Fn
+            Assert-MockCalled $Target -ModuleName SharePointTools -ParameterFilter { $SiteName -eq $Site } -Times 1
         }
     }
 

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -58,13 +58,15 @@ Describe 'SupportTools Module' {
             Update_Sysmon                = 'Update-Sysmon.ps1'
         }
 
-        foreach ($entry in $map.GetEnumerator()) {
-            $case = $entry
-            It "$($case.Key) calls Invoke-ScriptFile" {
-                Mock Invoke-ScriptFile {} -ModuleName SupportTools
-                & $case.Key.ToString().Replace('_','-')
-                Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -ParameterFilter { $Name -eq $case.Value } -Times 1
-            }
+        $cases = foreach ($entry in $map.GetEnumerator()) {
+            @{ Fn = $entry.Key; Script = $entry.Value }
+        }
+
+        It '<Fn> calls Invoke-ScriptFile' -ForEach $cases {
+            param($Fn, $Script)
+            Mock Invoke-ScriptFile {} -ModuleName SupportTools
+            & $Fn.ToString().Replace('_','-')
+            Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -ParameterFilter { $Name -eq $Script } -Times 1
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure test cases capture foreach variables using `-ForEach`
- update SupportTools and SharePointTools tests

## Testing
- `Invoke-Pester -Path tests -CI`

------
https://chatgpt.com/codex/tasks/task_e_684364a2bff4832c906400a4186aa2aa