### PR TITLE
Fix Write-STLog help format

### DIFF
--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -97,7 +97,7 @@ Accept wildcard characters: False
 ```
 
 ### -Structured
-Outputs the log entry as a JSON object.
+Outputs the log entry as a JSON object. Set the `ST_LOG_STRUCTURED` environment variable to `1` to enable structured output by default.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
@@ -109,7 +109,6 @@ Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-Set the `ST_LOG_STRUCTURED` environment variable to `1` to enable structured output by default.
 
 ### -Metric
 Name of a metric to record. Automatically enables structured output.


### PR DESCRIPTION
## Summary
- fix the Write-STLog help so platyPS can parse it

## Testing
- `Invoke-Pester -Configuration $cfg` *(fails: Could not find Command Start-Main)*
- `New-ExternalHelp -Path docs/Logging -OutputPath out -Force`

------
https://chatgpt.com/codex/tasks/task_e_68438faed5a0832c9e5ef7bed1880eb1