### PR TITLE
Add extra coverage for logging tests

### DIFF
--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -24,4 +24,54 @@ Describe 'Logging Module' {
             Remove-Item env:ST_LOG_PATH
         }
     }
+
+    It 'writes to the default log path' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+        New-Item -ItemType Directory -Path $tempDir | Out-Null
+        $oldHome = $env:HOME
+        $oldUser = $env:USERPROFILE
+        try {
+            $env:HOME = $tempDir
+            $env:USERPROFILE = ''
+            Remove-Item env:ST_LOG_PATH -ErrorAction SilentlyContinue
+            Write-STLog -Message 'default test'
+            $expected = Join-Path $tempDir 'SupportToolsLogs/supporttools.log'
+            (Get-Content $expected) | Should -Match 'default test'
+        } finally {
+            if ($null -ne $oldHome) { $env:HOME = $oldHome } else { Remove-Item env:HOME -ErrorAction SilentlyContinue }
+            if ($null -ne $oldUser) { $env:USERPROFILE = $oldUser } else { Remove-Item env:USERPROFILE -ErrorAction SilentlyContinue }
+            Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'creates the log directory when needed' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+        $logPath = Join-Path $tempDir 'nested/log.txt'
+        try {
+            Write-STLog -Message 'dir create test' -Path $logPath
+            Test-Path $logPath | Should -Be $true
+        } finally {
+            Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'includes timestamp and level in the output' {
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            Write-STLog -Message 'format test' -Level WARN -Path $temp
+            $content = Get-Content $temp
+            $content | Should -Match '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \[WARN\] format test$'
+        } finally {
+            Remove-Item $temp -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'throws on invalid log level' {
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            { Write-STLog -Message 'bad level' -Level INVALID -Path $temp } | Should -Throw
+        } finally {
+            Remove-Item $temp -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- extend `Logging.Tests.ps1` with more cases

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests -CI"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843689b6030832c8d160bfe5eced167