### PR TITLE
Update Pester invocation

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -25,7 +25,7 @@ jobs:
         shell: pwsh
         run: |
           $cfg = Import-PowerShellDataFile ./PesterConfiguration.psd1
-          Invoke-Pester -Configuration $cfg -CI
+          Invoke-Pester -Configuration $cfg
       - uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/PesterConfiguration.psd1
+++ b/PesterConfiguration.psd1
@@ -1,5 +1,6 @@
 @{
     Run = @{ Path = 'tests'; Exit = $true }
+    TestResult = @{ Enabled = $true; OutputFormat = 'NUnitXml'; OutputPath = 'TestResults.xml' }
     CodeCoverage = @{
         Enabled = $true
         Path = @('src/**/*.ps1','scripts/*.ps1')


### PR DESCRIPTION
## Summary
- capture test results in Pester configuration
- adjust GitHub workflow to drop the invalid `-CI` flag

## Testing
- `pwsh -NoLogo -Command '$cfg = Import-PowerShellDataFile "./PesterConfiguration.psd1"; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_684385c36758832c888f21e445eaeaac