### PR TITLE
Add job bundle execution support

### DIFF
--- a/scripts/Run-JobBundle.ps1
+++ b/scripts/Run-JobBundle.ps1
@@ -1,0 +1,67 @@
+<#+
+.SYNOPSIS
+    Executes a job packaged as a portable .job.zip bundle.
+.DESCRIPTION
+    The bundle is extracted to a temporary directory. job.json describes the
+    script to run and optional arguments. Any modules found in the
+    'dependencies' folder are added to $env:PSModulePath for the duration of the
+    job. After the script runs the temporary directory is removed.
+.PARAMETER BundlePath
+    Path to the .job.zip file.
+.EXAMPLE
+    ./Run-JobBundle.ps1 -BundlePath ./AddUsersToGroup.job.zip
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$BundlePath
+)
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+
+if (-not (Test-Path $BundlePath)) {
+    throw "Bundle not found: $BundlePath"
+}
+
+Write-STStatus "Unpacking bundle $BundlePath" -Level INFO
+$tempDir = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString())
+Expand-Archive -Path $BundlePath -DestinationPath $tempDir -Force
+
+$jobFile = Join-Path $tempDir 'job.json'
+if (-not (Test-Path $jobFile)) {
+    throw 'job.json not found in bundle.'
+}
+$job = Get-Content $jobFile | ConvertFrom-Json
+
+$scriptName = if ($job.Script) { $job.Script } else { 'job.ps1' }
+$scriptPath = Join-Path $tempDir $scriptName
+if (-not (Test-Path $scriptPath)) {
+    throw "Job script not found: $scriptPath"
+}
+
+$depDir = Join-Path $tempDir 'dependencies'
+if (Test-Path $depDir) {
+    $env:PSModulePath = "$depDir$([IO.Path]::PathSeparator)$env:PSModulePath"
+}
+
+Push-Location $tempDir
+$result = 'Success'
+$start = Get-Date
+try {
+    if ($job.Parameters) {
+        & $scriptPath @($job.Parameters)
+    } else {
+        & $scriptPath
+    }
+} catch {
+    Write-STLog "Job bundle execution failed: $_" -Level 'ERROR'
+    $result = 'Failure'
+    throw
+} finally {
+    $duration = (Get-Date) - $start
+    Write-STTelemetryEvent -ScriptName (Split-Path $scriptPath -Leaf) -Result $result -Duration $duration
+    Pop-Location
+    Remove-Item $tempDir -Recurse -Force
+}
+

--- a/src/SupportTools/Public/Invoke-JobBundle.ps1
+++ b/src/SupportTools/Public/Invoke-JobBundle.ps1
@@ -1,0 +1,43 @@
+function Invoke-JobBundle {
+    <#
+    .SYNOPSIS
+        Runs a job packaged as a .job.zip bundle.
+    .DESCRIPTION
+        Unpacks the specified bundle, executes the job script described in
+        job.json and archives the transcript and SupportTools log.
+    .PARAMETER Path
+        Path to the job bundle (.job.zip).
+    .PARAMETER LogArchivePath
+        Optional path to save the resulting log archive. Defaults to
+        '<bundle>.logs.zip'.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName=$true)]
+        [string]$Path,
+        [string]$LogArchivePath
+    )
+
+    process {
+        if (-not $LogArchivePath) {
+            $LogArchivePath = $Path -replace '\\.zip$','-logs.zip'
+        }
+
+        $transcript = [IO.Path]::GetTempFileName()
+        $args = @('-BundlePath', $Path)
+        Invoke-ScriptFile -Name 'Run-JobBundle.ps1' -Args $args -TranscriptPath $transcript
+
+        $logFile = if ($env:ST_LOG_PATH) {
+            $env:ST_LOG_PATH
+        } else {
+            $profile = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
+            Join-Path (Join-Path $profile 'SupportToolsLogs') 'supporttools.log'
+        }
+
+        $files = @($transcript)
+        if (Test-Path $logFile) { $files += $logFile }
+        Compress-Archive -Path $files -DestinationPath $LogArchivePath -Force
+        Remove-Item $transcript -Force
+        Write-STStatus "Logs archived to $LogArchivePath" -Level SUCCESS
+    }
+}

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -32,6 +32,7 @@ Describe 'SupportTools Module' {
             'Install-MaintenanceTasks'
             'Invoke-GroupMembershipCleanup'
             'Sync-SupportTools'
+            'Invoke-JobBundle'
         )
 
         $exported = (Get-Command -Module SupportTools).Name
@@ -67,6 +68,7 @@ Describe 'SupportTools Module' {
             Generate_SPUsageReport       = 'Generate-SPUsageReport.ps1'
             Install_MaintenanceTasks = 'Setup-ScheduledMaintenance.ps1'
             Invoke_GroupMembershipCleanup = 'CleanupGroupMembership.ps1'
+            Invoke_JobBundle = 'Run-JobBundle.ps1'
         }
 
         $cases = foreach ($entry in $map.GetEnumerator()) {


### PR DESCRIPTION
## Summary
- allow running .job.zip bundles via new `Invoke-JobBundle` command
- add helper script `Run-JobBundle.ps1` to unpack and run the job
- test updates to track new command

## Testing
- `pwsh -NoLogo -NoProfile -Command '$cfg = Import-PowerShellDataFile "./PesterConfiguration.psd1"; Invoke-Pester -Configuration $cfg'` *(fails: No modules named 'SupportTools')*

------
https://chatgpt.com/codex/tasks/task_e_684388b5bfa0832c9c41ffcbbb575631