### PR TITLE
Fix labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,9 @@
 documentation:
-  - docs/**
+  - changed-files:
+      - any-glob-to-any-file: docs/**
 enhancement:
-  - src/**
+  - changed-files:
+      - any-glob-to-any-file: src/**
 tests:
-  - tests/**
+  - changed-files:
+      - any-glob-to-any-file: tests/**


### PR DESCRIPTION
## Summary
- update labeler config to use actions/labeler v5 syntax

## Testing
- `pwsh -NoLogo -NoProfile -Command '$cfg = Import-PowerShellDataFile ./PesterConfiguration.psd1; Invoke-Pester -Configuration $cfg'` *(fails: no modules named 'SupportTools')*

------
https://chatgpt.com/codex/tasks/task_e_68438755662c832c840fac5c60bea3bf