### PR TITLE
Refactor SupportTools functions

### DIFF
--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -14,15 +14,15 @@ listed are forwarded to the underlying script unchanged.
 
 | Command | Wrapped Script | Key Parameters | Example |
 |---------|----------------|---------------|---------|
-| `Add-UsersToGroup` | `AddUsersToGroup.ps1` | `CsvPath`, `GroupName` | `Add-UsersToGroup -CsvPath users.csv -GroupName 'Team'` |
+| `Add-UserToGroup` | `AddUsersToGroup.ps1` | `CsvPath`, `GroupName` | `Add-UserToGroup -CsvPath users.csv -GroupName 'Team'` |
 | `Clear-ArchiveFolder` | `CleanupArchive.ps1` | *passthrough* | `Clear-ArchiveFolder -SiteUrl https://contoso.sharepoint.com/sites/Files` |
 | `Convert-ExcelToCsv` | `Convert-ExcelToCsv.ps1` | *passthrough* | `Convert-ExcelToCsv -Path workbook.xlsx` |
 | `Export-ProductKey` | `ProductKey.ps1` | *passthrough* | `Export-ProductKey` |
 | `Get-CommonSystemInfo` | `Get-CommonSystemInfo.ps1` | *passthrough* | `Get-CommonSystemInfo` |
-| `Get-FailedLogins` | `Get-FailedLogins.ps1` | *passthrough* | `Get-FailedLogins -ComputerName PC1` |
-| `Get-NetworkShares` | `Get-NetworkShares.ps1` | *passthrough* | `Get-NetworkShares -ComputerName FS01` |
-| `Get-UniquePermissions` | `Get-UniquePermissions.ps1` | *passthrough* | `Get-UniquePermissions -SiteUrl https://contoso.sharepoint.com/sites/HR` |
-| `Install-Fonts` | `Install-Fonts.ps1` | *passthrough* | `Install-Fonts -Source C:\Fonts` |
+| `Get-FailedLogin` | `Get-FailedLogins.ps1` | *passthrough* | `Get-FailedLogin -ComputerName PC1` |
+| `Get-NetworkShare` | `Get-NetworkShares.ps1` | *passthrough* | `Get-NetworkShare -ComputerName FS01` |
+| `Get-UniquePermission` | `Get-UniquePermissions.ps1` | *passthrough* | `Get-UniquePermission -SiteUrl https://contoso.sharepoint.com/sites/HR` |
+| `Install-Font` | `Install-Fonts.ps1` | *passthrough* | `Install-Font -Source C:\Fonts` |
 | `Invoke-DeploymentTemplate` | `SS_DEPLOYMENT_TEMPLATE.ps1` | *passthrough* | `Invoke-DeploymentTemplate -Verbose` |
 | `Invoke-ExchangeCalendarManager` | `ExchangeCalendarManager.ps1` | *interactive* | `Invoke-ExchangeCalendarManager` |
 | `Invoke-PostInstall` | `PostInstallScript.ps1` | *passthrough* | `Invoke-PostInstall -Domain contoso.com` |

--- a/docs/SupportTools/Add-UserToGroup.md
+++ b/docs/SupportTools/Add-UserToGroup.md
@@ -5,46 +5,61 @@ online version:
 schema: 2.0.0
 ---
 
-# Install-Fonts
+# Add-UserToGroup
 
 ## SYNOPSIS
-Installs font files for all users.
+Adds users from a CSV file to a Microsoft 365 group.
 
 ## SYNTAX
 
 ```
-Install-Fonts [[-Arguments] <Object[]>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>]
- [<CommonParameters>]
+Add-UserToGroup [[-CsvPath] <String>] [[-GroupName] <String>] [[-TranscriptPath] <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Simple wrapper for the Install-Fonts.ps1 script which performs the
-installation work.
-Arguments are passed directly through.
+Wraps the AddUsersToGroup.ps1 script located in the repository's scripts
+folder.
+Parameters are passed directly through to the script file.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> Install-Fonts -Path './Fonts'
+PS C:\> Add-UserToGroup -CsvPath './users.csv' -GroupName 'MyGroup'
 ```
 
-Demonstrates typical usage of Install-Fonts.
+Demonstrates typical usage of Add-UserToGroup.
 
 ## PARAMETERS
 
-### -Arguments
-Arguments passed directly to the underlying script.
+### -CsvPath
+Path to the CSV file containing user principal names.
 
 ```yaml
-Type: Object[]
+Type: String
 Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: 1
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -GroupName
+Name of the Microsoft 365 group to modify.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -57,7 +72,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/SupportTools/Clear-TempFile.md
+++ b/docs/SupportTools/Clear-TempFile.md
@@ -5,30 +5,29 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-FailedLogins
+# Clear-TempFile
 
 ## SYNOPSIS
-Retrieves failed login attempts from the Security event log.
+Removes temporary files from the repository.
 
 ## SYNTAX
 
 ```
-Get-FailedLogins [[-Arguments] <Object[]>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>]
+Clear-TempFile [[-Arguments] <Object[]>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Calls the Get-FailedLogins.ps1 script in the scripts folder and returns
-its output.
+Wraps the CleanupTempFiles.ps1 script in the scripts folder and forwards any provided arguments.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> Get-FailedLogins -ComputerName $env:COMPUTERNAME
+PS C:\> Clear-TempFile -? # replace with actual parameters
 ```
 
-Demonstrates typical usage of Get-FailedLogins.
+Demonstrates typical usage of Clear-TempFile.
 
 ## PARAMETERS
 

--- a/docs/SupportTools/Get-FailedLogin.md
+++ b/docs/SupportTools/Get-FailedLogin.md
@@ -5,61 +5,45 @@ online version:
 schema: 2.0.0
 ---
 
-# Add-UsersToGroup
+# Get-FailedLogin
 
 ## SYNOPSIS
-Adds users from a CSV file to a Microsoft 365 group.
+Retrieves failed login attempts from the Security event log.
 
 ## SYNTAX
 
 ```
-Add-UsersToGroup [[-CsvPath] <String>] [[-GroupName] <String>] [[-TranscriptPath] <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-FailedLogin [[-Arguments] <Object[]>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Wraps the AddUsersToGroup.ps1 script located in the repository's scripts
-folder.
-Parameters are passed directly through to the script file.
+Calls the Get-FailedLogins.ps1 script in the scripts folder and returns
+its output.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> Add-UsersToGroup -CsvPath './users.csv' -GroupName 'MyGroup'
+PS C:\> Get-FailedLogin -ComputerName $env:COMPUTERNAME
 ```
 
-Demonstrates typical usage of Add-UsersToGroup.
+Demonstrates typical usage of Get-FailedLogin.
 
 ## PARAMETERS
 
-### -CsvPath
-Path to the CSV file containing user principal names.
+### -Arguments
+Arguments passed directly to the underlying script.
 
 ```yaml
-Type: String
+Type: Object[]
 Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: 1
 Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -GroupName
-Name of the Microsoft 365 group to modify.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 2
-Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
@@ -72,7 +56,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/SupportTools/Get-NetworkShare.md
+++ b/docs/SupportTools/Get-NetworkShare.md
@@ -5,29 +5,30 @@ online version:
 schema: 2.0.0
 ---
 
-# Clear-TempFiles
+# Get-NetworkShare
 
 ## SYNOPSIS
-Removes temporary files from the repository.
+Lists network shares on a specified computer.
 
 ## SYNTAX
 
 ```
-Clear-TempFiles [[-Arguments] <Object[]>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>]
+Get-NetworkShare [[-Arguments] <Object[]>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Wraps the CleanupTempFiles.ps1 script in the scripts folder and forwards any provided arguments.
+Executes the Get-NetworkShares.ps1 script from the scripts folder and
+returns its results.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> Clear-TempFiles -? # replace with actual parameters
+PS C:\> Get-NetworkShare -ComputerName $env:COMPUTERNAME
 ```
 
-Demonstrates typical usage of Clear-TempFiles.
+Demonstrates typical usage of Get-NetworkShare.
 
 ## PARAMETERS
 

--- a/docs/SupportTools/Get-UniquePermission.md
+++ b/docs/SupportTools/Get-UniquePermission.md
@@ -5,30 +5,30 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-NetworkShares
+# Get-UniquePermission
 
 ## SYNOPSIS
-Lists network shares on a specified computer.
+Returns items with unique permissions in a SharePoint site.
 
 ## SYNTAX
 
 ```
-Get-NetworkShares [[-Arguments] <Object[]>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>]
- [<CommonParameters>]
+Get-UniquePermission [[-Arguments] <Object[]>] [[-TranscriptPath] <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Executes the Get-NetworkShares.ps1 script from the scripts folder and
-returns its results.
+Calls the Get-UniquePermissions.ps1 script contained in the scripts
+directory and outputs its results.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> Get-NetworkShares -ComputerName $env:COMPUTERNAME
+PS C:\> Get-UniquePermission -SiteUrl 'https://contoso.sharepoint.com/sites/Example'
 ```
 
-Demonstrates typical usage of Get-NetworkShares.
+Demonstrates typical usage of Get-UniquePermission.
 
 ## PARAMETERS
 

--- a/docs/SupportTools/Install-Font.md
+++ b/docs/SupportTools/Install-Font.md
@@ -5,30 +5,31 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-UniquePermissions
+# Install-Font
 
 ## SYNOPSIS
-Returns items with unique permissions in a SharePoint site.
+Installs font files for all users.
 
 ## SYNTAX
 
 ```
-Get-UniquePermissions [[-Arguments] <Object[]>] [[-TranscriptPath] <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Install-Font [[-Arguments] <Object[]>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Calls the Get-UniquePermissions.ps1 script contained in the scripts
-directory and outputs its results.
+Simple wrapper for the Install-Fonts.ps1 script which performs the
+installation work.
+Arguments are passed directly through.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> Get-UniquePermissions -SiteUrl 'https://contoso.sharepoint.com/sites/Example'
+PS C:\> Install-Font -Path './Fonts'
 ```
 
-Demonstrates typical usage of Get-UniquePermissions.
+Demonstrates typical usage of Install-Font.
 
 ## PARAMETERS
 

--- a/src/SupportTools/Public/Add-UserToGroup.ps1
+++ b/src/SupportTools/Public/Add-UserToGroup.ps1
@@ -1,4 +1,4 @@
-function Add-UsersToGroup {
+function Add-UserToGroup {
     <#
     .SYNOPSIS
         Adds users from a CSV file to a Microsoft 365 group.

--- a/src/SupportTools/Public/Clear-TempFile.ps1
+++ b/src/SupportTools/Public/Clear-TempFile.ps1
@@ -1,4 +1,4 @@
-function Clear-TempFiles {
+function Clear-TempFile {
     <#
     .SYNOPSIS
         Removes temporary files from the repository.

--- a/src/SupportTools/Public/Get-FailedLogin.ps1
+++ b/src/SupportTools/Public/Get-FailedLogin.ps1
@@ -1,4 +1,4 @@
-function Get-FailedLogins {
+function Get-FailedLogin {
     <#
     .SYNOPSIS
         Retrieves failed login attempts from the Security event log.

--- a/src/SupportTools/Public/Get-NetworkShare.ps1
+++ b/src/SupportTools/Public/Get-NetworkShare.ps1
@@ -1,4 +1,4 @@
-function Get-NetworkShares {
+function Get-NetworkShare {
     <#
     .SYNOPSIS
         Lists network shares on a specified computer.

--- a/src/SupportTools/Public/Get-UniquePermission.ps1
+++ b/src/SupportTools/Public/Get-UniquePermission.ps1
@@ -1,4 +1,4 @@
-function Get-UniquePermissions {
+function Get-UniquePermission {
     <#
     .SYNOPSIS
         Returns items with unique permissions in a SharePoint site.

--- a/src/SupportTools/Public/Install-Font.ps1
+++ b/src/SupportTools/Public/Install-Font.ps1
@@ -1,4 +1,4 @@
-function Install-Fonts {
+function Install-Font {
     <#
     .SYNOPSIS
         Installs font files for all users.

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -5,15 +5,15 @@
     Author = 'Contoso'
     Description = 'Collection of helper functions wrapping existing scripts.'
     FunctionsToExport = @(
-        'Add-UsersToGroup',
+        'Add-UserToGroup',
         'Clear-ArchiveFolder',
-        'Clear-TempFiles',
+        'Clear-TempFile',
         'Convert-ExcelToCsv',
         'Get-CommonSystemInfo',
-        'Get-FailedLogins',
-        'Get-NetworkShares',
-        'Get-UniquePermissions',
-        'Install-Fonts',
+        'Get-FailedLogin',
+        'Get-NetworkShare',
+        'Get-UniquePermission',
+        'Install-Font',
         'Invoke-PostInstall',
         'Export-ProductKey',
         'Invoke-DeploymentTemplate',

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -6,7 +6,7 @@ Import-Module $loggingModule -ErrorAction SilentlyContinue
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Add-UsersToGroup','Clear-ArchiveFolder','Clear-TempFiles','Convert-ExcelToCsv','Get-CommonSystemInfo','Get-FailedLogins','Get-NetworkShares','Get-UniquePermissions','Install-Fonts','Invoke-PostInstall','Export-ProductKey','Invoke-DeploymentTemplate','Search-ReadMe','Set-ComputerIPAddress','Set-NetAdapterMetering','Set-TimeZoneEasternStandardTime','Start-Countdown','Update-Sysmon','Set-SharedMailboxAutoReply','Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement'
+Export-ModuleMember -Function 'Add-UserToGroup','Clear-ArchiveFolder','Clear-TempFile','Convert-ExcelToCsv','Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Get-UniquePermission','Install-Font','Invoke-PostInstall','Export-ProductKey','Invoke-DeploymentTemplate','Search-ReadMe','Set-ComputerIPAddress','Set-NetAdapterMetering','Set-TimeZoneEasternStandardTime','Start-Countdown','Update-Sysmon','Set-SharedMailboxAutoReply','Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement'
 
 function Show-SupportToolsBanner {
     Write-STStatus '════════════════════════════════════════════' -Level INFO

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -5,15 +5,15 @@ Describe 'SupportTools Module' {
 
     Context 'Exported commands' {
         $expected = @(
-            'Add-UsersToGroup',
+            'Add-UserToGroup',
             'Clear-ArchiveFolder',
-            'Clear-TempFiles',
+            'Clear-TempFile',
             'Convert-ExcelToCsv',
             'Get-CommonSystemInfo',
-            'Get-FailedLogins',
-            'Get-NetworkShares',
-            'Get-UniquePermissions',
-            'Install-Fonts',
+            'Get-FailedLogin',
+            'Get-NetworkShare',
+            'Get-UniquePermission',
+            'Install-Font',
             'Invoke-PostInstall',
             'Export-ProductKey',
             'Invoke-DeploymentTemplate',
@@ -38,15 +38,15 @@ Describe 'SupportTools Module' {
 
     Context 'Wrapper script invocation' {
         $map = @{
-            Add_UsersToGroup             = 'AddUsersToGroup.ps1'
+            Add_UserToGroup             = 'AddUsersToGroup.ps1'
             Clear_ArchiveFolder          = 'CleanupArchive.ps1'
-            Clear_TempFiles              = 'CleanupTempFiles.ps1'
+            Clear_TempFile              = 'CleanupTempFiles.ps1'
             Convert_ExcelToCsv           = 'Convert-ExcelToCsv.ps1'
             Get_CommonSystemInfo         = 'Get-CommonSystemInfo.ps1'
-            Get_FailedLogins             = 'Get-FailedLogins.ps1'
-            Get_NetworkShares            = 'Get-NetworkShares.ps1'
-            Get_UniquePermissions        = 'Get-UniquePermissions.ps1'
-            Install_Fonts                = 'Install-Fonts.ps1'
+            Get_FailedLogin             = 'Get-FailedLogins.ps1'
+            Get_NetworkShare            = 'Get-NetworkShares.ps1'
+            Get_UniquePermission        = 'Get-UniquePermissions.ps1'
+            Install_Font                = 'Install-Fonts.ps1'
             Invoke_PostInstall           = 'PostInstallScript.ps1'
             Export_ProductKey            = 'ProductKey.ps1'
             Invoke_DeploymentTemplate    = 'SS_DEPLOYMENT_TEMPLATE.ps1'
@@ -58,17 +58,9 @@ Describe 'SupportTools Module' {
             Update_Sysmon                = 'Update-Sysmon.ps1'
         }
 
-        foreach ($key in $map.Keys) {
-            $cmdName = $key.Replace('_','-')
-            It "$key calls Invoke-ScriptFile" {
-                InModuleScope SupportTools -ScriptBlock {
-                    param($Name)
-                    Mock Invoke-ScriptFile {} -ModuleName SupportTools
-                    & $Name
-                    Assert-MockCalled Invoke-ScriptFile -Times 1
-                } -ArgumentList $cmdName
-            }
-
+        $cases = foreach ($entry in $map.GetEnumerator()) {
+            @{ Fn = $entry.Key.ToString().Replace('_','-') }
+        }
 
         It 'calls Invoke-ScriptFile for <Fn>' -ForEach $cases {
             Mock Invoke-ScriptFile {} -ModuleName SupportTools
@@ -78,12 +70,12 @@ Describe 'SupportTools Module' {
 
     }
 
-    Context 'Add-UsersToGroup output passthrough' {
+    Context 'Add-UserToGroup output passthrough' {
         It 'returns the object produced by the script' {
             InModuleScope SupportTools {
                 $expected = [pscustomobject]@{ GroupName = 'MyGroup'; AddedUsers = @('a'); SkippedUsers = @('b') }
                 Mock Invoke-ScriptFile { $expected } -ModuleName SupportTools
-                $result = Add-UsersToGroup -CsvPath 'users.csv' -GroupName 'MyGroup'
+                $result = Add-UserToGroup -CsvPath 'users.csv' -GroupName 'MyGroup'
                 $result | Should -Be $expected
             }
         }


### PR DESCRIPTION
## Summary
- rename SupportTools cmdlets to use singular nouns
- update module exports and manifest
- adjust docs for the new names
- fix tests for new command names

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests -CI"` *(fails: Set-MailboxAutoReplyConfiguration expected to be invoked)*

------
https://chatgpt.com/codex/tasks/task_e_68436ef7be6c832cb33c64b16f77adf8