### PR TITLE
Add metric logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Commands automatically record their activity to `%USERPROFILE%\SupportToolsLogs\
 Set the `ST_LOG_PATH` environment variable or use the `-Path` parameter of `Write-STLog` to write logs to a custom location.
 Use `-Structured` to emit JSON lines that include the current user and script name for ingestion into tools like Azure Log Analytics.
 Set `ST_LOG_STRUCTURED=1` to enable structured output without adding the switch each time.
+Use `-Metric` and `-Value` with `Write-STLog` to capture performance data like durations.
 Review the resulting log file with `Get-Content` when troubleshooting.
 
 ## Roadmap 🛣️

--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -15,6 +15,7 @@ schema: 2.0.0
 ```
 Write-STLog [-Message] <String> [[-Level] <String>] [[-Path] <String>] [-ProgressAction <ActionPreference>]
 [[-Metadata] <Hashtable>] [-Structured]
+[[-Metric] <String>] [[-Value] <Double>]
 [<CommonParameters>]
 ```
 
@@ -25,10 +26,12 @@ Write-STLog [-Message] <String> [[-Level] <String>] [[-Path] <String>] [-Progres
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> $sw = [System.Diagnostics.Stopwatch]::StartNew()
+PS C:\> # ... task runs ...
+PS C:\> $sw.Stop()
+PS C:\> Write-STLog -Metric 'Duration' -Value $sw.Elapsed.TotalSeconds
 ```
-
-{{ Add example description here }}
+Records how long the task took in seconds using a structured log entry.
 
 ## PARAMETERS
 
@@ -107,6 +110,34 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 Set the `ST_LOG_STRUCTURED` environment variable to `1` to enable structured output by default.
+
+### -Metric
+Name of a metric to record. Automatically enables structured output.
+```yaml
+Type: String
+Parameter Sets: Metric
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Value
+Numeric value associated with `-Metric`.
+```yaml
+Type: Double
+Parameter Sets: Metric
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -ProgressAction
 {{ Fill ProgressAction Description }}

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -10,16 +10,27 @@ if ($SupportToolsConfig.maintenanceMode) {
 }
 
 function Write-STLog {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Message')]
     param(
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ParameterSetName='Message')]
         [string]$Message,
         [ValidateSet('INFO','WARN','ERROR')]
         [string]$Level = 'INFO',
         [string]$Path,
         [hashtable]$Metadata,
-        [switch]$Structured
+        [switch]$Structured,
+        [Parameter(Mandatory, ParameterSetName='Metric')]
+        [string]$Metric,
+        [Parameter(Mandatory, ParameterSetName='Metric')]
+        [double]$Value
     )
+    if ($PSCmdlet.ParameterSetName -eq 'Metric') {
+        if (-not $Metadata) { $Metadata = @{} }
+        $Metadata.metric = $Metric
+        $Metadata.value  = $Value
+        $Message = $Metric
+        if (-not $Structured) { $Structured = $true }
+    }
     if (-not $Structured -and $env:ST_LOG_STRUCTURED -eq '1') {
         $Structured = $true
     }

--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -43,7 +43,7 @@ function Invoke-ScriptFile {
         Start-Transcript -Path $TranscriptPath -Append | Out-Null
     }
 
-    $start = Get-Date
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $result = 'Success'
     $oldPref = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'
@@ -57,7 +57,9 @@ function Invoke-ScriptFile {
     } finally {
         $ErrorActionPreference = $oldPref
         if ($TranscriptPath) { Stop-Transcript | Out-Null }
-        $duration = (Get-Date) - $start
+        $sw.Stop()
+        $duration = $sw.Elapsed
+        Write-STLog -Metric 'Duration' -Value $duration.TotalSeconds
         Write-STTelemetryEvent -ScriptName $Name -Result $result -Duration $duration
     }
     Write-STStatus "COMPLETED $Name" -Level FINAL -Log

--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -117,4 +117,16 @@ Describe 'Logging Module' {
             Remove-Item $temp -ErrorAction SilentlyContinue
         }
     }
+
+    It 'logs metric entries' {
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            Write-STLog -Metric 'Duration' -Value 2.5 -Path $temp
+            $json = Get-Content $temp | ConvertFrom-Json
+            $json.metric | Should -Be 'Duration'
+            $json.value  | Should -Be 2.5
+        } finally {
+            Remove-Item $temp -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- measure script duration using Stopwatch
- support `-Metric`/`-Value` in `Write-STLog`
- document metric logging and provide example
- test metric logging

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration PesterConfiguration.psd1"` *(fails: pwsh not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843882c07dc832c895300adc427cc19