### PR TITLE
Fix parameter blocks in SupportTools module

### DIFF
--- a/src/SupportTools/Public/Add-UserToGroup.ps1
+++ b/src/SupportTools/Public/Add-UserToGroup.ps1
@@ -16,7 +16,7 @@ function Add-UserToGroup {
         [string]$CsvPath,
         [Parameter(ValueFromPipelineByPropertyName=$true)]
         [string]$GroupName,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
 

--- a/src/SupportTools/Public/Clear-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Clear-ArchiveFolder.ps1
@@ -10,7 +10,7 @@ function Clear-ArchiveFolder {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Clear-TempFile.ps1
+++ b/src/SupportTools/Public/Clear-TempFile.ps1
@@ -9,7 +9,7 @@ function Clear-TempFile {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Convert-ExcelToCsv.ps1
+++ b/src/SupportTools/Public/Convert-ExcelToCsv.ps1
@@ -10,7 +10,7 @@ function Convert-ExcelToCsv {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Export-ProductKey.ps1
+++ b/src/SupportTools/Public/Export-ProductKey.ps1
@@ -10,7 +10,7 @@ function Export-ProductKey {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Generate-SPUsageReport.ps1
+++ b/src/SupportTools/Public/Generate-SPUsageReport.ps1
@@ -9,7 +9,7 @@ function Generate-SPUsageReport {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Get-CommonSystemInfo.ps1
+++ b/src/SupportTools/Public/Get-CommonSystemInfo.ps1
@@ -10,7 +10,7 @@ function Get-CommonSystemInfo {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Get-FailedLogin.ps1
+++ b/src/SupportTools/Public/Get-FailedLogin.ps1
@@ -10,7 +10,7 @@ function Get-FailedLogin {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Get-NetworkShare.ps1
+++ b/src/SupportTools/Public/Get-NetworkShare.ps1
@@ -10,7 +10,7 @@ function Get-NetworkShare {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Get-UniquePermission.ps1
+++ b/src/SupportTools/Public/Get-UniquePermission.ps1
@@ -10,7 +10,7 @@ function Get-UniquePermission {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Install-Font.ps1
+++ b/src/SupportTools/Public/Install-Font.ps1
@@ -10,7 +10,7 @@ function Install-Font {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Install-MaintenanceTasks.ps1
+++ b/src/SupportTools/Public/Install-MaintenanceTasks.ps1
@@ -11,7 +11,7 @@ function Install-MaintenanceTasks {
     [CmdletBinding()]
     param(
         [switch]$Register,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Invoke-CompanyPlaceManagement.ps1
+++ b/src/SupportTools/Public/Invoke-CompanyPlaceManagement.ps1
@@ -28,7 +28,7 @@ function Invoke-CompanyPlaceManagement {
         [string]$PostalCode,
         [string]$CountryOrRegion,
         [switch]$AutoAddFloor,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
 

--- a/src/SupportTools/Public/Invoke-DeploymentTemplate.ps1
+++ b/src/SupportTools/Public/Invoke-DeploymentTemplate.ps1
@@ -10,7 +10,7 @@ function Invoke-DeploymentTemplate {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -8,7 +8,7 @@ function Invoke-ExchangeCalendarManager {
     #>
     [CmdletBinding()]
     param(
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
 

--- a/src/SupportTools/Public/Invoke-PostInstall.ps1
+++ b/src/SupportTools/Public/Invoke-PostInstall.ps1
@@ -10,7 +10,7 @@ function Invoke-PostInstall {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Restore-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Restore-ArchiveFolder.ps1
@@ -10,7 +10,7 @@ function Restore-ArchiveFolder {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Search-ReadMe.ps1
+++ b/src/SupportTools/Public/Search-ReadMe.ps1
@@ -10,7 +10,7 @@ function Search-ReadMe {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Set-ComputerIPAddress.ps1
+++ b/src/SupportTools/Public/Set-ComputerIPAddress.ps1
@@ -9,7 +9,7 @@ function Set-ComputerIPAddress {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Set-NetAdapterMetering.ps1
+++ b/src/SupportTools/Public/Set-NetAdapterMetering.ps1
@@ -10,7 +10,7 @@ function Set-NetAdapterMetering {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
+++ b/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
@@ -22,7 +22,7 @@ function Set-SharedMailboxAutoReply {
         [Parameter(Mandatory)]
         [string]$AdminUser,
         [switch]$UseWebLogin,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
 

--- a/src/SupportTools/Public/Set-TimeZoneEasternStandardTime.ps1
+++ b/src/SupportTools/Public/Set-TimeZoneEasternStandardTime.ps1
@@ -10,7 +10,7 @@ function Set-TimeZoneEasternStandardTime {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Start-Countdown.ps1
+++ b/src/SupportTools/Public/Start-Countdown.ps1
@@ -10,7 +10,7 @@ function Start-Countdown {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Submit-SystemInfoTicket.ps1
+++ b/src/SupportTools/Public/Submit-SystemInfoTicket.ps1
@@ -7,13 +7,13 @@ function Submit-SystemInfoTicket {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$SiteName,
-        [Parameter(Mandatory)][string]$RequesterEmail,
+        [string]$SiteName,
+        [string]$RequesterEmail,
         [string]$Subject,
         [string]$Description,
         [string]$LibraryName,
         [string]$FolderPath,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {

--- a/src/SupportTools/Public/Update-Sysmon.ps1
+++ b/src/SupportTools/Public/Update-Sysmon.ps1
@@ -9,7 +9,7 @@ function Update-Sysmon {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate
     )
     process {


### PR DESCRIPTION
## Summary
- fix missing commas in SupportTools public functions
- drop mandatory attribute from Submit-SystemInfoTicket parameters

## Testing
- `Invoke-Pester -Path tests -CI` *(fails: Tests Passed: 134, Failed: 9)*

------
https://chatgpt.com/codex/tasks/task_e_6843841bc698832c86914d8ddacd0fb3