### PR TITLE
Add -Explain flag for training mode

### DIFF
--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -17,6 +17,12 @@ All commands now accept a `-Simulate` switch. When used, the command logs each
 step and returns randomized mock data without making changes. This is useful for
 testing in lab environments.
 
+### Learning Mode
+
+Use the `-Explain` switch with any command to view the underlying script's
+full help content instead of executing it. This is useful when training new
+administrators on what each task does.
+
 ## Available Commands
 
 The table below lists each command and the script it invokes. Arguments not

--- a/src/ServiceDeskTools/Public/Get-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDTicket.ps1
@@ -8,8 +8,14 @@ function Get-SDTicket {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][int]$Id,
-        [switch]$ChaosMode
+        [switch]$ChaosMode,
+        [switch]$Explain
     )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
 
     Write-STLog "Get-SDTicket $Id"
     Invoke-SDRequest -Method 'GET' -Path "/incidents/$Id.json" -ChaosMode:$ChaosMode

--- a/src/ServiceDeskTools/Public/Link-SDTicketToSPTask.ps1
+++ b/src/ServiceDeskTools/Public/Link-SDTicketToSPTask.ps1
@@ -14,8 +14,14 @@ function Link-SDTicketToSPTask {
         [Parameter(Mandatory)][int]$TicketId,
         [Parameter(Mandatory)][string]$TaskUrl,
         [string]$FieldName = 'sharepoint_task_url',
-        [switch]$ChaosMode
+        [switch]$ChaosMode,
+        [switch]$Explain
     )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
 
     Write-STLog "Link-SDTicketToSPTask $TicketId $TaskUrl"
     $fields = @{ $FieldName = $TaskUrl }

--- a/src/ServiceDeskTools/Public/New-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/New-SDTicket.ps1
@@ -14,8 +14,14 @@ function New-SDTicket {
         [Parameter(Mandatory)][string]$Subject,
         [Parameter(Mandatory)][string]$Description,
         [Parameter(Mandatory)][string]$RequesterEmail,
-        [switch]$ChaosMode
+        [switch]$ChaosMode,
+        [switch]$Explain
     )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
 
     Write-STLog "New-SDTicket $Subject"
     $body = @{ incident = @{ name = $Subject; description = $Description; requester_email = $RequesterEmail } }

--- a/src/ServiceDeskTools/Public/Search-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Search-SDTicket.ps1
@@ -8,8 +8,14 @@ function Search-SDTicket {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Query,
-        [switch]$ChaosMode
+        [switch]$ChaosMode,
+        [switch]$Explain
     )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
 
     Write-STLog "Search-SDTicket $Query"
     $encoded = [uri]::EscapeDataString($Query)

--- a/src/ServiceDeskTools/Public/Set-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicket.ps1
@@ -11,8 +11,14 @@ function Set-SDTicket {
     param(
         [Parameter(Mandatory)][int]$Id,
         [Parameter(Mandatory)][hashtable]$Fields,
-        [switch]$ChaosMode
+        [switch]$ChaosMode,
+        [switch]$Explain
     )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
 
     Write-STLog "Set-SDTicket $Id"
     $body = @{ incident = $Fields }

--- a/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
@@ -11,8 +11,14 @@ function Set-SDTicketBulk {
     param(
         [Parameter(Mandatory)][int[]]$Id,
         [Parameter(Mandatory)][hashtable]$Fields,
-        [switch]$ChaosMode
+        [switch]$ChaosMode,
+        [switch]$Explain
     )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
 
     foreach ($ticketId in $Id) {
         Write-STLog "Set-SDTicketBulk $ticketId"

--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -14,13 +14,19 @@ function Invoke-ScriptFile {
         [Parameter(ValueFromRemainingArguments=$true)]
         [object[]]$Args,
         [string]$TranscriptPath,
-        [switch]$Simulate
+        [switch]$Simulate,
+        [switch]$Explain
     )
     $Path = Join-Path $PSScriptRoot '..' |
             Join-Path -ChildPath '..' |
             Join-Path -ChildPath '..' |
             Join-Path -ChildPath "scripts/$Name"
     if (-not (Test-Path $Path)) { throw "Script '$Name' not found." }
+
+    if ($Explain) {
+        Get-Help $Path -Full
+        return
+    }
 
     Write-STStatus "EXECUTING $Name" -Level SUCCESS -Log
     if ($Args) {

--- a/src/SupportTools/Public/Add-UserToGroup.ps1
+++ b/src/SupportTools/Public/Add-UserToGroup.ps1
@@ -16,8 +16,9 @@ function Add-UserToGroup {
         [string]$CsvPath,
         [Parameter(ValueFromPipelineByPropertyName=$true)]
         [string]$GroupName,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
+        [switch]$Explain
     )
 
     process {
@@ -31,6 +32,6 @@ function Add-UserToGroup {
             $arguments += $GroupName
         }
 
-        Invoke-ScriptFile -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Clear-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Clear-ArchiveFolder.ps1
@@ -10,10 +10,12 @@ function Clear-ArchiveFolder {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
+        [switch]$Explain
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Clear-TempFile.ps1
+++ b/src/SupportTools/Public/Clear-TempFile.ps1
@@ -11,8 +11,9 @@ function Clear-TempFile {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "CleanupTempFiles.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "CleanupTempFiles.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Convert-ExcelToCsv.ps1
+++ b/src/SupportTools/Public/Convert-ExcelToCsv.ps1
@@ -10,10 +10,12 @@ function Convert-ExcelToCsv {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
+        [switch]$Explain
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Convert-ExcelToCsv.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "Convert-ExcelToCsv.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Export-ProductKey.ps1
+++ b/src/SupportTools/Public/Export-ProductKey.ps1
@@ -12,8 +12,9 @@ function Export-ProductKey {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "ProductKey.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "ProductKey.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Generate-SPUsageReport.ps1
+++ b/src/SupportTools/Public/Generate-SPUsageReport.ps1
@@ -11,8 +11,9 @@ function Generate-SPUsageReport {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name 'Generate-SPUsageReport.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name 'Generate-SPUsageReport.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Get-CommonSystemInfo.ps1
+++ b/src/SupportTools/Public/Get-CommonSystemInfo.ps1
@@ -10,10 +10,12 @@ function Get-CommonSystemInfo {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
+        [switch]$Explain
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Get-CommonSystemInfo.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "Get-CommonSystemInfo.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Get-FailedLogin.ps1
+++ b/src/SupportTools/Public/Get-FailedLogin.ps1
@@ -12,8 +12,9 @@ function Get-FailedLogin {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Get-FailedLogins.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "Get-FailedLogins.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Get-NetworkShare.ps1
+++ b/src/SupportTools/Public/Get-NetworkShare.ps1
@@ -12,8 +12,9 @@ function Get-NetworkShare {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Get-NetworkShares.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "Get-NetworkShares.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Get-UniquePermission.ps1
+++ b/src/SupportTools/Public/Get-UniquePermission.ps1
@@ -12,8 +12,9 @@ function Get-UniquePermission {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Get-UniquePermissions.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "Get-UniquePermissions.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Install-Font.ps1
+++ b/src/SupportTools/Public/Install-Font.ps1
@@ -12,8 +12,9 @@ function Install-Font {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Install-Fonts.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "Install-Fonts.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Install-MaintenanceTasks.ps1
+++ b/src/SupportTools/Public/Install-MaintenanceTasks.ps1
@@ -13,10 +13,11 @@ function Install-MaintenanceTasks {
         [switch]$Register,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
         $argsList = @()
         if ($Register) { $argsList += '-Register' }
-        Invoke-ScriptFile -Name 'Setup-ScheduledMaintenance.ps1' -Args $argsList -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name 'Setup-ScheduledMaintenance.ps1' -Args $argsList -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Invoke-CompanyPlaceManagement.ps1
+++ b/src/SupportTools/Public/Invoke-CompanyPlaceManagement.ps1
@@ -29,8 +29,14 @@ function Invoke-CompanyPlaceManagement {
         [string]$CountryOrRegion,
         [switch]$AutoAddFloor,
         [string]$TranscriptPath
-        [switch]$Simulate
+        [switch]$Simulate,
+        [switch]$Explain
     )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
 
     if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
     Write-STStatus "Invoke-CompanyPlaceManagement -Action $Action" -Level SUCCESS -Log

--- a/src/SupportTools/Public/Invoke-DeploymentTemplate.ps1
+++ b/src/SupportTools/Public/Invoke-DeploymentTemplate.ps1
@@ -12,8 +12,9 @@ function Invoke-DeploymentTemplate {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "SS_DEPLOYMENT_TEMPLATE.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "SS_DEPLOYMENT_TEMPLATE.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -9,8 +9,14 @@ function Invoke-ExchangeCalendarManager {
     [CmdletBinding()]
     param(
         [string]$TranscriptPath
-        [switch]$Simulate
+        [switch]$Simulate,
+        [switch]$Explain
     )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
 
     if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
     Write-STStatus 'ExchangeCalendarManager launched' -Level SUCCESS -Log

--- a/src/SupportTools/Public/Invoke-GroupMembershipCleanup.ps1
+++ b/src/SupportTools/Public/Invoke-GroupMembershipCleanup.ps1
@@ -15,12 +15,13 @@ function Invoke-GroupMembershipCleanup {
         [string]$CsvPath,
         [Parameter(ValueFromPipelineByPropertyName=$true)]
         [string]$GroupName,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
+        [switch]$Explain
     )
     process {
         $arguments = @()
         if ($PSBoundParameters.ContainsKey('CsvPath')) { $arguments += '-CsvPath'; $arguments += $CsvPath }
         if ($PSBoundParameters.ContainsKey('GroupName')) { $arguments += '-GroupName'; $arguments += $GroupName }
-        Invoke-ScriptFile -Name 'CleanupGroupMembership.ps1' -Args $arguments -TranscriptPath $TranscriptPath
+        Invoke-ScriptFile -Name 'CleanupGroupMembership.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Invoke-PostInstall.ps1
+++ b/src/SupportTools/Public/Invoke-PostInstall.ps1
@@ -12,8 +12,9 @@ function Invoke-PostInstall {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "PostInstallScript.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "PostInstallScript.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Restore-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Restore-ArchiveFolder.ps1
@@ -12,8 +12,9 @@ function Restore-ArchiveFolder {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "RollbackArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "RollbackArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Search-ReadMe.ps1
+++ b/src/SupportTools/Public/Search-ReadMe.ps1
@@ -12,8 +12,9 @@ function Search-ReadMe {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Search-ReadMe.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "Search-ReadMe.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Set-ComputerIPAddress.ps1
+++ b/src/SupportTools/Public/Set-ComputerIPAddress.ps1
@@ -11,8 +11,9 @@ function Set-ComputerIPAddress {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Set-ComputerIPAddress.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "Set-ComputerIPAddress.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Set-NetAdapterMetering.ps1
+++ b/src/SupportTools/Public/Set-NetAdapterMetering.ps1
@@ -12,8 +12,9 @@ function Set-NetAdapterMetering {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Set-NetAdapterMetering.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "Set-NetAdapterMetering.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
+++ b/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
@@ -23,8 +23,14 @@ function Set-SharedMailboxAutoReply {
         [string]$AdminUser,
         [switch]$UseWebLogin,
         [string]$TranscriptPath
-        [switch]$Simulate
+        [switch]$Simulate,
+        [switch]$Explain
     )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
 
     if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
     Write-STStatus 'Running Set-SharedMailboxAutoReply' -Level SUCCESS -Log

--- a/src/SupportTools/Public/Set-TimeZoneEasternStandardTime.ps1
+++ b/src/SupportTools/Public/Set-TimeZoneEasternStandardTime.ps1
@@ -12,8 +12,9 @@ function Set-TimeZoneEasternStandardTime {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Set-TimeZoneEasternStandardTime.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "Set-TimeZoneEasternStandardTime.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Start-Countdown.ps1
+++ b/src/SupportTools/Public/Start-Countdown.ps1
@@ -12,8 +12,9 @@ function Start-Countdown {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "SimpleCountdown.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "SimpleCountdown.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Submit-SystemInfoTicket.ps1
+++ b/src/SupportTools/Public/Submit-SystemInfoTicket.ps1
@@ -15,6 +15,7 @@ function Submit-SystemInfoTicket {
         [string]$FolderPath,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
         $arguments = @('-SiteName', $SiteName, '-RequesterEmail', $RequesterEmail)
@@ -22,6 +23,6 @@ function Submit-SystemInfoTicket {
         if ($PSBoundParameters.ContainsKey('Description')) { $arguments += @('-Description', $Description) }
         if ($PSBoundParameters.ContainsKey('LibraryName')) { $arguments += @('-LibraryName', $LibraryName) }
         if ($PSBoundParameters.ContainsKey('FolderPath'))  { $arguments += @('-FolderPath', $FolderPath) }
-        Invoke-ScriptFile -Name 'Submit-SystemInfoTicket.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name 'Submit-SystemInfoTicket.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Sync-SupportTools.ps1
+++ b/src/SupportTools/Public/Sync-SupportTools.ps1
@@ -13,8 +13,14 @@ function Sync-SupportTools {
     [CmdletBinding()]
     param(
         [string]$RepositoryUrl = 'https://github.com/yourlastnamesoundslikeatypeofpasta/PowerShell.git',
-        [string]$InstallPath = $(if ($env:USERPROFILE) { Join-Path $env:USERPROFILE 'SupportTools' } else { Join-Path $env:HOME 'SupportTools' })
+        [string]$InstallPath = $(if ($env:USERPROFILE) { Join-Path $env:USERPROFILE 'SupportTools' } else { Join-Path $env:HOME 'SupportTools' }),
+        [switch]$Explain
     )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
 
     if (Test-Path (Join-Path $InstallPath '.git')) {
         git -C $InstallPath pull

--- a/src/SupportTools/Public/Update-Sysmon.ps1
+++ b/src/SupportTools/Public/Update-Sysmon.ps1
@@ -11,8 +11,9 @@ function Update-Sysmon {
         [object[]]$Arguments,
         [string]$TranscriptPath
         [switch]$Simulate
+        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Update-Sysmon.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate
+        Invoke-ScriptFile -Name "Update-Sysmon.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }


### PR DESCRIPTION
## Summary
- support a new `-Explain` switch in `Invoke-ScriptFile`
- expose `-Explain` on all exported commands
- document Learning Mode in SupportTools docs

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)"` *(fails: No modules named 'SupportTools' are currently loaded)*

------
https://chatgpt.com/codex/tasks/task_e_684388d181b0832ca31979b8f3d8ec04