### PR TITLE
Add simulation mode switch

### DIFF
--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -10,6 +10,12 @@ Import-Module ./src/SupportTools/SupportTools.psd1
 For a guided experience, run `./scripts/SupportToolsMenu.ps1` to select
 common tasks from an interactive menu.
 
+### Simulation Mode
+
+All commands now accept a `-Simulate` switch. When used, the command logs each
+step and returns randomized mock data without making changes. This is useful for
+testing in lab environments.
+
 ## Available Commands
 
 The table below lists each command and the script it invokes. Arguments not

--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -13,7 +13,8 @@ function Invoke-ScriptFile {
         [string]$Name,
         [Parameter(ValueFromRemainingArguments=$true)]
         [object[]]$Args,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
+        [switch]$Simulate
     )
     $Path = Join-Path $PSScriptRoot '..' |
             Join-Path -ChildPath '..' |
@@ -24,6 +25,18 @@ function Invoke-ScriptFile {
     Write-STStatus "EXECUTING $Name" -Level SUCCESS -Log
     if ($Args) {
         Write-STStatus "ARGS: $($Args -join ' ')" -Level SUB -Log
+    }
+
+    if ($Simulate) {
+        Write-STStatus "SIMULATING $Name" -Level INFO -Log
+        if ($Args) {
+            Write-STStatus "ARGS: $($Args -join ' ')" -Level SUB -Log
+        }
+        $count = Get-Random -Minimum 1 -Maximum 5
+        $mock = for ($i = 1; $i -le $count; $i++) {
+            [pscustomobject]@{ Id = $i; Value = (Get-Random) }
+        }
+        return $mock
     }
 
     if ($TranscriptPath) {

--- a/src/SupportTools/Public/Add-UserToGroup.ps1
+++ b/src/SupportTools/Public/Add-UserToGroup.ps1
@@ -17,6 +17,7 @@ function Add-UserToGroup {
         [Parameter(ValueFromPipelineByPropertyName=$true)]
         [string]$GroupName,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
 
     process {
@@ -30,6 +31,6 @@ function Add-UserToGroup {
             $arguments += $GroupName
         }
 
-        Invoke-ScriptFile -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Clear-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Clear-ArchiveFolder.ps1
@@ -11,8 +11,9 @@ function Clear-ArchiveFolder {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Clear-TempFile.ps1
+++ b/src/SupportTools/Public/Clear-TempFile.ps1
@@ -10,8 +10,9 @@ function Clear-TempFile {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "CleanupTempFiles.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "CleanupTempFiles.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Convert-ExcelToCsv.ps1
+++ b/src/SupportTools/Public/Convert-ExcelToCsv.ps1
@@ -11,8 +11,9 @@ function Convert-ExcelToCsv {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "Convert-ExcelToCsv.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "Convert-ExcelToCsv.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Export-ProductKey.ps1
+++ b/src/SupportTools/Public/Export-ProductKey.ps1
@@ -11,8 +11,9 @@ function Export-ProductKey {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "ProductKey.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "ProductKey.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Generate-SPUsageReport.ps1
+++ b/src/SupportTools/Public/Generate-SPUsageReport.ps1
@@ -10,8 +10,9 @@ function Generate-SPUsageReport {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name 'Generate-SPUsageReport.ps1' -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name 'Generate-SPUsageReport.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Get-CommonSystemInfo.ps1
+++ b/src/SupportTools/Public/Get-CommonSystemInfo.ps1
@@ -11,8 +11,9 @@ function Get-CommonSystemInfo {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "Get-CommonSystemInfo.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "Get-CommonSystemInfo.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Get-FailedLogin.ps1
+++ b/src/SupportTools/Public/Get-FailedLogin.ps1
@@ -11,8 +11,9 @@ function Get-FailedLogin {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "Get-FailedLogins.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "Get-FailedLogins.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Get-NetworkShare.ps1
+++ b/src/SupportTools/Public/Get-NetworkShare.ps1
@@ -11,8 +11,9 @@ function Get-NetworkShare {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "Get-NetworkShares.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "Get-NetworkShares.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Get-UniquePermission.ps1
+++ b/src/SupportTools/Public/Get-UniquePermission.ps1
@@ -11,8 +11,9 @@ function Get-UniquePermission {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "Get-UniquePermissions.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "Get-UniquePermissions.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Install-Font.ps1
+++ b/src/SupportTools/Public/Install-Font.ps1
@@ -11,8 +11,9 @@ function Install-Font {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "Install-Fonts.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "Install-Fonts.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Install-MaintenanceTasks.ps1
+++ b/src/SupportTools/Public/Install-MaintenanceTasks.ps1
@@ -12,10 +12,11 @@ function Install-MaintenanceTasks {
     param(
         [switch]$Register,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
         $argsList = @()
         if ($Register) { $argsList += '-Register' }
-        Invoke-ScriptFile -Name 'Setup-ScheduledMaintenance.ps1' -Args $argsList -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name 'Setup-ScheduledMaintenance.ps1' -Args $argsList -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Invoke-CompanyPlaceManagement.ps1
+++ b/src/SupportTools/Public/Invoke-CompanyPlaceManagement.ps1
@@ -29,10 +29,22 @@ function Invoke-CompanyPlaceManagement {
         [string]$CountryOrRegion,
         [switch]$AutoAddFloor,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
 
     if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
     Write-STStatus "Invoke-CompanyPlaceManagement -Action $Action" -Level SUCCESS -Log
+    if ($Simulate) {
+        Write-STStatus 'Simulation mode active - no Microsoft Places changes will be made.' -Level WARN -Log
+        $mock = [pscustomobject]@{
+            Action      = $Action
+            DisplayName = $DisplayName
+            Simulated   = $true
+            Timestamp   = Get-Date
+        }
+        if ($TranscriptPath) { Stop-Transcript | Out-Null }
+        return $mock
+    }
     if (-not (Get-Command Get-PlaceV3 -ErrorAction SilentlyContinue)) {
         try {
             Import-Module MicrosoftPlaces -ErrorAction Stop

--- a/src/SupportTools/Public/Invoke-DeploymentTemplate.ps1
+++ b/src/SupportTools/Public/Invoke-DeploymentTemplate.ps1
@@ -11,8 +11,9 @@ function Invoke-DeploymentTemplate {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "SS_DEPLOYMENT_TEMPLATE.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "SS_DEPLOYMENT_TEMPLATE.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -9,10 +9,20 @@ function Invoke-ExchangeCalendarManager {
     [CmdletBinding()]
     param(
         [string]$TranscriptPath
+        [switch]$Simulate
     )
 
     if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
     Write-STStatus 'ExchangeCalendarManager launched' -Level SUCCESS -Log
+    if ($Simulate) {
+        Write-STStatus 'Simulation mode active - no Exchange operations will occur.' -Level WARN -Log
+        $mock = [pscustomobject]@{
+            Simulated = $true
+            Timestamp = Get-Date
+        }
+        if ($TranscriptPath) { Stop-Transcript | Out-Null }
+        return $mock
+    }
 
     if ($PSVersionTable.PSVersion.Major -lt 7) {
         throw 'This function requires PowerShell 7 or higher.'

--- a/src/SupportTools/Public/Invoke-PostInstall.ps1
+++ b/src/SupportTools/Public/Invoke-PostInstall.ps1
@@ -11,8 +11,9 @@ function Invoke-PostInstall {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "PostInstallScript.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "PostInstallScript.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Restore-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Restore-ArchiveFolder.ps1
@@ -11,8 +11,9 @@ function Restore-ArchiveFolder {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "RollbackArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "RollbackArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Search-ReadMe.ps1
+++ b/src/SupportTools/Public/Search-ReadMe.ps1
@@ -11,8 +11,9 @@ function Search-ReadMe {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "Search-ReadMe.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "Search-ReadMe.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Set-ComputerIPAddress.ps1
+++ b/src/SupportTools/Public/Set-ComputerIPAddress.ps1
@@ -10,8 +10,9 @@ function Set-ComputerIPAddress {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "Set-ComputerIPAddress.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "Set-ComputerIPAddress.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Set-NetAdapterMetering.ps1
+++ b/src/SupportTools/Public/Set-NetAdapterMetering.ps1
@@ -11,8 +11,9 @@ function Set-NetAdapterMetering {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "Set-NetAdapterMetering.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "Set-NetAdapterMetering.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
+++ b/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
@@ -23,10 +23,21 @@ function Set-SharedMailboxAutoReply {
         [string]$AdminUser,
         [switch]$UseWebLogin,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
 
     if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
     Write-STStatus 'Running Set-SharedMailboxAutoReply' -Level SUCCESS -Log
+    if ($Simulate) {
+        Write-STStatus 'Simulation mode active - auto-reply settings will not be changed.' -Level WARN -Log
+        $mock = [pscustomobject]@{
+            MailboxIdentity = $MailboxIdentity
+            Simulated       = $true
+            Timestamp       = Get-Date
+        }
+        if ($TranscriptPath) { Stop-Transcript | Out-Null }
+        return $mock
+    }
 
     if (-not $ExternalMessage) { $ExternalMessage = $InternalMessage }
 

--- a/src/SupportTools/Public/Set-TimeZoneEasternStandardTime.ps1
+++ b/src/SupportTools/Public/Set-TimeZoneEasternStandardTime.ps1
@@ -11,8 +11,9 @@ function Set-TimeZoneEasternStandardTime {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "Set-TimeZoneEasternStandardTime.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "Set-TimeZoneEasternStandardTime.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Start-Countdown.ps1
+++ b/src/SupportTools/Public/Start-Countdown.ps1
@@ -11,8 +11,9 @@ function Start-Countdown {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "SimpleCountdown.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "SimpleCountdown.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Submit-SystemInfoTicket.ps1
+++ b/src/SupportTools/Public/Submit-SystemInfoTicket.ps1
@@ -14,6 +14,7 @@ function Submit-SystemInfoTicket {
         [string]$LibraryName,
         [string]$FolderPath,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
         $arguments = @('-SiteName', $SiteName, '-RequesterEmail', $RequesterEmail)
@@ -21,6 +22,6 @@ function Submit-SystemInfoTicket {
         if ($PSBoundParameters.ContainsKey('Description')) { $arguments += @('-Description', $Description) }
         if ($PSBoundParameters.ContainsKey('LibraryName')) { $arguments += @('-LibraryName', $LibraryName) }
         if ($PSBoundParameters.ContainsKey('FolderPath'))  { $arguments += @('-FolderPath', $FolderPath) }
-        Invoke-ScriptFile -Name 'Submit-SystemInfoTicket.ps1' -Args $arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name 'Submit-SystemInfoTicket.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }

--- a/src/SupportTools/Public/Update-Sysmon.ps1
+++ b/src/SupportTools/Public/Update-Sysmon.ps1
@@ -10,8 +10,9 @@ function Update-Sysmon {
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
         [string]$TranscriptPath
+        [switch]$Simulate
     )
     process {
-        Invoke-ScriptFile -Name "Update-Sysmon.ps1" -Args $Arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name "Update-Sysmon.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
     }
 }


### PR DESCRIPTION
## Summary
- implement `-Simulate` in Invoke-ScriptFile
- pass `-Simulate` through all SupportTools wrappers
- handle simulation for Exchange and Microsoft Places helpers
- document the new `-Simulate` option

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68437f6ead28832cb73dbee217de056b