### PR TITLE
Add maintenance kill switch

### DIFF
--- a/config/supporttools.json
+++ b/config/supporttools.json
@@ -1,0 +1,3 @@
+{
+    "maintenanceMode": false
+}

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -1,3 +1,14 @@
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
+$configFile = Join-Path $repoRoot 'config/supporttools.json'
+$SupportToolsConfig = @{ maintenanceMode = $false }
+if (Test-Path $configFile) {
+    try { $SupportToolsConfig = Get-Content $configFile | ConvertFrom-Json } catch {}
+}
+if ($SupportToolsConfig.maintenanceMode) {
+    Write-Host 'SupportTools is currently in maintenance mode. Exiting.' -ForegroundColor Yellow
+    exit 1
+}
+
 function Write-STLog {
     [CmdletBinding()]
     param(


### PR DESCRIPTION
## Summary
- add config/supporttools.json with maintenanceMode flag
- check kill switch in Logging module and exit when active

## Testing
- `pwsh -c 'Invoke-Pester tests -Passthru'` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68437f467668832c835402db16815902