### PR TITLE
Implement system info ticket automation

### DIFF
--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -34,6 +34,7 @@ listed are forwarded to the underlying script unchanged.
 | `Start-Countdown` | `SimpleCountdown.ps1` | *passthrough* | `Start-Countdown -Seconds 30` |
 | `Update-Sysmon` | `Update-Sysmon.ps1` | *passthrough* | `Update-Sysmon -SourcePath D:\Tools` |
 | `Invoke-CompanyPlaceManagement` | `Invoke-CompanyPlaceManagement.ps1` | `Action`, `DisplayName`, `[Type]`, `Street`, `City`, `State`, `PostalCode`, `CountryOrRegion`, `[AutoAddFloor]` | `Invoke-CompanyPlaceManagement -Action Create -DisplayName 'HQ' -Type Building -City Seattle` |
+| `Submit-SystemInfoTicket` | `Submit-SystemInfoTicket.ps1` | `SiteName`, `RequesterEmail`, `[Subject]`, `[Description]`, `[LibraryName]`, `[FolderPath]` | `Submit-SystemInfoTicket -SiteName IT -RequesterEmail 'user@contoso.com'` |
 
 For details on what each script does see [scripts/README.md](../scripts/README.md).
 

--- a/docs/SupportTools/Submit-SystemInfoTicket.md
+++ b/docs/SupportTools/Submit-SystemInfoTicket.md
@@ -1,0 +1,65 @@
+---
+external help file: SupportTools-help.xml
+Module Name: SupportTools
+online version:
+schema: 2.0.0
+---
+
+# Submit-SystemInfoTicket
+
+## SYNOPSIS
+Collects system information, uploads it to SharePoint and creates a Service Desk ticket.
+
+## SYNTAX
+
+```
+Submit-SystemInfoTicket [-SiteName] <String> [-RequesterEmail] <String> [[-Subject] <String>] [[-Description] <String>] [[-LibraryName] <String>] [[-FolderPath] <String>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Wraps the Submit-SystemInfoTicket.ps1 script. The command gathers common system information, uploads the JSON report to the specified SharePoint site and then opens a Service Desk ticket referencing the uploaded file.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Submit-SystemInfoTicket -SiteName IT -RequesterEmail "jane.doe@example.com"
+```
+Collects system info, uploads the report to the IT site and creates a ticket for jane.doe@example.com.
+
+## PARAMETERS
+
+### -SiteName
+Friendly name of the SharePoint site configured with Configure-SharePointTools.
+
+### -RequesterEmail
+Email address of the ticket requester.
+
+### -Subject
+Ticket subject. Defaults to "System info from <computername>".
+
+### -Description
+Ticket description. Defaults to a short message referencing the uploaded report.
+
+### -LibraryName
+Document library to upload the report. Defaults to "Shared Documents".
+
+### -FolderPath
+Optional folder path within the library.
+
+### -TranscriptPath
+Optional transcript output path.
+
+### -ProgressAction
+Specifies how progress is displayed.
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,7 @@ The following table provides a brief description of each script.
 | **Set-TimeZoneEasternStandardTime.ps1** | Sets the system time zone to Eastern Standard Time. |
 | **SimpleCountdown.ps1** | Outputs a simple countdown from 10 to 1. |
 | **Update-Sysmon.ps1** | Reinstalls Sysmon from a removable drive and verifies it is running. |
+| **Submit-SystemInfoTicket.ps1** | Collects system info, uploads it to SharePoint and opens a Service Desk ticket. |
 | **SS_DEPLOYMENT_TEMPLATE.ps1** | Template for sneaker net deployments that installs agents and configures a system. |
 | **Configure-SharePointTools.ps1** | Prompts for SharePoint application values and saves them to a settings file. |
 | **CleanupTempFiles.ps1** | Removes .tmp files and empty logs from the repository. |

--- a/scripts/Submit-SystemInfoTicket.ps1
+++ b/scripts/Submit-SystemInfoTicket.ps1
@@ -1,0 +1,66 @@
+<#+
+.SYNOPSIS
+    Collect system info, upload the report to SharePoint, and open a Service Desk ticket.
+.DESCRIPTION
+    Uses the SupportTools, SharePointTools and ServiceDeskTools modules to gather
+    system information, upload the JSON report to a configured SharePoint site,
+    then create a new ticket referencing the uploaded file.
+.PARAMETER SiteName
+    Friendly name of the SharePoint site defined via Configure-SharePointTools.
+.PARAMETER RequesterEmail
+    Email address of the ticket requester.
+.PARAMETER Subject
+    Subject for the Service Desk ticket. Defaults to "System info from <computername>".
+.PARAMETER Description
+    Ticket description. Defaults to a short message referencing the report.
+.PARAMETER LibraryName
+    Document library to upload the report into. Defaults to "Shared Documents".
+.PARAMETER FolderPath
+    Optional folder path within the library.
+.PARAMETER TranscriptPath
+    Path for the transcript log file.
+#>
+param(
+    [Parameter(Mandatory)]
+    [string]$SiteName,
+    [Parameter(Mandatory)]
+    [string]$RequesterEmail,
+    [string]$Subject = "System info from $env:COMPUTERNAME",
+    [string]$Description = 'System information collected automatically.',
+    [string]$LibraryName = 'Shared Documents',
+    [string]$FolderPath = '',
+    [string]$TranscriptPath
+)
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/SupportTools/SupportTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/SharePointTools/SharePointTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction SilentlyContinue
+
+if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+
+try {
+    Write-STStatus 'Gathering system information...' -Level INFO -Log
+    $info = Get-CommonSystemInfo
+    $tempFile = Join-Path $env:TEMP "systeminfo_$((Get-Date).ToString('yyyyMMdd_HHmmss')).json"
+    $info | ConvertTo-Json -Depth 10 | Out-File -FilePath $tempFile -Encoding utf8
+    Write-STStatus "Report saved to $tempFile" -Level SUCCESS -Log
+
+    $settings = Get-SPToolsSettings
+    $siteUrl = Get-SPToolsSiteUrl -SiteName $SiteName
+    Connect-PnPOnline -Url $siteUrl -ClientId $settings.ClientId -Tenant $settings.TenantId -CertificatePath $settings.CertPath
+
+    Write-STStatus 'Uploading report to SharePoint...' -Level INFO -Log
+    $targetFolder = if ($FolderPath) { "$LibraryName/$FolderPath" } else { $LibraryName }
+    $upload = Add-PnPFile -Path $tempFile -Folder $targetFolder -ErrorAction Stop
+    $fileUrl = "$siteUrl$($upload.ServerRelativeUrl)"
+    Write-STStatus "Uploaded report to $fileUrl" -Level SUCCESS -Log
+
+    Write-STStatus 'Creating Service Desk ticket...' -Level INFO -Log
+    $ticketBody = "$Description`n`nReport: $fileUrl"
+    New-SDTicket -Subject $Subject -Description $ticketBody -RequesterEmail $RequesterEmail | Out-Null
+    Write-STStatus 'Service Desk ticket created.' -Level SUCCESS -Log
+}
+finally {
+    if ($TranscriptPath) { Stop-Transcript | Out-Null }
+}

--- a/src/SupportTools/Public/Submit-SystemInfoTicket.ps1
+++ b/src/SupportTools/Public/Submit-SystemInfoTicket.ps1
@@ -1,0 +1,26 @@
+function Submit-SystemInfoTicket {
+    <#
+    .SYNOPSIS
+        Collect system info, upload it to SharePoint, and create a Service Desk ticket.
+    .DESCRIPTION
+        Wraps the Submit-SystemInfoTicket.ps1 script in the scripts folder with the supplied parameters.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SiteName,
+        [Parameter(Mandatory)][string]$RequesterEmail,
+        [string]$Subject,
+        [string]$Description,
+        [string]$LibraryName,
+        [string]$FolderPath,
+        [string]$TranscriptPath
+    )
+    process {
+        $arguments = @('-SiteName', $SiteName, '-RequesterEmail', $RequesterEmail)
+        if ($PSBoundParameters.ContainsKey('Subject'))     { $arguments += @('-Subject', $Subject) }
+        if ($PSBoundParameters.ContainsKey('Description')) { $arguments += @('-Description', $Description) }
+        if ($PSBoundParameters.ContainsKey('LibraryName')) { $arguments += @('-LibraryName', $LibraryName) }
+        if ($PSBoundParameters.ContainsKey('FolderPath'))  { $arguments += @('-FolderPath', $FolderPath) }
+        Invoke-ScriptFile -Name 'Submit-SystemInfoTicket.ps1' -Args $arguments -TranscriptPath $TranscriptPath
+    }
+}

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -24,6 +24,6 @@
         'Start-Countdown',
         'Update-Sysmon',
         'Set-SharedMailboxAutoReply',
-        'Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement'
+        'Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket'
     )
 }

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -6,7 +6,7 @@ Import-Module $loggingModule -ErrorAction SilentlyContinue
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Add-UserToGroup','Clear-ArchiveFolder','Clear-TempFile','Convert-ExcelToCsv','Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Get-UniquePermission','Install-Font','Invoke-PostInstall','Export-ProductKey','Invoke-DeploymentTemplate','Search-ReadMe','Set-ComputerIPAddress','Set-NetAdapterMetering','Set-TimeZoneEasternStandardTime','Start-Countdown','Update-Sysmon','Set-SharedMailboxAutoReply','Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement'
+Export-ModuleMember -Function 'Add-UserToGroup','Clear-ArchiveFolder','Clear-TempFile','Convert-ExcelToCsv','Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Get-UniquePermission','Install-Font','Invoke-PostInstall','Export-ProductKey','Invoke-DeploymentTemplate','Search-ReadMe','Set-ComputerIPAddress','Set-NetAdapterMetering','Set-TimeZoneEasternStandardTime','Start-Countdown','Update-Sysmon','Set-SharedMailboxAutoReply','Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket'
 
 function Show-SupportToolsBanner {
     Write-STStatus '════════════════════════════════════════════' -Level INFO

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -25,7 +25,8 @@ Describe 'SupportTools Module' {
             'Update-Sysmon',
             'Set-SharedMailboxAutoReply',
             'Invoke-ExchangeCalendarManager',
-            'Invoke-CompanyPlaceManagement'
+            'Invoke-CompanyPlaceManagement',
+            'Submit-SystemInfoTicket'
         )
 
         $exported = (Get-Command -Module SupportTools).Name
@@ -56,6 +57,7 @@ Describe 'SupportTools Module' {
             Set_TimeZoneEasternStandardTime = 'Set-TimeZoneEasternStandardTime.ps1'
             Start_Countdown              = 'SimpleCountdown.ps1'
             Update_Sysmon                = 'Update-Sysmon.ps1'
+            Submit_SystemInfoTicket      = 'Submit-SystemInfoTicket.ps1'
         }
 
         $cases = foreach ($entry in $map.GetEnumerator()) {


### PR DESCRIPTION
## Summary
- add Submit-SystemInfoTicket script and wrapper command
- export new command via SupportTools module
- document Submit-SystemInfoTicket usage
- update script catalog and README
- adjust tests for new command

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843749d20e0832c9f888b9bca8c793b