### PR TITLE
Fix Pester wrapper tests

### DIFF
--- a/tests/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools.Tests.ps1
@@ -56,16 +56,14 @@ Describe 'SharePointTools Module' {
             @{ Fn = 'Invoke-MexCentralFilesSharingLinkCleanup'; Target = 'Invoke-SharingLinkCleanup'; Site = 'MexCentralFiles' }
         )
 
-        foreach ($m in $maps) {
-            $case = $m
-            It "$($case.Fn) calls $($case.Target)" {
-                InModuleScope SharePointTools {
-                    Mock $case.Target {}
-                    & $case.Fn
-                    Assert-MockCalled $case.Target -Times 1
-                }
-            }
+        $cases = foreach ($m in $maps) {
+            @{ Fn = $m.Fn; Target = $m.Target }
+        }
 
+        It '<Fn> calls <Target>' -ForEach $cases {
+            Mock $Target {} -ModuleName SharePointTools
+            & $Fn
+            Assert-MockCalled $Target -ModuleName SharePointTools -Times 1
         }
     }
 

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -58,17 +58,16 @@ Describe 'SupportTools Module' {
             Update_Sysmon                = 'Update-Sysmon.ps1'
         }
 
-        foreach ($entry in $map.GetEnumerator()) {
-            $case = $entry
-            It "$($case.Key) calls Invoke-ScriptFile" {
-                InModuleScope SupportTools {
-                    Mock Invoke-ScriptFile {}
-                    & $case.Key.ToString().Replace('_','-')
-                    Assert-MockCalled Invoke-ScriptFile -Times 1
-                }
-            }
-
+        $cases = foreach ($entry in $map.GetEnumerator()) {
+            @{ Fn = $entry.Key.ToString().Replace('_','-') }
         }
+
+        It 'calls Invoke-ScriptFile for <Fn>' -ForEach $cases {
+            Mock Invoke-ScriptFile {} -ModuleName SupportTools
+            & $Fn
+            Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -Times 1
+        }
+
     }
 
     Context 'Add-UsersToGroup output passthrough' {


### PR DESCRIPTION
## Summary
- fix wrapper tests by mocking module functions directly
- use test case variables with `-ForEach`
- ensure tests run cleanly

## Testing
- `Invoke-Pester -Path tests -CI`

------
https://chatgpt.com/codex/tasks/task_e_6843686783fc832ca67c2ce3c8af5e1b