### PR TITLE
Improve Write-STLog parameter

### DIFF
--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -12,7 +12,7 @@ if ($SupportToolsConfig.maintenanceMode) {
 function Write-STLog {
     [CmdletBinding(DefaultParameterSetName='Message')]
     param(
-        [Parameter(Mandatory, ParameterSetName='Message')]
+        [Parameter(Mandatory, Position=0, ParameterSetName='Message')]
         [string]$Message,
         [ValidateSet('INFO','WARN','ERROR')]
         [string]$Level = 'INFO',


### PR DESCRIPTION
## Summary
- allow Write-STLog to accept its message as a positional argument

## Testing
- `pwsh -File /tmp/run_pester.ps1` *(fails: parameter prompts in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68438d9887ec832c9f059107d2ebf018