### PR TITLE
Add confirmation and masking features

### DIFF
--- a/scripts/CleanupArchive.ps1
+++ b/scripts/CleanupArchive.ps1
@@ -27,7 +27,8 @@ This script requires tenant admin access and assumes the user has the necessary 
 This example runs the script, connecting to the predefined SharePoint site and processing the 'Shared Documents' library to delete all items within the 'zzz_Archive_Production' folder.
 #>
 
-# Import the PnP PowerShell module
+$loggingModule = Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1'
+Import-Module $loggingModule -ErrorAction SilentlyContinue
 Import-Module Pnp.PowerShell
 $InformationPreference = 'Continue'
 
@@ -57,6 +58,13 @@ $SiteUrl = "SITEURL"
 Connect-PnPOnline -Url $SiteUrl -Interactive
 $Libraries = "Shared Documents"
 Write-Debug -Message "Connected to SharePoint..."
+
+Write-STStatus "About to delete contents of 'zzz_Archive_Production'." -Level WARN
+$confirm = Read-Host 'Proceed with deletion? (Y/N)'
+if ($confirm -ne 'Y') {
+    Write-STStatus 'Cleanup cancelled by user.' -Level WARN
+    return
+}
 
 # Navigate to the root folder of the document library
 $SharedDocumentsLibrary = Get-PnPFolder -ListRootFolder $Libraries

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -31,7 +31,8 @@ function Write-STStatus {
         [string]$Message,
         [ValidateSet('INFO','SUCCESS','ERROR','WARN','SUB','FINAL','FATAL')]
         [string]$Level = 'INFO',
-        [switch]$Log
+        [switch]$Log,
+        [switch]$MaskSensitive
     )
 
     switch ($Level) {
@@ -42,6 +43,10 @@ function Write-STStatus {
         'FINAL'   { $prefix = '[✔]'; $color = 'Green' }
         'FATAL'   { $prefix = '[✘]'; $color = 'Red' }
         default   { $prefix = '[*]'; $color = 'Cyan' }
+    }
+
+    if ($MaskSensitive -and $Message -match '(^[^:=]+[:=])\s*(.+)$') {
+        $Message = "$($Matches[1]) ****"
     }
 
     Write-Host "$prefix $Message" -ForegroundColor $color

--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -74,4 +74,16 @@ Describe 'Logging Module' {
             Remove-Item $temp -ErrorAction SilentlyContinue
         }
     }
+
+    It 'masks sensitive data in status messages' {
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            $env:ST_LOG_PATH = $temp
+            Write-STStatus -Message 'Token: secret123' -MaskSensitive -Log
+            (Get-Content $temp) | Should -Match 'Token: \*\*\*\*'
+        } finally {
+            Remove-Item $temp -ErrorAction SilentlyContinue
+            Remove-Item env:ST_LOG_PATH
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- allow Write-STStatus to mask sensitive strings
- cover new `-MaskSensitive` option in Logging tests
- verify Graph scopes and prompt before adding users
- prompt before cleaning up SharePoint archive

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests -Output Detailed"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437bff7c80832c8bd649e4e1c43290