### PR TITLE
Add module path subfolders for tests

### DIFF
--- a/tests/Logging/Logging.Tests.ps1
+++ b/tests/Logging/Logging.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'Logging Module' {
     BeforeAll {
-        Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
     }
 
     It 'writes to the path parameter' {

--- a/tests/ServiceDeskTools/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools/ServiceDeskTools.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'ServiceDeskTools Module' {
     BeforeAll {
-        Import-Module $PSScriptRoot/../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
     }
 
     Context 'Exported commands' {

--- a/tests/SharePointTools/ArchiveCleanup.Tests.ps1
+++ b/tests/SharePointTools/ArchiveCleanup.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'Invoke-ArchiveCleanup' {
     BeforeAll {
-        Import-Module $PSScriptRoot/../src/SharePointTools/SharePointTools.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/SharePointTools/SharePointTools.psd1 -Force
     }
     BeforeEach {
         function Connect-PnPOnline {}

--- a/tests/SharePointTools/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools/SharePointTools.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'SharePointTools Module' {
     BeforeAll {
-        Import-Module $PSScriptRoot/../src/SharePointTools/SharePointTools.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/SharePointTools/SharePointTools.psd1 -Force
     }
 
     Context 'Exported commands' {

--- a/tests/SupportTools/AddUsersToGroup.Tests.ps1
+++ b/tests/SupportTools/AddUsersToGroup.Tests.ps1
@@ -1,6 +1,7 @@
 Describe 'AddUsersToGroup Script' {
     BeforeAll {
-        $scriptPath = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'scripts/AddUsersToGroup.ps1'
+        $repoRoot   = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath '..'
+        $scriptPath = Join-Path $repoRoot 'scripts/AddUsersToGroup.ps1'
         function Install-Module {}
         function Import-Module {}
         function Connect-MgGraph {}

--- a/tests/SupportTools/SupportTools.Tests.ps1
+++ b/tests/SupportTools/SupportTools.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'SupportTools Module' {
     BeforeAll {
-        Import-Module $PSScriptRoot/../src/SupportTools/SupportTools.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force
     }
 
     Context 'Exported commands' {

--- a/tests/Telemetry/Telemetry.Tests.ps1
+++ b/tests/Telemetry/Telemetry.Tests.ps1
@@ -1,11 +1,12 @@
 Describe 'Telemetry Opt-In' {
     BeforeAll {
-        Import-Module $PSScriptRoot/../src/SupportTools/SupportTools.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force
     }
 
     It 'does not log telemetry when not opted in' {
         $log = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
-        $scriptFile = Join-Path $PSScriptRoot/.. 'scripts/TelemetryTest.ps1'
+        $repoRoot   = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath '..'
+        $scriptFile = Join-Path $repoRoot 'scripts/TelemetryTest.ps1'
         Set-Content $scriptFile "Write-Host 'test'"
         try {
             Remove-Item env:ST_ENABLE_TELEMETRY -ErrorAction SilentlyContinue
@@ -22,7 +23,8 @@ Describe 'Telemetry Opt-In' {
 
     It 'logs telemetry when opt-in variable is set' {
         $log = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
-        $scriptFile = Join-Path $PSScriptRoot/.. 'scripts/TelemetryTest.ps1'
+        $repoRoot   = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath '..'
+        $scriptFile = Join-Path $repoRoot 'scripts/TelemetryTest.ps1'
         Set-Content $scriptFile "Write-Host 'test'"
         try {
             $env:ST_ENABLE_TELEMETRY = '1'
@@ -45,7 +47,7 @@ Describe 'Telemetry Opt-In' {
 
 Describe 'Telemetry Metrics Summary' {
     BeforeAll {
-        Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
     }
 
     It 'aggregates telemetry data' {


### PR DESCRIPTION
## Summary
- create module subdirectories inside `tests`
- update test scripts with new relative paths

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile './PesterConfiguration.psd1')` *(fails: SupportTools module fails to load)*

------
https://chatgpt.com/codex/tasks/task_e_684383737250832ca42b12ca042ac998