### PR TITLE
Add SharePoint usage reporting script

### DIFF
--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -35,6 +35,7 @@ listed are forwarded to the underlying script unchanged.
 | `Update-Sysmon` | `Update-Sysmon.ps1` | *passthrough* | `Update-Sysmon -SourcePath D:\Tools` |
 | `Invoke-CompanyPlaceManagement` | `Invoke-CompanyPlaceManagement.ps1` | `Action`, `DisplayName`, `[Type]`, `Street`, `City`, `State`, `PostalCode`, `CountryOrRegion`, `[AutoAddFloor]` | `Invoke-CompanyPlaceManagement -Action Create -DisplayName 'HQ' -Type Building -City Seattle` |
 | `Submit-SystemInfoTicket` | `Submit-SystemInfoTicket.ps1` | `SiteName`, `RequesterEmail`, `[Subject]`, `[Description]`, `[LibraryName]`, `[FolderPath]` | `Submit-SystemInfoTicket -SiteName IT -RequesterEmail 'user@contoso.com'` |
+| `Generate-SPUsageReport` | `Generate-SPUsageReport.ps1` | `[ItemThreshold]`, `[RequesterEmail]`, `[CsvPath]`, `[TranscriptPath]` | `Generate-SPUsageReport -RequesterEmail 'user@contoso.com'` |
 
 For details on what each script does see [scripts/README.md](../scripts/README.md).
 

--- a/docs/SupportTools/Generate-SPUsageReport.md
+++ b/docs/SupportTools/Generate-SPUsageReport.md
@@ -1,0 +1,9 @@
+# Generate-SPUsageReport
+
+Generates library usage reports for all configured SharePoint sites and optionally creates Service Desk tickets when libraries exceed a specified item count.
+
+```
+Generate-SPUsageReport [-ItemThreshold <Int>] [-RequesterEmail <String>] [-CsvPath <String>] [-TranscriptPath <String>]
+```
+
+When `-RequesterEmail` is provided, libraries with an `ItemCount` greater than `-ItemThreshold` trigger a call to `New-SDTicket` for follow-up.

--- a/scripts/Generate-SPUsageReport.ps1
+++ b/scripts/Generate-SPUsageReport.ps1
@@ -1,0 +1,47 @@
+<#+
+.SYNOPSIS
+    Generate library usage reports and create Service Desk tickets when thresholds are exceeded.
+.DESCRIPTION
+    Runs Get-SPToolsAllLibraryReports from the SharePointTools module and exports the results to CSV.
+    Libraries with an ItemCount greater than the specified threshold trigger a Service Desk ticket.
+.PARAMETER ItemThreshold
+    Number of items that must be exceeded before a ticket is created.
+.PARAMETER RequesterEmail
+    Email address for the ticket requester.
+.PARAMETER CsvPath
+    Path to save the CSV report. Defaults to LibraryReport_<timestamp>.csv in the current directory.
+.PARAMETER TranscriptPath
+    Optional transcript log path.
+#>
+param(
+    [int]$ItemThreshold = 5000,
+    [string]$RequesterEmail,
+    [string]$CsvPath = $(Join-Path (Get-Location) "LibraryReport_$((Get-Date).ToString('yyyyMMdd_HHmmss')).csv"),
+    [string]$TranscriptPath
+)
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/SharePointTools/SharePointTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction SilentlyContinue
+
+if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+
+try {
+    Write-STStatus 'Generating library usage report...' -Level INFO -Log
+    $report = Get-SPToolsAllLibraryReports
+    $report | Export-Csv -Path $CsvPath -NoTypeInformation
+    Write-STStatus "Report saved to $CsvPath" -Level SUCCESS -Log
+
+    if ($RequesterEmail) {
+        $over = $report | Where-Object { $_.ItemCount -gt $ItemThreshold }
+        foreach ($siteGroup in $over | Group-Object SiteName) {
+            $subject = "SharePoint library usage over $ItemThreshold items - $($siteGroup.Name)"
+            $desc = ($siteGroup.Group | Format-Table LibraryName, ItemCount -AutoSize | Out-String)
+            Write-STStatus "Creating ticket for site $($siteGroup.Name)..." -Level INFO -Log
+            New-SDTicket -Subject $subject -Description $desc -RequesterEmail $RequesterEmail | Out-Null
+        }
+    }
+}
+finally {
+    if ($TranscriptPath) { Stop-Transcript | Out-Null }
+}

--- a/src/SupportTools/Public/Generate-SPUsageReport.ps1
+++ b/src/SupportTools/Public/Generate-SPUsageReport.ps1
@@ -1,0 +1,17 @@
+function Generate-SPUsageReport {
+    <#
+    .SYNOPSIS
+        Generate library usage CSV reports and create Service Desk tickets when limits are exceeded.
+    .DESCRIPTION
+        This is a wrapper for the Generate-SPUsageReport.ps1 script in the scripts folder.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
+        [object[]]$Arguments,
+        [string]$TranscriptPath
+    )
+    process {
+        Invoke-ScriptFile -Name 'Generate-SPUsageReport.ps1' -Args $Arguments -TranscriptPath $TranscriptPath
+    }
+}

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -24,6 +24,6 @@
         'Start-Countdown',
         'Update-Sysmon',
         'Set-SharedMailboxAutoReply',
-        'Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket'
+        'Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket','Generate-SPUsageReport'
     )
 }

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -6,7 +6,7 @@ Import-Module $loggingModule -ErrorAction SilentlyContinue
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Add-UserToGroup','Clear-ArchiveFolder','Clear-TempFile','Convert-ExcelToCsv','Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Get-UniquePermission','Install-Font','Invoke-PostInstall','Export-ProductKey','Invoke-DeploymentTemplate','Search-ReadMe','Set-ComputerIPAddress','Set-NetAdapterMetering','Set-TimeZoneEasternStandardTime','Start-Countdown','Update-Sysmon','Set-SharedMailboxAutoReply','Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket'
+Export-ModuleMember -Function 'Add-UserToGroup','Clear-ArchiveFolder','Clear-TempFile','Convert-ExcelToCsv','Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Get-UniquePermission','Install-Font','Invoke-PostInstall','Export-ProductKey','Invoke-DeploymentTemplate','Search-ReadMe','Set-ComputerIPAddress','Set-NetAdapterMetering','Set-TimeZoneEasternStandardTime','Start-Countdown','Update-Sysmon','Set-SharedMailboxAutoReply','Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket','Generate-SPUsageReport'
 
 function Show-SupportToolsBanner {
     Write-STStatus '════════════════════════════════════════════' -Level INFO

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -26,7 +26,8 @@ Describe 'SupportTools Module' {
             'Set-SharedMailboxAutoReply',
             'Invoke-ExchangeCalendarManager',
             'Invoke-CompanyPlaceManagement',
-            'Submit-SystemInfoTicket'
+            'Submit-SystemInfoTicket',
+            'Generate-SPUsageReport'
         )
 
         $exported = (Get-Command -Module SupportTools).Name
@@ -58,6 +59,7 @@ Describe 'SupportTools Module' {
             Start_Countdown              = 'SimpleCountdown.ps1'
             Update_Sysmon                = 'Update-Sysmon.ps1'
             Submit_SystemInfoTicket      = 'Submit-SystemInfoTicket.ps1'
+            Generate_SPUsageReport       = 'Generate-SPUsageReport.ps1'
         }
 
         $cases = foreach ($entry in $map.GetEnumerator()) {


### PR DESCRIPTION
## Summary
- generate library usage CSVs with a script
- expose `Generate-SPUsageReport` via SupportTools module
- document the new command
- cover wrapper invocation in tests

## Testing
- `Invoke-Pester -Output Detailed` *(fails: adds default floor when creating a building with AutoAddFloor)*

------
https://chatgpt.com/codex/tasks/task_e_68437939a550832c90ee240e696a0095