### PR TITLE
Add Select-SPToolsFolder function

### DIFF
--- a/docs/SharePointTools.md
+++ b/docs/SharePointTools.md
@@ -43,6 +43,7 @@ All functions emit short, high contrast messages following the style in [ModuleS
 | `Clean-SPVersionHistory` | Trim file versions beyond a limit. | `SiteUrl`, `[LibraryName]`, `[KeepVersions]`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `Clean-SPVersionHistory -SiteUrl https://contoso.sharepoint.com/sites/hr -KeepVersions 5` |
 | `Find-OrphanedSPFiles` | Locate files not modified for a period. | `SiteUrl`, `[LibraryName]`, `[Days]`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `Find-OrphanedSPFiles -SiteUrl https://contoso.sharepoint.com/sites/hr -Days 90` |
 | `Get-SPToolsFileReport` | Export file metadata from a library. | `SiteName`, `[SiteUrl]`, `[LibraryName]`, `[ClientId]`, `[TenantId]`, `[CertPath]`, `[ReportPath]` | `Get-SPToolsFileReport -SiteName HR -ReportPath files.csv` |
+| `Select-SPToolsFolder` | Recursively choose a library folder. | `SiteName`, `[SiteUrl]`, `[LibraryName]`, `[Filter]` | `Select-SPToolsFolder -SiteName HR` |
 | `List-OneDriveUsage` | Report OneDrive storage use across the tenant. | `AdminUrl`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `List-OneDriveUsage -AdminUrl https://contoso-admin.sharepoint.com` |
 
 

--- a/docs/SharePointTools/Select-SPToolsFolder.md
+++ b/docs/SharePointTools/Select-SPToolsFolder.md
@@ -1,0 +1,54 @@
+---
+external help file: SharePointTools-help.xml
+Module Name: SharePointTools
+online version:
+schema: 2.0.0
+---
+
+# Select-SPToolsFolder
+
+## SYNOPSIS
+Interactively choose a folder from a SharePoint document library.
+
+## SYNTAX
+```
+Select-SPToolsFolder [[-SiteName] <String>] [[-SiteUrl] <String>] [[-LibraryName] <String>] [[-Filter] <String>] [[-ClientId] <String>] [[-TenantId] <String>] [[-CertPath] <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Recursively lists folders in the target library and prompts for a selection. Provide a filter string to narrow the results.
+
+## EXAMPLES
+### Example 1
+```powershell
+PS C:\> Select-SPToolsFolder -SiteName HR
+```
+Choose a folder from the HR site's Shared Documents library.
+
+## PARAMETERS
+### -SiteName
+Friendly name of the site.
+
+### -SiteUrl
+Full URL of the site.
+
+### -LibraryName
+Document library to browse. Defaults to `Shared Documents`.
+
+### -Filter
+Optional string used to filter folder paths.
+
+### -ClientId
+### -TenantId
+### -CertPath
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/tests/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools.Tests.ps1
@@ -32,7 +32,7 @@ Describe 'SharePointTools Module' {
             'Get-SPPermissionsReport',
             'Clean-SPVersionHistory',
             'Find-OrphanedSPFiles','Get-SPToolsFileReport',
-            'List-OneDriveUsage'
+            'Select-SPToolsFolder','List-OneDriveUsage'
         )
         $exported = (Get-Command -Module SharePointTools).Name
         foreach ($cmd in $expected) {


### PR DESCRIPTION
## Summary
- add `Select-SPToolsFolder` helper to pick SharePoint folders recursively
- integrate helper into `Invoke-SharingLinkCleanup`
- export and complete the new command
- document the command and update module docs
- update tests to expect the new function

## Testing
- `Invoke-Pester -Output Detailed` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437c8e90a8832c97ec82a6b9288f11