### PR TITLE
Add file metadata reporting cmdlet

### DIFF
--- a/docs/SharePointTools.md
+++ b/docs/SharePointTools.md
@@ -42,6 +42,7 @@ All functions emit short, high contrast messages following the style in [ModuleS
 | `Get-SPPermissionsReport` | List role assignments for a site or folder. | `SiteUrl`, `[FolderUrl]`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `Get-SPPermissionsReport -SiteUrl https://contoso.sharepoint.com/sites/hr` |
 | `Clean-SPVersionHistory` | Trim file versions beyond a limit. | `SiteUrl`, `[LibraryName]`, `[KeepVersions]`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `Clean-SPVersionHistory -SiteUrl https://contoso.sharepoint.com/sites/hr -KeepVersions 5` |
 | `Find-OrphanedSPFiles` | Locate files not modified for a period. | `SiteUrl`, `[LibraryName]`, `[Days]`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `Find-OrphanedSPFiles -SiteUrl https://contoso.sharepoint.com/sites/hr -Days 90` |
+| `Get-SPToolsFileReport` | Export file metadata from a library. | `SiteName`, `[SiteUrl]`, `[LibraryName]`, `[ClientId]`, `[TenantId]`, `[CertPath]`, `[ReportPath]` | `Get-SPToolsFileReport -SiteName HR -ReportPath files.csv` |
 | `List-OneDriveUsage` | Report OneDrive storage use across the tenant. | `AdminUrl`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `List-OneDriveUsage -AdminUrl https://contoso-admin.sharepoint.com` |
 
 

--- a/docs/SharePointTools/Get-SPToolsFileReport.md
+++ b/docs/SharePointTools/Get-SPToolsFileReport.md
@@ -1,0 +1,67 @@
+---
+external help file: SharePointTools-help.xml
+Module Name: SharePointTools
+online version:
+schema: 2.0.0
+---
+
+# Get-SPToolsFileReport
+
+## SYNOPSIS
+Return metadata for all files in a document library.
+
+## SYNTAX
+
+```
+Get-SPToolsFileReport [-SiteName] <String> [[-SiteUrl] <String>] [[-LibraryName] <String>] [[-ClientId] <String>] [[-TenantId] <String>] [[-CertPath] <String>] [[-ReportPath] <String>] [[-PageSize] <Int32>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Collects detailed information about each file in the specified library. When `-ReportPath` is supplied the data is written to a CSV file.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Get-SPToolsFileReport -SiteName HR -ReportPath files.csv
+```
+
+## PARAMETERS
+
+### -SiteName
+Friendly name of the site.
+
+### -SiteUrl
+URL of the SharePoint site if not stored in settings.
+
+### -LibraryName
+Name of the document library. Defaults to `Documents`.
+
+### -ClientId
+Client ID used for authentication.
+
+### -TenantId
+Tenant ID used for authentication.
+
+### -CertPath
+Certificate path used for authentication.
+
+### -ReportPath
+Optional path for the exported CSV report.
+
+### -PageSize
+Number of items retrieved per request. Defaults to 5000.
+
+### CommonParameters
+This cmdlet supports the common parameters.
+
+## INPUTS
+None
+
+## OUTPUTS
+System.Object
+
+## NOTES
+
+## RELATED LINKS
+

--- a/src/SharePointTools/SharePointTools.psd1
+++ b/src/SharePointTools/SharePointTools.psd1
@@ -31,7 +31,7 @@
         'Get-SPToolsAllPreservationHoldReports',
         'Get-SPPermissionsReport',
         'Clean-SPVersionHistory',
-        'Find-OrphanedSPFiles',
+        'Find-OrphanedSPFiles','Get-SPToolsFileReport',
         'List-OneDriveUsage'
     )
 }

--- a/tests/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools.Tests.ps1
@@ -31,7 +31,7 @@ Describe 'SharePointTools Module' {
             'Get-SPToolsAllPreservationHoldReports',
             'Get-SPPermissionsReport',
             'Clean-SPVersionHistory',
-            'Find-OrphanedSPFiles',
+            'Find-OrphanedSPFiles','Get-SPToolsFileReport',
             'List-OneDriveUsage'
         )
         $exported = (Get-Command -Module SharePointTools).Name


### PR DESCRIPTION
## Summary
- add `Get-SPToolsFileReport` cmdlet for collecting library file info
- export the new cmdlet in module manifest and provide tab completion
- document the cmdlet and reference it in module docs
- update tests for exported commands

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6843728ea50c832c9800c31514f39de0