### PR TITLE
Add Maintenance Task automation

### DIFF
--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -36,6 +36,7 @@ listed are forwarded to the underlying script unchanged.
 | `Invoke-CompanyPlaceManagement` | `Invoke-CompanyPlaceManagement.ps1` | `Action`, `DisplayName`, `[Type]`, `Street`, `City`, `State`, `PostalCode`, `CountryOrRegion`, `[AutoAddFloor]` | `Invoke-CompanyPlaceManagement -Action Create -DisplayName 'HQ' -Type Building -City Seattle` |
 | `Submit-SystemInfoTicket` | `Submit-SystemInfoTicket.ps1` | `SiteName`, `RequesterEmail`, `[Subject]`, `[Description]`, `[LibraryName]`, `[FolderPath]` | `Submit-SystemInfoTicket -SiteName IT -RequesterEmail 'user@contoso.com'` |
 | `Generate-SPUsageReport` | `Generate-SPUsageReport.ps1` | `[ItemThreshold]`, `[RequesterEmail]`, `[CsvPath]`, `[TranscriptPath]` | `Generate-SPUsageReport -RequesterEmail 'user@contoso.com'` |
+| `Install-MaintenanceTasks` | `Setup-ScheduledMaintenance.ps1` | `[Register]` | `Install-MaintenanceTasks -Register` |
 
 For details on what each script does see [scripts/README.md](../scripts/README.md).
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,3 +26,4 @@ The following table provides a brief description of each script.
 | **SS_DEPLOYMENT_TEMPLATE.ps1** | Template for sneaker net deployments that installs agents and configures a system. |
 | **Configure-SharePointTools.ps1** | Prompts for SharePoint application values and saves them to a settings file. |
 | **CleanupTempFiles.ps1** | Removes .tmp files and empty logs from the repository. |
+| **Setup-ScheduledMaintenance.ps1** | Generates Task Scheduler XML for weekly maintenance tasks. |

--- a/scripts/Setup-ScheduledMaintenance.ps1
+++ b/scripts/Setup-ScheduledMaintenance.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+    Creates scheduled tasks for SupportTools maintenance.
+.DESCRIPTION
+    Generates Task Scheduler XML definitions for weekly cleanup, group maintenance
+    and permission audit tasks. The XML is created dynamically and can be written
+    to files or registered directly.
+.PARAMETER Register
+    If specified, the tasks are registered using Register-ScheduledTask. Without
+    this switch the XML files are output to the current directory.
+#>
+[CmdletBinding()]
+param(
+    [switch]$Register
+)
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+
+function New-MaintenanceTaskXml {
+    param(
+        [Parameter(Mandatory)][string]$TaskName,
+        [Parameter(Mandatory)][string]$ScriptPath,
+        [string]$Day = 'Sunday',
+        [string]$Time = '03:00'
+    )
+
+    $start = (Get-Date -Format 'yyyy-MM-dd') + "T$Time:00"
+    $triggerXml = @"
+  <Triggers>
+    <CalendarTrigger>
+      <StartBoundary>$start</StartBoundary>
+      <ScheduleByWeek>
+        <DaysOfWeek><$Day/></DaysOfWeek>
+        <WeeksInterval>1</WeeksInterval>
+      </ScheduleByWeek>
+    </CalendarTrigger>
+  </Triggers>
+"@
+
+    $encodedScript = $ScriptPath.Replace('&','&amp;')
+    $xml = @"
+<Task xmlns='http://schemas.microsoft.com/windows/2004/02/mit/task'>
+  <RegistrationInfo><Description>$TaskName</Description></RegistrationInfo>
+  $triggerXml
+  <Principals>
+    <Principal id='Author'>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+  </Settings>
+  <Actions Context='Author'>
+    <Exec>
+      <Command>powershell.exe</Command>
+      <Arguments>-NoProfile -ExecutionPolicy Bypass -File "$encodedScript"</Arguments>
+    </Exec>
+  </Actions>
+</Task>
+"@
+    return $xml
+}
+
+$repo = Split-Path $PSScriptRoot -Parent
+$tasks = @{
+    'Weekly Cleanup'    = Join-Path $repo 'scripts' 'CleanupTempFiles.ps1'
+    'Group Maintenance' = Join-Path $repo 'scripts' 'AddUsersToGroup.ps1'
+    'Permission Audit'  = Join-Path $repo 'scripts' 'Get-UniquePermissions.ps1'
+}
+
+foreach ($name in $tasks.Keys) {
+    $xml = New-MaintenanceTaskXml -TaskName $name -ScriptPath $tasks[$name]
+    if ($Register) {
+        Write-STStatus "Registering task $name" -Level INFO -Log
+        Register-ScheduledTask -TaskName $name -Xml $xml -Force | Out-Null
+    } else {
+        $file = "$($name -replace ' ', '')Task.xml"
+        Write-STStatus "Writing $file" -Level INFO -Log
+        $xml | Set-Content -Path $file -Encoding UTF8
+    }
+}

--- a/src/SupportTools/Public/Install-MaintenanceTasks.ps1
+++ b/src/SupportTools/Public/Install-MaintenanceTasks.ps1
@@ -1,0 +1,21 @@
+function Install-MaintenanceTasks {
+    <#
+    .SYNOPSIS
+        Registers weekly maintenance scheduled tasks.
+    .DESCRIPTION
+        Wraps the Setup-ScheduledMaintenance.ps1 script which generates Task Scheduler XML
+        and optionally registers the tasks. Parameters are passed directly through.
+    .PARAMETER Register
+        If set, tasks are registered immediately; otherwise XML files are created.
+    #>
+    [CmdletBinding()]
+    param(
+        [switch]$Register,
+        [string]$TranscriptPath
+    )
+    process {
+        $argsList = @()
+        if ($Register) { $argsList += '-Register' }
+        Invoke-ScriptFile -Name 'Setup-ScheduledMaintenance.ps1' -Args $argsList -TranscriptPath $TranscriptPath
+    }
+}

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -24,6 +24,6 @@
         'Start-Countdown',
         'Update-Sysmon',
         'Set-SharedMailboxAutoReply',
-        'Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket','Generate-SPUsageReport'
+        'Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket','Generate-SPUsageReport','Install-MaintenanceTasks'
     )
 }

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -6,7 +6,7 @@ Import-Module $loggingModule -ErrorAction SilentlyContinue
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Add-UserToGroup','Clear-ArchiveFolder','Clear-TempFile','Convert-ExcelToCsv','Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Get-UniquePermission','Install-Font','Invoke-PostInstall','Export-ProductKey','Invoke-DeploymentTemplate','Search-ReadMe','Set-ComputerIPAddress','Set-NetAdapterMetering','Set-TimeZoneEasternStandardTime','Start-Countdown','Update-Sysmon','Set-SharedMailboxAutoReply','Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket','Generate-SPUsageReport'
+Export-ModuleMember -Function 'Add-UserToGroup','Clear-ArchiveFolder','Clear-TempFile','Convert-ExcelToCsv','Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Get-UniquePermission','Install-Font','Invoke-PostInstall','Export-ProductKey','Invoke-DeploymentTemplate','Search-ReadMe','Set-ComputerIPAddress','Set-NetAdapterMetering','Set-TimeZoneEasternStandardTime','Start-Countdown','Update-Sysmon','Set-SharedMailboxAutoReply','Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket','Generate-SPUsageReport','Install-MaintenanceTasks'
 
 function Show-SupportToolsBanner {
     Write-STStatus '════════════════════════════════════════════' -Level INFO

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -28,6 +28,7 @@ Describe 'SupportTools Module' {
             'Invoke-CompanyPlaceManagement',
             'Submit-SystemInfoTicket',
             'Generate-SPUsageReport'
+            'Install-MaintenanceTasks'
         )
 
         $exported = (Get-Command -Module SupportTools).Name
@@ -60,6 +61,7 @@ Describe 'SupportTools Module' {
             Update_Sysmon                = 'Update-Sysmon.ps1'
             Submit_SystemInfoTicket      = 'Submit-SystemInfoTicket.ps1'
             Generate_SPUsageReport       = 'Generate-SPUsageReport.ps1'
+            Install_MaintenanceTasks = 'Setup-ScheduledMaintenance.ps1'
         }
 
         $cases = foreach ($entry in $map.GetEnumerator()) {


### PR DESCRIPTION
## Summary
- add script to generate Scheduled Task XML and register tasks
- expose `Install-MaintenanceTasks` wrapper in SupportTools
- document new command and script
- adjust tests for additional export

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests -CI"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437ba302a4832ca2b350e5d2b1ba19