### PR TITLE
Fix ServiceDeskTools request body and SupportTools tests

### DIFF
--- a/src/ServiceDeskTools/Public/New-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/New-SDTicket.ps1
@@ -17,6 +17,6 @@ function New-SDTicket {
     )
 
     Write-STLog "New-SDTicket $Subject"
-    $body = @{ incident = @{ name = $Subject; description = $Description; requestor_email = $RequesterEmail } }
+    $body = @{ incident = @{ name = $Subject; description = $Description; requester_email = $RequesterEmail } }
     Invoke-SDRequest -Method 'POST' -Path '/incidents.json' -Body $body
 }

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -76,6 +76,8 @@ Describe 'SupportTools Module' {
             Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -Times 1
         }
 
+        }
+
     }
 
     Context 'Add-UsersToGroup output passthrough' {
@@ -213,7 +215,7 @@ Describe 'SupportTools Module' {
                 Mock Get-PlaceV3 { @() } -ModuleName SupportTools
                 Mock New-Place {
                     if ($Type -eq 'Building') { return @{ PlaceId = '1' } }
-                } -ModuleName SupportTools
+                }
                 Mock Write-Host {} -ModuleName SupportTools
 
                 Invoke-CompanyPlaceManagement -Action Create -DisplayName 'B1' -Type Building -AutoAddFloor


### PR DESCRIPTION
## Summary
- correct property name in New-SDTicket
- fix syntax in SupportTools tests and adjust mocking for `New-Place`

## Testing
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester -Path tests/ServiceDeskTools.Tests.ps1 -CI`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester -Path tests/Logging.Tests.ps1 -CI`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester -Path tests/SharePointTools.Tests.ps1 -CI`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester -Path tests/SupportTools.Tests.ps1 -CI` *(fails: New-Place mock not called)*

------
https://chatgpt.com/codex/tasks/task_e_68436fd8bfdc832c96d8c78247d8e391