### PR TITLE
Add script to generate function dependency diagrams

### DIFF
--- a/docs/Get-FunctionDependencyGraph.md
+++ b/docs/Get-FunctionDependencyGraph.md
@@ -1,0 +1,13 @@
+# Get-FunctionDependencyGraph
+
+Generates a diagram showing how functions inside a script call each other. The command parses the target script, identifies all function definitions and then determines which of those functions invoke the others.
+
+## Usage
+
+```powershell
+./scripts/Get-FunctionDependencyGraph.ps1 -Path ./scripts/AddUsersToGroup.ps1 -Format Graphviz
+```
+
+Specify `-Format Mermaid` to emit Mermaid markup instead of Graphviz DOT syntax. Use `-OutputFile` to write the diagram to disk.
+
+The output can be visualized with tools like Graphviz or any online Mermaid renderer.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,6 @@ The key guides are:
 - [SupportTools](./SupportTools.md), [SharePointTools](./SharePointTools.md), [ServiceDeskTools](./ServiceDeskTools.md) – high level summaries of each module and the commands they expose.
 - [Credential Storage](./CredentialStorage.md) – recommended approach to store secrets securely.
 - [Module Style Guide](./ModuleStyleGuide.md) – how scripts display progress messages and log output.
+- [Get-FunctionDependencyGraph](./Get-FunctionDependencyGraph.md) – generate a visual map of function calls in a script.
 
 Command specific help topics live in the `SupportTools`, `SharePointTools` and `ServiceDeskTools` subfolders.

--- a/scripts/Get-FunctionDependencyGraph.ps1
+++ b/scripts/Get-FunctionDependencyGraph.ps1
@@ -1,0 +1,68 @@
+<#+
+.SYNOPSIS
+    Generates a dependency map of functions defined in a script.
+.DESCRIPTION
+    Parses the specified PowerShell script using the abstract syntax tree (AST)
+    and determines which functions call other functions within the same file.
+    The map can be exported as Graphviz DOT or Mermaid markup for visualization.
+.PARAMETER Path
+    Path to the script file to analyze.
+.PARAMETER Format
+    Output format of the diagram. Either 'Graphviz' or 'Mermaid'. Defaults to
+    Graphviz.
+.PARAMETER OutputFile
+    Optional path to write the diagram. When omitted the diagram text is
+    returned to the pipeline.
+.EXAMPLE
+    ./Get-FunctionDependencyGraph.ps1 -Path ./scripts/AddUsersToGroup.ps1 -Format Mermaid
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Path,
+
+    [ValidateSet('Graphviz','Mermaid')]
+    [string]$Format = 'Graphviz',
+
+    [string]$OutputFile
+)
+
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$errors)
+if ($errors) { throw 'Parsing errors were encountered.' }
+
+$functions = @{}
+$ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true) | ForEach-Object {
+    $functions[$_.Name] = @()
+}
+
+foreach ($fn in $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)) {
+    $called = $fn.Body.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) |
+        ForEach-Object { $_.GetCommandName() } |
+        Where-Object { $_ -and $functions.ContainsKey($_) } |
+        Select-Object -Unique
+    $functions[$fn.Name] = $called
+}
+
+$edges = foreach ($name in $functions.Keys) {
+    foreach ($target in $functions[$name]) {
+        [pscustomobject]@{ From=$name; To=$target }
+    }
+}
+
+$lines = switch ($Format) {
+    'Graphviz' {
+        'digraph G {'
+        foreach ($e in $edges) { '    "{0}" -> "{1}"' -f $e.From, $e.To }
+        '}'
+    }
+    'Mermaid' {
+        'graph TD'
+        foreach ($e in $edges) { '    {0} --> {1}' -f $e.From, $e.To }
+    }
+}
+
+$diagram = $lines -join [Environment]::NewLine
+if ($OutputFile) { $diagram | Set-Content -Path $OutputFile -Encoding utf8 }
+$diagram

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,3 +26,4 @@ The following table provides a brief description of each script.
 | **SS_DEPLOYMENT_TEMPLATE.ps1** | Template for sneaker net deployments that installs agents and configures a system. |
 | **Configure-SharePointTools.ps1** | Prompts for SharePoint application values and saves them to a settings file. |
 | **CleanupTempFiles.ps1** | Removes .tmp files and empty logs from the repository. |
+| **Get-FunctionDependencyGraph.ps1** | Generates a Graphviz or Mermaid map of function calls inside a script. |


### PR DESCRIPTION
## Summary
- add `Get-FunctionDependencyGraph.ps1` to visualize function call relationships
- document the new command
- list the helper in docs and script tables

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration @{ Run=@{ Exit=$true } }"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437c58add4832cbe44e59ae80b4181