### PR TITLE
Add structured log persistence option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ module see [docs/CredentialStorage.md](docs/CredentialStorage.md).
 Commands automatically record their activity to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default.
 Set the `ST_LOG_PATH` environment variable or use the `-Path` parameter of `Write-STLog` to write logs to a custom location.
 Use `-Structured` to emit JSON lines that include the current user and script name for ingestion into tools like Azure Log Analytics.
+Set `ST_LOG_STRUCTURED=1` to enable structured output without adding the switch each time.
 Review the resulting log file with `Get-Content` when troubleshooting.
 
 ## Roadmap 🛣️

--- a/docs/Logging/RichLogFormat.md
+++ b/docs/Logging/RichLogFormat.md
@@ -13,4 +13,4 @@ All SupportTools commands should log structured events in a single JSON format. 
 }
 ```
 
-Use `Write-STRichLog` to emit entries in this format. Logs default to `~/SupportToolsLogs/supporttools.log` unless a custom path is provided or `ST_LOG_PATH` is set.
+Use `Write-STRichLog` to emit entries in this format. Logs default to `~/SupportToolsLogs/supporttools.log` unless a custom path is provided or `ST_LOG_PATH` is set. You can also set `ST_LOG_STRUCTURED=1` to automatically write structured entries when calling `Write-STLog` without the `-Structured` switch.

--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -106,6 +106,7 @@ Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+Set the `ST_LOG_STRUCTURED` environment variable to `1` to enable structured output by default.
 
 ### -ProgressAction
 {{ Fill ProgressAction Description }}

--- a/docs/ModuleStyleGuide.md
+++ b/docs/ModuleStyleGuide.md
@@ -23,3 +23,4 @@ Write-STClosing
 
 All messages can also be logged to `%USERPROFILE%\SupportToolsLogs\supporttools.log` using the `-Log` switch or by setting `ST_LOG_PATH`.
 Use the `-Structured` parameter of `Write-STLog` to output JSON lines with extra metadata for ingestion into a centralized dashboard.
+Set the `ST_LOG_STRUCTURED` environment variable to `1` to enable structured output automatically.

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -20,6 +20,9 @@ function Write-STLog {
         [hashtable]$Metadata,
         [switch]$Structured
     )
+    if (-not $Structured -and $env:ST_LOG_STRUCTURED -eq '1') {
+        $Structured = $true
+    }
     $userProfile = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
     if ($Path) {
         $logFile = $Path

--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -79,6 +79,20 @@ Describe 'Logging Module' {
         }
     }
 
+    It 'writes structured log entries when ST_LOG_STRUCTURED is set' {
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            $env:ST_LOG_STRUCTURED = '1'
+            Write-STLog -Message 'env json test' -Path $temp
+            $json = Get-Content $temp | ConvertFrom-Json
+            $json.message | Should -Be 'env json test'
+            $json.level | Should -Be 'INFO'
+        } finally {
+            Remove-Item $temp -ErrorAction SilentlyContinue
+            Remove-Item env:ST_LOG_STRUCTURED -ErrorAction SilentlyContinue
+        }
+    }
+
     It 'throws on invalid log level' {
         $temp = [System.IO.Path]::GetTempFileName()
         try {


### PR DESCRIPTION
## Summary
- allow `Write-STLog` to default to structured JSON format when the `ST_LOG_STRUCTURED` environment variable is set
- document the new environment variable in the style guide, logging docs, and README
- note the option in the rich log documentation
- add a test covering `ST_LOG_STRUCTURED`

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Configuration ./PesterConfiguration.psd1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843837f7ff8832cb94a28eda4864634