### PR TITLE
Add basic telemetry opt-in support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,15 @@ Potential areas for improvement and extension include:
    Provide a consistent logging approach across all commands for easier troubleshooting.~~ - Commands now log to `%USERPROFILE%\SupportToolsLogs\supporttools.log`.
 7. **Error Handling**
    Add standardized error handling and optional transcript output.
-8. ~~**Configuration Guidance**
+8. **Telemetry (Opt-In)**
+   Track script usage patterns, failure rates and execution time.
+   Set the `ST_ENABLE_TELEMETRY` environment variable to `1` to enable collection.
+9. ~~**Configuration Guidance**
    Document a recommended workflow for securely storing credentials.~~ - Example
 workflow added ([docs/CredentialStorage.md](docs/CredentialStorage.md)).
-9. ~~**Linting and Code Quality**
+10. ~~**Linting and Code Quality**
    Check scripts with PSScriptAnalyzer on each commit.~~ - Linting automated via GitHub Actions.
-10. **Cmdlet Design Improvements**
+11. **Cmdlet Design Improvements**
     Convert module functions into full advanced functions with parameter validation,
     `SupportsShouldProcess`, and dynamic argument completers for easier interactive use.
 

--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -30,6 +30,8 @@ function Invoke-ScriptFile {
         Start-Transcript -Path $TranscriptPath -Append | Out-Null
     }
 
+    $start = Get-Date
+    $result = 'Success'
     $oldPref = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'
     try {
@@ -37,10 +39,13 @@ function Invoke-ScriptFile {
     } catch {
         Write-Error "Execution of '$Name' failed: $_"
         Write-STLog "Execution of '$Name' failed: $_" -Level 'ERROR'
+        $result = 'Failure'
         throw
     } finally {
         $ErrorActionPreference = $oldPref
         if ($TranscriptPath) { Stop-Transcript | Out-Null }
+        $duration = (Get-Date) - $start
+        Write-STTelemetryEvent -ScriptName $Name -Result $result -Duration $duration
     }
     Write-STStatus "COMPLETED $Name" -Level FINAL -Log
 }

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -1,7 +1,9 @@
 $PublicDir = Join-Path $PSScriptRoot 'Public'
 $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+$telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
 Import-Module $loggingModule -ErrorAction SilentlyContinue
+Import-Module $telemetryModule -ErrorAction SilentlyContinue
 
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }

--- a/src/Telemetry/Telemetry.psd1
+++ b/src/Telemetry/Telemetry.psd1
@@ -1,0 +1,8 @@
+@{
+    RootModule = 'Telemetry.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000011'
+    Author = 'Contoso'
+    Description = 'Telemetry utilities.'
+    FunctionsToExport = @('Write-STTelemetryEvent')
+}

--- a/src/Telemetry/Telemetry.psm1
+++ b/src/Telemetry/Telemetry.psm1
@@ -1,0 +1,32 @@
+
+function Write-STTelemetryEvent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ScriptName,
+        [Parameter(Mandatory)][string]$Result,
+        [Parameter(Mandatory)][timespan]$Duration
+    )
+    if ($env:ST_ENABLE_TELEMETRY -ne '1') { return }
+
+    $userProfile = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
+    if ($env:ST_TELEMETRY_PATH) {
+        $logFile = $env:ST_TELEMETRY_PATH
+    } else {
+        $dir = Join-Path $userProfile 'SupportToolsTelemetry'
+        $logFile = Join-Path $dir 'telemetry.jsonl'
+    }
+    $dir = Split-Path -Path $logFile -Parent
+    if (-not (Test-Path $dir)) {
+        New-Item -Path $dir -ItemType Directory -Force | Out-Null
+    }
+    $event = [pscustomobject]@{
+        Timestamp = (Get-Date).ToString('o')
+        Script    = $ScriptName
+        Result    = $Result
+        Duration  = [math]::Round($Duration.TotalSeconds, 2)
+    } | ConvertTo-Json -Compress
+
+    $event | Out-File -FilePath $logFile -Encoding utf8 -Append
+}
+
+Export-ModuleMember -Function 'Write-STTelemetryEvent'


### PR DESCRIPTION
## Summary
- add new Telemetry module
- log execution time and success/failure in Invoke-ScriptFile
- import Telemetry module from SupportTools
- document telemetry opt-in
- test telemetry opt-in behavior

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Path tests/Telemetry.Tests.ps1 -CI"`

------
https://chatgpt.com/codex/tasks/task_e_68437bd76884832c957c7f1c25c676aa