### PR TITLE
Add performance benchmarking module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository packages a collection of scripts into reusable modules.
 * **SupportTools** – general helper commands that wrap the scripts in the `/scripts` folder.
 * **SharePointTools** – commands for SharePoint cleanup tasks such as removing archives or sharing links.
 * **ServiceDeskTools** – interact with the Service Desk ticketing system.
+* **PerformanceTools** – measure script runtime and resource usage.
 
 ### Module Maturity
 
@@ -15,6 +16,7 @@ This repository packages a collection of scripts into reusable modules.
 | SupportTools | Stable |
 | SharePointTools | Beta |
 | ServiceDeskTools | Experimental |
+| PerformanceTools | Experimental |
 
 ## Requirements 📋
 
@@ -73,7 +75,7 @@ Invoke-YFArchiveCleanup -Verbose
 Get-SPToolsAllLibraryReports | Format-Table
 ```
 
-See [docs/SupportTools.md](docs/SupportTools.md), [docs/SharePointTools.md](docs/SharePointTools.md) and [docs/ServiceDeskTools.md](docs/ServiceDeskTools.md) for a full list of commands. For a short introduction refer to [docs/Quickstart.md](docs/Quickstart.md). For detailed deployment guidance see [docs/UserGuide.md](docs/UserGuide.md).
+See [docs/SupportTools.md](docs/SupportTools.md), [docs/SharePointTools.md](docs/SharePointTools.md), [docs/ServiceDeskTools.md](docs/ServiceDeskTools.md) and [docs/PerformanceTools.md](docs/PerformanceTools.md) for a full list of commands. For a short introduction refer to [docs/Quickstart.md](docs/Quickstart.md). For detailed deployment guidance see [docs/UserGuide.md](docs/UserGuide.md).
 
 The module also provides `Set-SharedMailboxAutoReply` for configuring automatic
 out-of-office replies on a shared mailbox.

--- a/docs/PerformanceTools.md
+++ b/docs/PerformanceTools.md
@@ -1,0 +1,13 @@
+# PerformanceTools Module
+
+Provides helper commands for measuring script performance. Import the module using its manifest:
+
+```powershell
+Import-Module ./src/PerformanceTools/PerformanceTools.psd1
+```
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `Measure-STCommand` | Execute a script block and report duration, CPU time and memory delta. |

--- a/docs/PerformanceTools/Measure-STCommand.md
+++ b/docs/PerformanceTools/Measure-STCommand.md
@@ -1,0 +1,63 @@
+---
+external help file: PerformanceTools-help.xml
+Module Name: PerformanceTools
+online version:
+schema: 2.0.0
+---
+
+# Measure-STCommand
+
+## SYNOPSIS
+Measures execution time, CPU usage and memory change for a script block.
+
+## SYNTAX
+```powershell
+Measure-STCommand [-ScriptBlock] <scriptblock> [-Quiet] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Runs the supplied script block and returns an object with the total duration in seconds,
+processor time consumed and change in working set memory. By default it also prints
+this information using the logging helpers.
+
+## EXAMPLES
+### Example 1
+```powershell
+PS C:\> Measure-STCommand { Get-Process pwsh }
+```
+
+Demonstrates collecting performance metrics for a command.
+
+## PARAMETERS
+### -ScriptBlock
+Script block containing the commands to execute.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: sb
+```
+
+### -Quiet
+Suppress status output and only return the metrics object.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+```
+
+## INPUTS
+None
+
+## OUTPUTS
+```
+System.Object
+```
+
+Object with the properties `DurationSeconds`, `CpuSeconds` and `MemoryDeltaMB`.
+
+## NOTES
+None
+
+## RELATED LINKS
+None

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ The key guides are:
 - [SupportTools](./SupportTools.md), [SharePointTools](./SharePointTools.md), [ServiceDeskTools](./ServiceDeskTools.md) – high level summaries of each module and the commands they expose.
 - [Credential Storage](./CredentialStorage.md) – recommended approach to store secrets securely.
 - [Module Style Guide](./ModuleStyleGuide.md) – how scripts display progress messages and log output.
+- [PerformanceTools](./PerformanceTools.md) – measure execution time and resource usage.
 - [Telemetry Metrics](./Telemetry/Get-STTelemetryMetrics.md) – summarize execution statistics and output to CSV or SQLite.
 - [Get-FunctionDependencyGraph](./Get-FunctionDependencyGraph.md) – generate a visual map of function calls in a script.
 - [Local Mock API](./LocalMockApi.md) – run a lightweight HTTP server for offline tests.

--- a/src/PerformanceTools/PerformanceTools.psd1
+++ b/src/PerformanceTools/PerformanceTools.psd1
@@ -1,0 +1,8 @@
+@{
+    RootModule = 'PerformanceTools.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000012'
+    Author = 'Contoso'
+    Description = 'Commands for measuring script performance.'
+    FunctionsToExport = @('Measure-STCommand')
+}

--- a/src/PerformanceTools/PerformanceTools.psm1
+++ b/src/PerformanceTools/PerformanceTools.psm1
@@ -1,0 +1,48 @@
+$loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+Import-Module $loggingModule -ErrorAction SilentlyContinue
+
+function Measure-STCommand {
+    <#
+    .SYNOPSIS
+        Measures execution time, CPU usage and memory change for a script block.
+    .DESCRIPTION
+        Executes the provided script block and returns the elapsed time in seconds,
+        processor time consumed and the change in working set memory in megabytes.
+    .PARAMETER ScriptBlock
+        The commands to execute.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [scriptblock]$ScriptBlock,
+        [switch]$Quiet
+    )
+
+    $before = Get-Process -Id $PID
+    $cpuStart = $before.TotalProcessorTime
+    $memStart = $before.WorkingSet64
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    & $ScriptBlock
+    $sw.Stop()
+
+    $after = Get-Process -Id $PID
+    $cpuEnd = $after.TotalProcessorTime
+    $memEnd = $after.WorkingSet64
+
+    $result = [pscustomobject]@{
+        DurationSeconds = [math]::Round($sw.Elapsed.TotalSeconds, 2)
+        CpuSeconds      = [math]::Round(($cpuEnd - $cpuStart).TotalSeconds, 2)
+        MemoryDeltaMB   = [math]::Round(($memEnd - $memStart) / 1MB, 2)
+    }
+
+    if (-not $Quiet) {
+        Write-STStatus "Duration: $($result.DurationSeconds)s" -Level INFO
+        Write-STStatus "CPU Time: $($result.CpuSeconds)s" -Level INFO
+        Write-STStatus "Memory Change: $($result.MemoryDeltaMB) MB" -Level INFO
+    }
+
+    return $result
+}
+
+Export-ModuleMember -Function 'Measure-STCommand'

--- a/tests/PerformanceTools.Tests.ps1
+++ b/tests/PerformanceTools.Tests.ps1
@@ -1,0 +1,16 @@
+Describe 'PerformanceTools Module' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/PerformanceTools/PerformanceTools.psd1 -Force
+    }
+
+    It 'exports Measure-STCommand' {
+        (Get-Command -Module PerformanceTools).Name | Should -Contain 'Measure-STCommand'
+    }
+
+    It 'measures a script block' {
+        $result = Measure-STCommand { Start-Sleep -Milliseconds 50 }
+        $result.DurationSeconds | Should -BeGreaterThan 0
+        $result | Should -HaveProperty 'CpuSeconds'
+        $result | Should -HaveProperty 'MemoryDeltaMB'
+    }
+}


### PR DESCRIPTION
## Summary
- integrate new PerformanceTools module with `Measure-STCommand`
- document the module and command usage
- mention PerformanceTools throughout docs and README
- add basic Pester tests for the command

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration ./PesterConfiguration.psd1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438da20100832cb8d02a0b964a53e4