### PR TITLE
Add sample tests and coverage config

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -24,4 +24,9 @@ jobs:
       - name: Run Pester tests
         shell: pwsh
         run: |
-          Invoke-Pester -Path tests -CI
+          $cfg = Import-PowerShellDataFile ./PesterConfiguration.psd1
+          Invoke-Pester -Configuration $cfg -CI
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage.xml

--- a/PesterConfiguration.psd1
+++ b/PesterConfiguration.psd1
@@ -1,0 +1,9 @@
+@{
+    Run = @{ Path = 'tests'; Exit = $true }
+    CodeCoverage = @{
+        Enabled = $true
+        Path = @('src/**/*.ps1','scripts/*.ps1')
+        OutputFormat = 'JaCoCo'
+        OutputPath = 'coverage.xml'
+    }
+}

--- a/tests/AddUsersToGroup.Tests.ps1
+++ b/tests/AddUsersToGroup.Tests.ps1
@@ -1,0 +1,40 @@
+Describe 'AddUsersToGroup Script' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'scripts/AddUsersToGroup.ps1'
+        function Install-Module {}
+        function Import-Module {}
+        function Connect-MgGraph {}
+        function Disconnect-MgGraph {}
+        function Get-MgContext {}
+        function New-MgGroupMember {}
+        Mock Add-Type {}
+        Mock Import-Module {}
+        Mock Install-Module {}
+        Mock Start-Main {}
+        . $scriptPath -CsvPath 'dummy.csv' -GroupName 'Group'
+    }
+    BeforeEach {
+        Mock Connect-MgGraph {}
+        Mock Disconnect-MgGraph {}
+        Mock Get-MgContext { @{ Account = 'test' } }
+        Mock Get-Group { [pscustomobject]@{ Id='1'; DisplayName='Group' } }
+        Mock Get-GroupExistingMembers { @('existing@contoso.com') }
+        Mock Get-CSVFilePath { 'dummy.csv' }
+        Mock Import-Csv { @([pscustomobject]@{ UPN='user1@contoso.com' }, [pscustomobject]@{ UPN='existing@contoso.com' }) }
+        Mock Get-UserID { param($UserPrincipalName) [pscustomobject]@{ UserPrincipalName=$UserPrincipalName; DisplayName='User'; Id='id' } }
+        Mock New-MgGroupMember {}
+    }
+    It 'connects and disconnects from Graph' {
+        Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' | Out-Null
+        Assert-MockCalled Connect-MgGraph -Times 1
+        Assert-MockCalled Disconnect-MgGraph -Times 1
+    }
+    It 'imports the CSV' {
+        Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' | Out-Null
+        Assert-MockCalled Import-Csv -ParameterFilter { $Path -eq 'dummy.csv' } -Times 1
+    }
+    It 'adds only missing users' {
+        Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' | Out-Null
+        Assert-MockCalled New-MgGroupMember -Times 1
+    }
+}

--- a/tests/ArchiveCleanup.Tests.ps1
+++ b/tests/ArchiveCleanup.Tests.ps1
@@ -1,0 +1,27 @@
+Describe 'Invoke-ArchiveCleanup' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/SharePointTools/SharePointTools.psd1 -Force
+    }
+    BeforeEach {
+        function Connect-PnPOnline {}
+        function Get-PnPListItem {}
+        function Remove-PnPFile {}
+        function Remove-PnPFolder {}
+        Mock Connect-PnPOnline {} -ModuleName SharePointTools
+        Mock Get-PnPListItem { $script:testItems } -ModuleName SharePointTools
+        Mock Remove-PnPFile {} -ModuleName SharePointTools
+        Mock Remove-PnPFolder {} -ModuleName SharePointTools
+        Mock Start-Transcript {}
+        Mock Stop-Transcript {}
+        Mock Get-SPToolsSiteUrl { 'https://contoso' } -ModuleName SharePointTools
+    }
+    It 'removes archived files and folders' {
+        $script:testItems = @(
+            [pscustomobject]@{ FileSystemObjectType='File'; FieldValues=@{ FileRef='Shared Documents/zzz_Archive/file.txt' } },
+            [pscustomobject]@{ FileSystemObjectType='Folder'; FieldValues=@{ FileRef='Shared Documents/zzz_Archive/sub'; FileDirRef='Shared Documents/zzz_Archive'; FileLeafRef='sub' } }
+        )
+        Invoke-ArchiveCleanup -SiteName 'SiteA' -SiteUrl 'https://contoso' -Confirm:$false | Out-Null
+        Assert-MockCalled Remove-PnPFile -Times 1 -ModuleName SharePointTools
+        Assert-MockCalled Remove-PnPFolder -Times 1 -ModuleName SharePointTools
+    }
+}


### PR DESCRIPTION
## Summary
- configure Pester code coverage
- upload coverage artifact in workflow
- add a sample test for AddUsersToGroup script
- add a sample test for ArchiveCleanup

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: Parameter set cannot be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68437bf5fe38832cbff22bbdb4f8f86c