### PR TITLE
Include module version in error logs

### DIFF
--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -16,6 +16,13 @@ function Invoke-ScriptFile {
         [string]$TranscriptPath,
         [switch]$Simulate
     )
+    # Retrieve the SupportTools module version for log metadata
+    $manifest = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'SupportTools.psd1'
+    $moduleVersion = try {
+        (Import-PowerShellDataFile $manifest).ModuleVersion
+    } catch {
+        'unknown'
+    }
     $Path = Join-Path $PSScriptRoot '..' |
             Join-Path -ChildPath '..' |
             Join-Path -ChildPath '..' |
@@ -51,7 +58,7 @@ function Invoke-ScriptFile {
         & $Path @Args
     } catch {
         Write-Error "Execution of '$Name' failed: $_"
-        Write-STLog "Execution of '$Name' failed: $_" -Level 'ERROR'
+        Write-STLog "Execution of '$Name' failed: $_" -Level 'ERROR' -Structured -Metadata @{ version = $moduleVersion; script = $Name }
         $result = 'Failure'
         throw
     } finally {

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -5,6 +5,14 @@ $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetr
 Import-Module $loggingModule -ErrorAction SilentlyContinue
 Import-Module $telemetryModule -ErrorAction SilentlyContinue
 
+# Determine the version of the SupportTools module for logging purposes
+$manifestPath = Join-Path $PSScriptRoot 'SupportTools.psd1'
+$STModuleVersion = try {
+    (Import-PowerShellDataFile $manifestPath).ModuleVersion
+} catch {
+    'unknown'
+}
+
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue |
     ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir" -Filter *.ps1 -ErrorAction SilentlyContinue |


### PR DESCRIPTION
## Summary
- capture `SupportTools` module version when imported
- attach version metadata to structured failure logs in `Invoke-ScriptFile`

## Testing
- `pwsh -NoLogo -NoProfile -File run_tests.ps1` *(fails: No modules named 'SupportTools' are currently loaded)*

------
https://chatgpt.com/codex/tasks/task_e_684387a031f4832c86b8b976adfb5fd3