### PR TITLE
Add ChaosMode toggle for ServiceDesk API

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ SD_BASE_URI
 ```
 
 When set, these variables override values stored in `config/SharePointToolsSettings.psd1`.
+Set `ST_CHAOS_MODE` to `1` or use the `-ChaosMode` switch on ServiceDeskTools commands to simulate throttled or failing API calls during testing.
 For a step-by-step example of loading these variables from the SecretManagement
 module see [docs/CredentialStorage.md](docs/CredentialStorage.md).
 

--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -14,3 +14,7 @@ Commands for interacting with the Service Desk ticketing API.
 | `Link-SDTicketToSPTask` | Add a related SharePoint task link | `Link-SDTicketToSPTask -TicketId 42 -TaskUrl 'https://contoso.sharepoint.com/tasks/1'` |
 
 `SD_API_TOKEN` must be set in the environment. Optionally set `SD_BASE_URI` if your Service Desk API uses a custom URL.
+
+### Chaos Mode
+
+All commands accept the `-ChaosMode` switch (or set the `ST_CHAOS_MODE` environment variable) to simulate delays and random request failures. Use this in development to test how your automation handles throttling and unreliable responses.

--- a/src/ServiceDeskTools/Public/Get-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDTicket.ps1
@@ -6,8 +6,11 @@ function Get-SDTicket {
         Incident ID to retrieve.
     #>
     [CmdletBinding()]
-    param([Parameter(Mandatory)][int]$Id)
+    param(
+        [Parameter(Mandatory)][int]$Id,
+        [switch]$ChaosMode
+    )
 
     Write-STLog "Get-SDTicket $Id"
-    Invoke-SDRequest -Method 'GET' -Path "/incidents/$Id.json"
+    Invoke-SDRequest -Method 'GET' -Path "/incidents/$Id.json" -ChaosMode:$ChaosMode
 }

--- a/src/ServiceDeskTools/Public/Link-SDTicketToSPTask.ps1
+++ b/src/ServiceDeskTools/Public/Link-SDTicketToSPTask.ps1
@@ -13,10 +13,11 @@ function Link-SDTicketToSPTask {
     param(
         [Parameter(Mandatory)][int]$TicketId,
         [Parameter(Mandatory)][string]$TaskUrl,
-        [string]$FieldName = 'sharepoint_task_url'
+        [string]$FieldName = 'sharepoint_task_url',
+        [switch]$ChaosMode
     )
 
     Write-STLog "Link-SDTicketToSPTask $TicketId $TaskUrl"
     $fields = @{ $FieldName = $TaskUrl }
-    Set-SDTicket -Id $TicketId -Fields $fields
+    Set-SDTicket -Id $TicketId -Fields $fields -ChaosMode:$ChaosMode
 }

--- a/src/ServiceDeskTools/Public/New-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/New-SDTicket.ps1
@@ -13,10 +13,11 @@ function New-SDTicket {
     param(
         [Parameter(Mandatory)][string]$Subject,
         [Parameter(Mandatory)][string]$Description,
-        [Parameter(Mandatory)][string]$RequesterEmail
+        [Parameter(Mandatory)][string]$RequesterEmail,
+        [switch]$ChaosMode
     )
 
     Write-STLog "New-SDTicket $Subject"
     $body = @{ incident = @{ name = $Subject; description = $Description; requester_email = $RequesterEmail } }
-    Invoke-SDRequest -Method 'POST' -Path '/incidents.json' -Body $body
+    Invoke-SDRequest -Method 'POST' -Path '/incidents.json' -Body $body -ChaosMode:$ChaosMode
 }

--- a/src/ServiceDeskTools/Public/Search-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Search-SDTicket.ps1
@@ -7,10 +7,11 @@ function Search-SDTicket {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$Query
+        [Parameter(Mandatory)][string]$Query,
+        [switch]$ChaosMode
     )
 
     Write-STLog "Search-SDTicket $Query"
     $encoded = [uri]::EscapeDataString($Query)
-    Invoke-SDRequest -Method 'GET' -Path "/incidents.json?search=$encoded"
+    Invoke-SDRequest -Method 'GET' -Path "/incidents.json?search=$encoded" -ChaosMode:$ChaosMode
 }

--- a/src/ServiceDeskTools/Public/Set-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicket.ps1
@@ -10,10 +10,11 @@ function Set-SDTicket {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][int]$Id,
-        [Parameter(Mandatory)][hashtable]$Fields
+        [Parameter(Mandatory)][hashtable]$Fields,
+        [switch]$ChaosMode
     )
 
     Write-STLog "Set-SDTicket $Id"
     $body = @{ incident = $Fields }
-    Invoke-SDRequest -Method 'PUT' -Path "/incidents/$Id.json" -Body $body
+    Invoke-SDRequest -Method 'PUT' -Path "/incidents/$Id.json" -Body $body -ChaosMode:$ChaosMode
 }

--- a/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
@@ -10,11 +10,12 @@ function Set-SDTicketBulk {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][int[]]$Id,
-        [Parameter(Mandatory)][hashtable]$Fields
+        [Parameter(Mandatory)][hashtable]$Fields,
+        [switch]$ChaosMode
     )
 
     foreach ($ticketId in $Id) {
         Write-STLog "Set-SDTicketBulk $ticketId"
-        Set-SDTicket -Id $ticketId -Fields $Fields
+        Set-SDTicket -Id $ticketId -Fields $Fields -ChaosMode:$ChaosMode
     }
 }


### PR DESCRIPTION
## Summary
- simulate throttling and random failures using a new `-ChaosMode` switch
- allow enabling Chaos Mode with `ST_CHAOS_MODE` environment variable
- document Chaos Mode usage

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Path tests -EnableExit"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437c99a064832ca3ebc9825fbccce8