### PR TITLE
Fix braces in tests

### DIFF
--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -68,8 +68,6 @@ Describe 'SupportTools Module' {
             Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -Times 1
         }
 
-        }
-
     }
 
     Context 'Add-UserToGroup output passthrough' {


### PR DESCRIPTION
## Summary
- clean up Wrapper script invocation context braces

## Testing
- `Invoke-Pester -Path tests -CI`

------
https://chatgpt.com/codex/tasks/task_e_6843744e4828832c8116ecc644ff5e2e