### PR TITLE
Update artifact action to v4

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           $cfg = Import-PowerShellDataFile ./PesterConfiguration.psd1
           Invoke-Pester -Configuration $cfg -CI
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage.xml


### PR DESCRIPTION
## Summary
- update deprecated `actions/upload-artifact` to v4 in the Pester workflow

## Testing
- `Invoke-Pester` *(fails: No modules named 'SupportTools' are currently loaded)*

------
https://chatgpt.com/codex/tasks/task_e_684381b86f90832c978fa4bcdd30fef8