### PR TITLE
Fix workflow badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SupportTools PowerShell Modules
-[![Pester Tests](https://github.com/your-org/PowerShell/actions/workflows/pester-tests.yml/badge.svg)](https://github.com/your-org/PowerShell/actions/workflows/pester-tests.yml)
+[![Pester Tests](https://github.com/yourlastnamesoundslikeatypeofpasta/PowerShell/actions/workflows/pester-tests.yml/badge.svg)](https://github.com/yourlastnamesoundslikeatypeofpasta/PowerShell/actions/workflows/pester-tests.yml)
 
 
 This repository packages a collection of scripts into reusable modules.


### PR DESCRIPTION
## Summary
- update the pester tests workflow badge URL in README

## Testing
- `Invoke-Pester -CI` *(fails: CommandNotFoundException and RuntimeException)*

------
https://chatgpt.com/codex/tasks/task_e_684368f18768832c82f2d70d67717444