### PR TITLE
Auto-generate module exports

### DIFF
--- a/src/ServiceDeskTools/ServiceDeskTools.psd1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psd1
@@ -4,8 +4,5 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000003'
     Author = 'Contoso'
     Description = 'Commands for interacting with the Service Desk ticketing system.'
-    FunctionsToExport = @(
-        'Get-SDTicket','New-SDTicket','Set-SDTicket',
-        'Search-SDTicket','Set-SDTicketBulk','Link-SDTicketToSPTask'
-    )
+    FunctionsToExport = '*'
 }

--- a/src/ServiceDeskTools/ServiceDeskTools.psm1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psm1
@@ -3,7 +3,11 @@ $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 Import-Module $loggingModule -ErrorAction SilentlyContinue
 
-Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
-Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
+Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue |
+    ForEach-Object { . $_.FullName }
+Get-ChildItem -Path "$PublicDir" -Filter *.ps1 -ErrorAction SilentlyContinue |
+    ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Get-SDTicket','New-SDTicket','Set-SDTicket','Search-SDTicket','Set-SDTicketBulk','Link-SDTicketToSPTask'
+Export-ModuleMember -Function (
+    Get-ChildItem "$PublicDir/*.ps1" -ErrorAction SilentlyContinue
+).BaseName

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -4,26 +4,5 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000001'
     Author = 'Contoso'
     Description = 'Collection of helper functions wrapping existing scripts.'
-    FunctionsToExport = @(
-        'Add-UserToGroup',
-        'Clear-ArchiveFolder',
-        'Clear-TempFile',
-        'Convert-ExcelToCsv',
-        'Get-CommonSystemInfo',
-        'Get-FailedLogin',
-        'Get-NetworkShare',
-        'Get-UniquePermission',
-        'Install-Font',
-        'Invoke-PostInstall',
-        'Export-ProductKey',
-        'Invoke-DeploymentTemplate',
-        'Search-ReadMe',
-        'Set-ComputerIPAddress',
-        'Set-NetAdapterMetering',
-        'Set-TimeZoneEasternStandardTime',
-        'Start-Countdown',
-        'Update-Sysmon',
-        'Set-SharedMailboxAutoReply',
-        'Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket','Generate-SPUsageReport','Install-MaintenanceTasks','Invoke-GroupMembershipCleanup'
-    )
+    FunctionsToExport = '*'
 }

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -5,10 +5,14 @@ $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetr
 Import-Module $loggingModule -ErrorAction SilentlyContinue
 Import-Module $telemetryModule -ErrorAction SilentlyContinue
 
-Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
-Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
+Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue |
+    ForEach-Object { . $_.FullName }
+Get-ChildItem -Path "$PublicDir" -Filter *.ps1 -ErrorAction SilentlyContinue |
+    ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Add-UserToGroup','Clear-ArchiveFolder','Restore-ArchiveFolder','Clear-TempFile','Convert-ExcelToCsv','Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Get-UniquePermission','Install-Font','Invoke-PostInstall','Export-ProductKey','Invoke-DeploymentTemplate','Search-ReadMe','Set-ComputerIPAddress','Set-NetAdapterMetering','Set-TimeZoneEasternStandardTime','Start-Countdown','Update-Sysmon','Set-SharedMailboxAutoReply','Invoke-ExchangeCalendarManager','Invoke-CompanyPlaceManagement','Submit-SystemInfoTicket','Generate-SPUsageReport'
+Export-ModuleMember -Function (
+    Get-ChildItem "$PublicDir/*.ps1" -ErrorAction SilentlyContinue
+).BaseName
 
 
 function Show-SupportToolsBanner {


### PR DESCRIPTION
## Summary
- auto-register public functions in ServiceDeskTools and SupportTools modules
- rely on manifest wildcard for exported functions

## Testing
- `pwsh -NoLogo -Command '$config = Import-PowerShellDataFile "PesterConfiguration.psd1"; Invoke-Pester -Configuration $config'` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684383a7329c832caa1457e53c2a3613