### PR TITLE
Fix SupportTools export and syntax

### DIFF
--- a/src/SupportTools/Public/Add-UserToGroup.ps1
+++ b/src/SupportTools/Public/Add-UserToGroup.ps1
@@ -32,6 +32,6 @@ function Add-UserToGroup {
             $arguments += $GroupName
         }
 
-        Invoke-ScriptFile -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain -Explain:$Explain
+        Invoke-ScriptFile -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Clear-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Clear-ArchiveFolder.ps1
@@ -13,7 +13,6 @@ function Clear-ArchiveFolder {
         [string]$TranscriptPath,
         [switch]$Simulate,
         [switch]$Explain
-        [switch]$Explain
     )
     process {
         Invoke-ScriptFile -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain -Explain:$Explain

--- a/src/SupportTools/Public/Clear-TempFile.ps1
+++ b/src/SupportTools/Public/Clear-TempFile.ps1
@@ -9,8 +9,8 @@ function Clear-TempFile {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Convert-ExcelToCsv.ps1
+++ b/src/SupportTools/Public/Convert-ExcelToCsv.ps1
@@ -13,9 +13,8 @@ function Convert-ExcelToCsv {
         [string]$TranscriptPath,
         [switch]$Simulate,
         [switch]$Explain
-        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Convert-ExcelToCsv.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain -Explain:$Explain
+        Invoke-ScriptFile -Name "Convert-ExcelToCsv.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Export-ProductKey.ps1
+++ b/src/SupportTools/Public/Export-ProductKey.ps1
@@ -10,8 +10,8 @@ function Export-ProductKey {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Generate-SPUsageReport.ps1
+++ b/src/SupportTools/Public/Generate-SPUsageReport.ps1
@@ -9,8 +9,8 @@ function Generate-SPUsageReport {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Get-CommonSystemInfo.ps1
+++ b/src/SupportTools/Public/Get-CommonSystemInfo.ps1
@@ -13,9 +13,8 @@ function Get-CommonSystemInfo {
         [string]$TranscriptPath,
         [switch]$Simulate,
         [switch]$Explain
-        [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Get-CommonSystemInfo.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain -Explain:$Explain
+        Invoke-ScriptFile -Name "Get-CommonSystemInfo.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Get-FailedLogin.ps1
+++ b/src/SupportTools/Public/Get-FailedLogin.ps1
@@ -10,8 +10,8 @@ function Get-FailedLogin {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Get-NetworkShare.ps1
+++ b/src/SupportTools/Public/Get-NetworkShare.ps1
@@ -10,8 +10,8 @@ function Get-NetworkShare {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Get-UniquePermission.ps1
+++ b/src/SupportTools/Public/Get-UniquePermission.ps1
@@ -10,8 +10,8 @@ function Get-UniquePermission {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Install-Font.ps1
+++ b/src/SupportTools/Public/Install-Font.ps1
@@ -10,8 +10,8 @@ function Install-Font {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Install-MaintenanceTasks.ps1
+++ b/src/SupportTools/Public/Install-MaintenanceTasks.ps1
@@ -11,8 +11,8 @@ function Install-MaintenanceTasks {
     [CmdletBinding()]
     param(
         [switch]$Register,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Invoke-CompanyPlaceManagement.ps1
+++ b/src/SupportTools/Public/Invoke-CompanyPlaceManagement.ps1
@@ -28,7 +28,7 @@ function Invoke-CompanyPlaceManagement {
         [string]$PostalCode,
         [string]$CountryOrRegion,
         [switch]$AutoAddFloor,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate,
         [switch]$Explain
     )

--- a/src/SupportTools/Public/Invoke-DeploymentTemplate.ps1
+++ b/src/SupportTools/Public/Invoke-DeploymentTemplate.ps1
@@ -10,8 +10,8 @@ function Invoke-DeploymentTemplate {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -8,7 +8,7 @@ function Invoke-ExchangeCalendarManager {
     #>
     [CmdletBinding()]
     param(
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate,
         [switch]$Explain
     )

--- a/src/SupportTools/Public/Invoke-PostInstall.ps1
+++ b/src/SupportTools/Public/Invoke-PostInstall.ps1
@@ -10,8 +10,8 @@ function Invoke-PostInstall {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Restore-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Restore-ArchiveFolder.ps1
@@ -10,8 +10,8 @@ function Restore-ArchiveFolder {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Search-ReadMe.ps1
+++ b/src/SupportTools/Public/Search-ReadMe.ps1
@@ -10,11 +10,11 @@ function Search-ReadMe {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "Search-ReadMe.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain -Explain:$Explain
+        Invoke-ScriptFile -Name "Search-ReadMe.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Set-ComputerIPAddress.ps1
+++ b/src/SupportTools/Public/Set-ComputerIPAddress.ps1
@@ -9,8 +9,8 @@ function Set-ComputerIPAddress {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Set-NetAdapterMetering.ps1
+++ b/src/SupportTools/Public/Set-NetAdapterMetering.ps1
@@ -10,8 +10,8 @@ function Set-NetAdapterMetering {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
+++ b/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
@@ -22,7 +22,7 @@ function Set-SharedMailboxAutoReply {
         [Parameter(Mandatory)]
         [string]$AdminUser,
         [switch]$UseWebLogin,
-        [string]$TranscriptPath
+        [string]$TranscriptPath,
         [switch]$Simulate,
         [switch]$Explain
     )

--- a/src/SupportTools/Public/Set-TimeZoneEasternStandardTime.ps1
+++ b/src/SupportTools/Public/Set-TimeZoneEasternStandardTime.ps1
@@ -10,8 +10,8 @@ function Set-TimeZoneEasternStandardTime {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Start-Countdown.ps1
+++ b/src/SupportTools/Public/Start-Countdown.ps1
@@ -10,8 +10,8 @@ function Start-Countdown {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Submit-SystemInfoTicket.ps1
+++ b/src/SupportTools/Public/Submit-SystemInfoTicket.ps1
@@ -13,8 +13,8 @@ function Submit-SystemInfoTicket {
         [string]$Description,
         [string]$LibraryName,
         [string]$FolderPath,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/Public/Update-Sysmon.ps1
+++ b/src/SupportTools/Public/Update-Sysmon.ps1
@@ -9,8 +9,8 @@ function Update-Sysmon {
     param(
         [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
         [object[]]$Arguments,
-        [string]$TranscriptPath
-        [switch]$Simulate
+        [string]$TranscriptPath,
+        [switch]$Simulate,
         [switch]$Explain
     )
     process {

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -5,5 +5,34 @@
     Author = 'Contoso'
     Description = 'Collection of helper functions wrapping existing scripts.'
 
-    FunctionsToExport = '*'
+    FunctionsToExport = @(
+        'Add-UserToGroup',
+        'Clear-ArchiveFolder',
+        'Clear-TempFile',
+        'Convert-ExcelToCsv',
+        'Export-ProductKey',
+        'Generate-SPUsageReport',
+        'Get-CommonSystemInfo',
+        'Get-FailedLogin',
+        'Get-NetworkShare',
+        'Get-UniquePermission',
+        'Install-Font',
+        'Install-MaintenanceTasks',
+        'Invoke-CompanyPlaceManagement',
+        'Invoke-DeploymentTemplate',
+        'Invoke-ExchangeCalendarManager',
+        'Invoke-GroupMembershipCleanup',
+        'Invoke-JobBundle',
+        'Invoke-PostInstall',
+        'Restore-ArchiveFolder',
+        'Search-ReadMe',
+        'Set-ComputerIPAddress',
+        'Set-NetAdapterMetering',
+        'Set-SharedMailboxAutoReply',
+        'Set-TimeZoneEasternStandardTime',
+        'Start-Countdown',
+        'Submit-SystemInfoTicket',
+        'Sync-SupportTools',
+        'Update-Sysmon'
+    )
 }

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -19,9 +19,36 @@ Get-ChildItem -Path "$PublicDir" -Filter *.ps1 -ErrorAction SilentlyContinue |
     ForEach-Object { . $_.FullName }
 
 
-Export-ModuleMember -Function (
-    Get-ChildItem "$PublicDir/*.ps1" -ErrorAction SilentlyContinue
-).BaseName
+Export-ModuleMember -Function @(
+    'Add-UserToGroup',
+    'Clear-ArchiveFolder',
+    'Clear-TempFile',
+    'Convert-ExcelToCsv',
+    'Export-ProductKey',
+    'Generate-SPUsageReport',
+    'Get-CommonSystemInfo',
+    'Get-FailedLogin',
+    'Get-NetworkShare',
+    'Get-UniquePermission',
+    'Install-Font',
+    'Install-MaintenanceTasks',
+    'Invoke-CompanyPlaceManagement',
+    'Invoke-DeploymentTemplate',
+    'Invoke-ExchangeCalendarManager',
+    'Invoke-GroupMembershipCleanup',
+    'Invoke-JobBundle',
+    'Invoke-PostInstall',
+    'Restore-ArchiveFolder',
+    'Search-ReadMe',
+    'Set-ComputerIPAddress',
+    'Set-NetAdapterMetering',
+    'Set-SharedMailboxAutoReply',
+    'Set-TimeZoneEasternStandardTime',
+    'Start-Countdown',
+    'Submit-SystemInfoTicket',
+    'Sync-SupportTools',
+    'Update-Sysmon'
+)
 
 
 function Show-SupportToolsBanner {


### PR DESCRIPTION
## Summary
- add missing commas in SupportTools public function parameter blocks
- ensure `-Simulate` parameters end with a comma
- export all public functions explicitly
- list exported functions in module manifest

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)"` *(fails: CommandNotFoundException: Could not find Command Start-Main)*

------
https://chatgpt.com/codex/tasks/task_e_68438b578378832cab47b2f3440eb2c4