### PR TITLE
Add interactive SupportTools menu

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -35,5 +35,9 @@ This short guide shows the basic steps to start using the modules in this reposi
    # Create a Service Desk ticket
    New-SDTicket -Title "Test" -Description "Quick start test"
    ```
+7. **Launch the interactive menu** (optional)
+   ```powershell
+   ./scripts/SupportToolsMenu.ps1
+   ```
 
 See [docs/UserGuide.md](UserGuide.md) for detailed deployment and usage instructions.

--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -7,6 +7,9 @@ Import the module and run the desired function rather than calling the script di
 Import-Module ./src/SupportTools/SupportTools.psd1
 ```
 
+For a guided experience, run `./scripts/SupportToolsMenu.ps1` to select
+common tasks from an interactive menu.
+
 ## Available Commands
 
 The table below lists each command and the script it invokes. Arguments not

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,3 +26,4 @@ The following table provides a brief description of each script.
 | **SS_DEPLOYMENT_TEMPLATE.ps1** | Template for sneaker net deployments that installs agents and configures a system. |
 | **Configure-SharePointTools.ps1** | Prompts for SharePoint application values and saves them to a settings file. |
 | **CleanupTempFiles.ps1** | Removes .tmp files and empty logs from the repository. |
+| **SupportToolsMenu.ps1** | Interactive menu for common SupportTools tasks. |

--- a/scripts/SupportToolsMenu.ps1
+++ b/scripts/SupportToolsMenu.ps1
@@ -1,0 +1,43 @@
+<#
+.SYNOPSIS
+    Launch an interactive menu to run common SupportTools tasks.
+.DESCRIPTION
+    Provides a simple CLI menu so colleagues can choose actions
+    without typing commands. Each option invokes the related
+    SupportTools function.
+.EXAMPLE
+    ./SupportToolsMenu.ps1
+#>
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/SupportTools/SupportTools.psd1') -ErrorAction SilentlyContinue
+
+function Show-Menu {
+    Write-STDivider 'SupportTools Menu' -Style heavy
+    Write-Host '1. Add users to group'
+    Write-Host '2. Cleanup archive folder'
+    Write-Host 'Q. Quit'
+}
+
+while ($true) {
+    Show-Menu
+    $choice = Read-Host 'Select an option'
+    switch ($choice) {
+        '1' {
+            Write-STStatus 'Running Add-UserToGroup...' -Level INFO
+            Add-UserToGroup
+        }
+        '2' {
+            Write-STStatus 'Running Clear-ArchiveFolder...' -Level INFO
+            Clear-ArchiveFolder
+        }
+        'q' { break }
+        'Q' { break }
+        default {
+            Write-STStatus 'Invalid choice. Try again.' -Level WARN
+        }
+    }
+    Write-Host
+}
+
+Write-STClosing


### PR DESCRIPTION
## Summary
- add `SupportToolsMenu.ps1` script for an interactive CLI menu
- document the menu in SupportTools docs
- mention the menu in Quickstart guide
- list the script in scripts README

## Testing
- `Invoke-Pester` *(fails: prompts for input)*

------
https://chatgpt.com/codex/tasks/task_e_68437b7db8f4832c96f9e9442eafc6d1