### PR TITLE
Add stewardship docs and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ This repository packages a collection of scripts into reusable modules.
 * **SharePointTools** – commands for SharePoint cleanup tasks such as removing archives or sharing links.
 * **ServiceDeskTools** – interact with the Service Desk ticketing system.
 
+### Module Maturity
+
+| Module | Status |
+| ------ | ------ |
+| SupportTools | Stable |
+| SharePointTools | Beta |
+| ServiceDeskTools | Experimental |
+
 ## Requirements 📋
 
 * **PowerShell 7 or later** must be installed to import these modules.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@ The key guides are:
 - [Telemetry Metrics](./Telemetry/Get-STTelemetryMetrics.md) – summarize execution statistics and output to CSV or SQLite.
 - [Get-FunctionDependencyGraph](./Get-FunctionDependencyGraph.md) – generate a visual map of function calls in a script.
 - [Local Mock API](./LocalMockApi.md) – run a lightweight HTTP server for offline tests.
+- [Stewardship](./Stewardship.md) – how to maintain and hand off the project.
+- [Roadmap](./Roadmap.md) – upcoming features and goals.
 
 
 Command specific help topics live in the `SupportTools`, `SharePointTools` and `ServiceDeskTools` subfolders.

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1,0 +1,9 @@
+# Project Roadmap
+
+This roadmap highlights the major areas of focus for upcoming releases.
+
+1. Publish the modules to an internal feed to simplify installation.
+2. Expand Pester coverage to include ServiceDeskTools scenarios.
+3. Build a simple dashboard that surfaces log files and job history.
+4. Continue refining SharePointTools commands based on user feedback.
+5. Formalize versioning and release notes for each stable release.

--- a/docs/Stewardship.md
+++ b/docs/Stewardship.md
@@ -1,0 +1,27 @@
+# Long-Term Stewardship
+
+This guide explains how to keep the PowerShell modules healthy over time and prepare others to take over maintenance when needed.
+
+## Succession Planning
+
+- Keep the documentation in the `docs` folder current. Update examples whenever commands change.
+- Archive resolved issues and tag open work with clear priority labels.
+- Ensure at least two maintainers have rights to publish new module versions and manage CI secrets.
+
+## Module Maturity
+
+| Module            | Status       |
+|-------------------|-------------|
+| SupportTools      | Stable      |
+| SharePointTools   | Beta        |
+| ServiceDeskTools  | Experimental|
+
+## Backup Strategy
+
+- Store job histories, logs, and module state outside of this repository in a shared location.
+- Periodically export any `$PSFramework` data stores and configuration files.
+- Retain CI logs for at least 90 days to aid troubleshooting.
+
+## Weekly Self-Tests
+
+Set up a cron job or scheduled task to run `Invoke-Pester` across the repository every week. Review the results and update dependencies as required.


### PR DESCRIPTION
## Summary
- document long term stewardship including backup strategy and self-tests
- add a new roadmap file
- reference new docs in `docs/README.md`
- show module maturity ratings in the main `README.md`

## Testing
- `pwsh` command failed: command not found
- `apt-get install -y powershell` failed: unable to locate package

------
https://chatgpt.com/codex/tasks/task_e_684384887ef0832ca0b7a8ed884276fc