### PR TITLE
Add role-aware menu and cleanup command

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -41,7 +41,7 @@ This short guide shows the basic steps to start using the modules in this reposi
    ```
 7. **Launch the interactive menu** (optional)
    ```powershell
-   ./scripts/SupportToolsMenu.ps1
+   ./scripts/SupportToolsMenu.ps1 -UserRole Helpdesk
    ```
 
 See [docs/UserGuide.md](UserGuide.md) for detailed deployment and usage instructions.

--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -7,8 +7,9 @@ Import the module and run the desired function rather than calling the script di
 Import-Module ./src/SupportTools/SupportTools.psd1
 ```
 
-For a guided experience, run `./scripts/SupportToolsMenu.ps1` to select
-common tasks from an interactive menu.
+For a guided experience, run `./scripts/SupportToolsMenu.ps1` with the optional
+`-UserRole` parameter to select common tasks from an interactive menu tailored
+for `Helpdesk` or `Site Admin` roles.
 
 ## Available Commands
 
@@ -18,6 +19,7 @@ listed are forwarded to the underlying script unchanged.
 | Command | Wrapped Script | Key Parameters | Example |
 |---------|----------------|---------------|---------|
 | `Add-UserToGroup` | `AddUsersToGroup.ps1` | `CsvPath`, `GroupName` | `Add-UserToGroup -CsvPath users.csv -GroupName 'Team'` |
+| `Invoke-GroupMembershipCleanup` | `CleanupGroupMembership.ps1` | `CsvPath`, `GroupName` | `Invoke-GroupMembershipCleanup -CsvPath remove.csv -GroupName 'Team'` |
 | `Clear-ArchiveFolder` | `CleanupArchive.ps1` | *passthrough* | `Clear-ArchiveFolder -SiteUrl https://contoso.sharepoint.com/sites/Files` |
 | `Restore-ArchiveFolder` | `RollbackArchive.ps1` | `SnapshotPath`, `SiteUrl` | `Restore-ArchiveFolder -SiteUrl https://contoso.sharepoint.com/sites/Files -SnapshotPath preDeleteLog.json` |
 | `Convert-ExcelToCsv` | `Convert-ExcelToCsv.ps1` | *passthrough* | `Convert-ExcelToCsv -Path workbook.xlsx` |

--- a/scripts/CleanupGroupMembership.ps1
+++ b/scripts/CleanupGroupMembership.ps1
@@ -1,0 +1,37 @@
+<#+
+.SYNOPSIS
+    Removes users from a Microsoft 365 group.
+.DESCRIPTION
+    Imports user principal names from a CSV file and removes each
+    user from the target group if they are currently a member.
+.EXAMPLE
+    ./CleanupGroupMembership.ps1 -CsvPath users.csv -GroupName "Team"
+#>
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+
+param(
+    [Parameter(Mandatory)][string]$CsvPath,
+    [Parameter(Mandatory)][string]$GroupName
+)
+
+Write-STStatus 'Connecting to Microsoft Graph...' -Level INFO
+Connect-MgGraph -Scopes "User.Read.All","Group.ReadWrite.All" -NoWelcome
+
+$group = Get-MgGroup -Filter "displayName eq '$GroupName'" | Select-Object -First 1
+if (-not $group) { throw "Group '$GroupName' not found." }
+
+$users = Import-Csv $CsvPath
+foreach ($user in $users.UPN) {
+    $obj = Get-MgUser -UserId $user -ErrorAction SilentlyContinue
+    if (-not $obj) { Write-Warning "User not found: $user"; continue }
+    try {
+        Remove-MgGroupMemberByRef -GroupId $group.Id -DirectoryObjectId $obj.Id -ErrorAction Stop
+        Write-STStatus "Removed $($obj.UserPrincipalName)" -Level SUCCESS
+    } catch {
+        Write-Warning "Failed to remove $user: $_"
+    }
+}
+
+Disconnect-MgGraph | Out-Null
+Write-STStatus 'Group membership cleanup finished.' -Level SUCCESS

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,7 @@ The following table provides a brief description of each script.
 | Script | Description |
 |-------|-------------|
 | **AddUsersToGroup.ps1** | Adds users from a CSV file to a Microsoft 365 group using Microsoft Graph. |
+| **CleanupGroupMembership.ps1** | Removes users from a Microsoft 365 group based on a CSV list. |
 | **CleanupArchive.ps1** | Deletes files and folders inside the `zzz_Archive_Production` directory of a SharePoint library. |
 | **Convert-ExcelToCsv.ps1** | Converts Excel files to CSV format. |
 | **Get-CommonSystemInfo.ps1** | Retrieves operating system, processor, memory and disk information. |

--- a/scripts/SupportToolsMenu.ps1
+++ b/scripts/SupportToolsMenu.ps1
@@ -12,30 +12,47 @@
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
 Import-Module (Join-Path $PSScriptRoot '..' 'src/SupportTools/SupportTools.psd1') -ErrorAction SilentlyContinue
 
+param(
+    [ValidateSet('Helpdesk','Site Admin')]
+    [string]$UserRole = 'Helpdesk'
+)
+
+$Menu = @(
+    @{ Label = 'Add users to group'; Action = { Write-STStatus 'Running Add-UserToGroup...' -Level INFO; Add-UserToGroup } },
+    @{ Label = 'Cleanup archive folder'; Action = { Write-STStatus 'Running Clear-ArchiveFolder...' -Level INFO; Clear-ArchiveFolder } }
+)
+
+if ($UserRole -eq 'Helpdesk') {
+    $Menu += @{ Label = 'Create ticket'; Action = {
+            $subject = Read-Host 'Subject'
+            $desc = Read-Host 'Description'
+            $email = Read-Host 'Requester email'
+            New-SDTicket -Subject $subject -Description $desc -RequesterEmail $email
+        } }
+}
+
+if ($UserRole -eq 'Site Admin') {
+    $Menu += @{ Label = 'Group membership cleanup'; Action = { Invoke-GroupMembershipCleanup } }
+}
+
 function Show-Menu {
     Write-STDivider 'SupportTools Menu' -Style heavy
-    Write-Host '1. Add users to group'
-    Write-Host '2. Cleanup archive folder'
+    for ($i = 0; $i -lt $Menu.Count; $i++) {
+        $num = $i + 1
+        Write-Host "$num. $($Menu[$i].Label)"
+    }
     Write-Host 'Q. Quit'
 }
 
 while ($true) {
     Show-Menu
     $choice = Read-Host 'Select an option'
-    switch ($choice) {
-        '1' {
-            Write-STStatus 'Running Add-UserToGroup...' -Level INFO
-            Add-UserToGroup
-        }
-        '2' {
-            Write-STStatus 'Running Clear-ArchiveFolder...' -Level INFO
-            Clear-ArchiveFolder
-        }
-        'q' { break }
-        'Q' { break }
-        default {
-            Write-STStatus 'Invalid choice. Try again.' -Level WARN
-        }
+    if ($choice -match '^[Qq]$') { break }
+    $index = [int]$choice - 1
+    if ($index -ge 0 -and $index -lt $Menu.Count) {
+        & $Menu[$index].Action
+    } else {
+        Write-STStatus 'Invalid choice. Try again.' -Level WARN
     }
     Write-Host
 }

--- a/src/SupportTools/Public/Invoke-GroupMembershipCleanup.ps1
+++ b/src/SupportTools/Public/Invoke-GroupMembershipCleanup.ps1
@@ -1,0 +1,26 @@
+function Invoke-GroupMembershipCleanup {
+    <#
+    .SYNOPSIS
+        Removes users from a Microsoft 365 group.
+    .DESCRIPTION
+        Wraps the CleanupGroupMembership.ps1 script located in the scripts folder.
+    .PARAMETER CsvPath
+        Path to the CSV file containing user principal names.
+    .PARAMETER GroupName
+        Name of the Microsoft 365 group to modify.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipelineByPropertyName=$true)]
+        [string]$CsvPath,
+        [Parameter(ValueFromPipelineByPropertyName=$true)]
+        [string]$GroupName,
+        [string]$TranscriptPath
+    )
+    process {
+        $arguments = @()
+        if ($PSBoundParameters.ContainsKey('CsvPath')) { $arguments += '-CsvPath'; $arguments += $CsvPath }
+        if ($PSBoundParameters.ContainsKey('GroupName')) { $arguments += '-GroupName'; $arguments += $GroupName }
+        Invoke-ScriptFile -Name 'CleanupGroupMembership.ps1' -Args $arguments -TranscriptPath $TranscriptPath
+    }
+}

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -24,6 +24,6 @@
         'Start-Countdown',
         'Update-Sysmon',
         'Set-SharedMailboxAutoReply',
-        'Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket','Generate-SPUsageReport','Install-MaintenanceTasks'
+        'Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket','Generate-SPUsageReport','Install-MaintenanceTasks','Invoke-GroupMembershipCleanup'
     )
 }

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -30,6 +30,7 @@ Describe 'SupportTools Module' {
             'Submit-SystemInfoTicket',
             'Generate-SPUsageReport'
             'Install-MaintenanceTasks'
+            'Invoke-GroupMembershipCleanup'
         )
 
         $exported = (Get-Command -Module SupportTools).Name
@@ -64,6 +65,7 @@ Describe 'SupportTools Module' {
             Submit_SystemInfoTicket      = 'Submit-SystemInfoTicket.ps1'
             Generate_SPUsageReport       = 'Generate-SPUsageReport.ps1'
             Install_MaintenanceTasks = 'Setup-ScheduledMaintenance.ps1'
+            Invoke_GroupMembershipCleanup = 'CleanupGroupMembership.ps1'
         }
 
         $cases = foreach ($entry in $map.GetEnumerator()) {


### PR DESCRIPTION
## Summary
- add `CleanupGroupMembership.ps1` and wrapper function
- update SupportTools manifest and tests
- implement `-UserRole` parameter in SupportToolsMenu
- document the role-based menu and new script

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437f073260832cb03237b6ca0c6f5b