### PR TITLE
Add local mock API server

### DIFF
--- a/docs/LocalMockApi.md
+++ b/docs/LocalMockApi.md
@@ -1,0 +1,22 @@
+# Local Mock API
+
+This short guide describes how to start a lightweight HTTP server that simulates minimal responses from Microsoft Graph and PnP.PowerShell APIs. Use it when developing or running the Pester tests offline.
+
+## Starting the server
+
+Run the script in the `scripts` folder:
+
+```powershell
+# Start the mock API on the default port 8080
+./scripts/Start-MockApiServer.ps1
+```
+
+Specify a different port if needed:
+
+```powershell
+./scripts/Start-MockApiServer.ps1 -Port 9090
+```
+
+The server listens on `http://localhost:<port>/`. Requests to `/graph/` return a stubbed Graph response while `/pnp/` yields a stubbed PnP payload.
+
+Stop the server with <kbd>Ctrl</kbd>+<kbd>C</kbd>.

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -11,24 +11,28 @@ This short guide shows the basic steps to start using the modules in this reposi
    ```powershell
    ./scripts/Install-ModuleDependencies.ps1
    ```
-3. **Install from gallery (optional)**
+3. **Start the local mock API server** (optional)
+   ```powershell
+   ./scripts/Start-MockApiServer.ps1
+   ```
+4. **Install from gallery (optional)**
    ```powershell
    ./scripts/Install-SupportTools.ps1 -SupportToolsVersion 1.3.0
    ```
-4. **Import the modules**
+5. **Import the modules**
    ```powershell
    Import-Module ./src/SupportTools/SupportTools.psd1
    Import-Module ./src/SharePointTools/SharePointTools.psd1
    Import-Module ./src/ServiceDeskTools/ServiceDeskTools.psd1
    ```
-5. **Run configuration** (for SharePoint functions)
+6. **Run configuration** (for SharePoint functions)
    ```powershell
    ./scripts/Configure-SharePointTools.ps1
    ```
-6. **Load credentials** (optional)
+7. **Load credentials** (optional)
    Refer to [CredentialStorage.md](CredentialStorage.md) for a step‑by‑step
    walkthrough of using SecretManagement to load environment variables.
-7. **Try a few common commands**
+8. **Try a few common commands**
    ```powershell
    # System information
    Get-CommonSystemInfo | Format-Table
@@ -39,7 +43,7 @@ This short guide shows the basic steps to start using the modules in this reposi
    # Create a Service Desk ticket
    New-SDTicket -Title "Test" -Description "Quick start test"
    ```
-7. **Launch the interactive menu** (optional)
+9. **Launch the interactive menu** (optional)
    ```powershell
    ./scripts/SupportToolsMenu.ps1
    ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ The key guides are:
 - [Credential Storage](./CredentialStorage.md) – recommended approach to store secrets securely.
 - [Module Style Guide](./ModuleStyleGuide.md) – how scripts display progress messages and log output.
 - [Get-FunctionDependencyGraph](./Get-FunctionDependencyGraph.md) – generate a visual map of function calls in a script.
+- [Local Mock API](./LocalMockApi.md) – run a lightweight HTTP server for offline tests.
 
 
 Command specific help topics live in the `SupportTools`, `SharePointTools` and `ServiceDeskTools` subfolders.

--- a/scripts/Start-MockApiServer.ps1
+++ b/scripts/Start-MockApiServer.ps1
@@ -1,0 +1,40 @@
+param(
+    [int]$Port = 8080
+)
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+
+$listener = [System.Net.HttpListener]::new()
+$listener.Prefixes.Add("http://localhost:$Port/")
+
+try {
+    $listener.Start()
+    Write-STStatus "Mock API server listening on http://localhost:$Port/" -Level SUCCESS
+    while ($listener.IsListening) {
+        $context = $listener.GetContext()
+        $path = $context.Request.RawUrl
+        switch -Wildcard ($path) {
+            '/graph/*' {
+                $payload = @{ value = 'fake Graph response' } | ConvertTo-Json
+                $bytes = [System.Text.Encoding]::UTF8.GetBytes($payload)
+                $context.Response.ContentType = 'application/json'
+                $context.Response.ContentLength64 = $bytes.Length
+                $context.Response.OutputStream.Write($bytes,0,$bytes.Length)
+            }
+            '/pnp/*' {
+                $payload = @{ value = 'fake PnP response' } | ConvertTo-Json
+                $bytes = [System.Text.Encoding]::UTF8.GetBytes($payload)
+                $context.Response.ContentType = 'application/json'
+                $context.Response.ContentLength64 = $bytes.Length
+                $context.Response.OutputStream.Write($bytes,0,$bytes.Length)
+            }
+            default {
+                $context.Response.StatusCode = 404
+            }
+        }
+        $context.Response.Close()
+    }
+}
+finally {
+    $listener.Stop()
+}


### PR DESCRIPTION
## Summary
- create a lightweight HTTP listener for stub Graph/PnP responses
- document how to use the mock API
- mention the mock server in docs overview and quickstart guide

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration @{ Run = @{ Exit=$false } }"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437f86ce1c832c9cfe75c7e22637de