### PR TITLE
Add general script launcher menu

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -43,9 +43,13 @@ This short guide shows the basic steps to start using the modules in this reposi
    # Create a Service Desk ticket
    New-SDTicket -Title "Test" -Description "Quick start test"
    ```
-9. **Launch the interactive menu** (optional)
+9. **Launch an interactive menu** (optional)
    ```powershell
+   # Common SupportTools tasks
    ./scripts/SupportToolsMenu.ps1 -UserRole Helpdesk
+
+   # Browse any script in the repository
+   ./scripts/ScriptLauncher.ps1
    ```
 
 See [docs/UserGuide.md](UserGuide.md) for detailed deployment and usage instructions.

--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -9,7 +9,8 @@ Import-Module ./src/SupportTools/SupportTools.psd1
 
 For a guided experience, run `./scripts/SupportToolsMenu.ps1` with the optional
 `-UserRole` parameter to select common tasks from an interactive menu tailored
-for `Helpdesk` or `Site Admin` roles.
+for `Helpdesk` or `Site Admin` roles. To browse and execute any script in the
+repository, use `./scripts/ScriptLauncher.ps1` for a general menu of options.
 
 ### Simulation Mode
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,5 +28,6 @@ The following table provides a brief description of each script.
 | **Configure-SharePointTools.ps1** | Prompts for SharePoint application values and saves them to a settings file. |
 | **CleanupTempFiles.ps1** | Removes .tmp files and empty logs from the repository. |
 | **SupportToolsMenu.ps1** | Interactive menu for common SupportTools tasks. |
+| **ScriptLauncher.ps1** | Menu to browse and run any script in this folder. |
 | **Get-FunctionDependencyGraph.ps1** | Generates a Graphviz or Mermaid map of function calls inside a script. |
 

--- a/scripts/ScriptLauncher.ps1
+++ b/scripts/ScriptLauncher.ps1
@@ -1,0 +1,49 @@
+<#
+.SYNOPSIS
+    Browse and execute scripts from an interactive menu.
+.DESCRIPTION
+    Lists all .ps1 files in the current folder and allows
+    the user to select one to run. Useful for discovering
+    scripts without memorizing each filename.
+.EXAMPLE
+    ./ScriptLauncher.ps1
+#>
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+
+function Get-ScriptInfo {
+    param([string]$Path)
+    $lines = Get-Content $Path -First 10
+    $synopsis = $lines | Where-Object { $_ -match '\.SYNOPSIS' } |
+        ForEach-Object { ($_ -replace '.*\.SYNOPSIS', '').Trim() }
+    if (-not $synopsis) { $synopsis = Split-Path $Path -Leaf }
+    [pscustomobject]@{ Path = $Path; Name = Split-Path $Path -Leaf; Synopsis = $synopsis }
+}
+
+$scriptFiles = Get-ChildItem -Path $PSScriptRoot -Filter '*.ps1' |
+    Where-Object { $_.Name -notin 'ScriptLauncher.ps1', 'SupportToolsMenu.ps1' } |
+    ForEach-Object { Get-ScriptInfo $_.FullName }
+
+function Show-Menu {
+    Write-STDivider 'Available Scripts' -Style light
+    for ($i = 0; $i -lt $scriptFiles.Count; $i++) {
+        $num = $i + 1
+        Write-Host "$num. $($scriptFiles[$i].Name) - $($scriptFiles[$i].Synopsis)"
+    }
+    Write-Host 'Q. Quit'
+}
+
+while ($true) {
+    Show-Menu
+    $choice = Read-Host 'Select an option'
+    if ($choice -match '^[Qq]$') { break }
+    $index = [int]$choice - 1
+    if ($index -ge 0 -and $index -lt $scriptFiles.Count) {
+        & $scriptFiles[$index].Path
+    } else {
+        Write-STStatus 'Invalid choice. Try again.' -Level WARN
+    }
+    Write-Host
+}
+
+Write-STClosing


### PR DESCRIPTION
## Summary
- implement `ScriptLauncher.ps1` for an interactive menu of scripts
- document generic script menu in SupportTools and Quickstart guides
- add entry to scripts README

## Testing
- `pwsh` (failed: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68438d6fe0a0832c9b57c840a7bf1838