### PR TITLE
Restore full test suite and fix logging

### DIFF
--- a/PesterConfiguration.psd1
+++ b/PesterConfiguration.psd1
@@ -1,5 +1,10 @@
 @{
-    Run = @{ Path = 'passing-tests'; Exit = $true }
+    Run = @{ Path = 'tests'; Exit = $true }
     TestResult = @{ Enabled = $true; OutputFormat = 'NUnitXml'; OutputPath = 'TestResults.xml' }
-    CodeCoverage = @{ Enabled = $false }
+    CodeCoverage = @{
+        Enabled = $true
+        Path = @('src/**/*.ps1','scripts/*.ps1')
+        OutputFormat = 'JaCoCo'
+        OutputPath = 'coverage.xml'
+    }
 }

--- a/passing-tests/Dummy.Tests.ps1
+++ b/passing-tests/Dummy.Tests.ps1
@@ -1,5 +1,0 @@
-Describe 'Dummy' {
-    It 'always passes' {
-        $true | Should -Be $true
-    }
-}

--- a/scripts/AddUsersToGroup.ps1
+++ b/scripts/AddUsersToGroup.ps1
@@ -87,14 +87,7 @@ function Connect-MicrosoftGraph {
     $scopes = 'User.Read.All','Group.ReadWrite.All','Directory.ReadWrite.All'
     try {
         Connect-MgGraph -Scopes $scopes -NoWelcome
-        try {
-            Confirm-MgGraphScopes -Scopes $scopes
-        } catch {
-            Write-Warning 'Microsoft Graph scopes not granted. Exiting.'
-            throw
-        }
-    }
-    catch {
+    } catch {
         Write-Error -Message "Error: $_.Exception.Message"
         throw "Error: Cannot connect to Microsoft Graph"
     }

--- a/scripts/Run-JobBundle.ps1
+++ b/scripts/Run-JobBundle.ps1
@@ -55,7 +55,7 @@ try {
         & $scriptPath
     }
 } catch {
-    Write-STLog "Job bundle execution failed: $_" -Level 'ERROR'
+    Write-STLog -Message "Job bundle execution failed: $_" -Level 'ERROR'
     $result = 'Failure'
     throw
 } finally {

--- a/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
+++ b/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
@@ -15,7 +15,7 @@ function Invoke-SDRequest {
     if (-not $ChaosMode) { $ChaosMode = [bool]$env:ST_CHAOS_MODE }
     if ($ChaosMode) {
         $delay = Get-Random -Minimum 500 -Maximum 1500
-        Write-STLog "CHAOS MODE delay $delay ms"
+        Write-STLog -Message "CHAOS MODE delay $delay ms"
         Start-Sleep -Milliseconds $delay
         $roll = Get-Random -Minimum 1 -Maximum 100
         if ($roll -le 10) { throw 'ChaosMode: simulated throttling (429 Too Many Requests)' }
@@ -24,22 +24,22 @@ function Invoke-SDRequest {
 
     $headers = @{ 'X-Samanage-Authorization' = "Bearer $token"; Accept = 'application/json' }
     $uri = $baseUri.TrimEnd('/') + $Path
-    Write-STLog "SDRequest $Method $uri"
+    Write-STLog -Message "SDRequest $Method $uri"
     if ($Body) {
         $json = $Body | ConvertTo-Json -Depth 10
         try {
             Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers -Body $json -ContentType 'application/json'
-            Write-STLog "SUCCESS $Method $uri"
+            Write-STLog -Message "SUCCESS $Method $uri"
         } catch {
-            Write-STLog "ERROR $Method $uri :: $_" -Level 'ERROR'
+            Write-STLog -Message "ERROR $Method $uri :: $_" -Level 'ERROR'
             throw
         }
     } else {
         try {
             Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers
-            Write-STLog "SUCCESS $Method $uri"
+            Write-STLog -Message "SUCCESS $Method $uri"
         } catch {
-            Write-STLog "ERROR $Method $uri :: $_" -Level 'ERROR'
+            Write-STLog -Message "ERROR $Method $uri :: $_" -Level 'ERROR'
             throw
         }
     }

--- a/src/ServiceDeskTools/Public/Get-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDTicket.ps1
@@ -17,6 +17,6 @@ function Get-SDTicket {
         return
     }
 
-    Write-STLog "Get-SDTicket $Id"
+    Write-STLog -Message "Get-SDTicket $Id"
     Invoke-SDRequest -Method 'GET' -Path "/incidents/$Id.json" -ChaosMode:$ChaosMode
 }

--- a/src/ServiceDeskTools/Public/Link-SDTicketToSPTask.ps1
+++ b/src/ServiceDeskTools/Public/Link-SDTicketToSPTask.ps1
@@ -23,7 +23,7 @@ function Link-SDTicketToSPTask {
         return
     }
 
-    Write-STLog "Link-SDTicketToSPTask $TicketId $TaskUrl"
+    Write-STLog -Message "Link-SDTicketToSPTask $TicketId $TaskUrl"
     $fields = @{ $FieldName = $TaskUrl }
     Set-SDTicket -Id $TicketId -Fields $fields -ChaosMode:$ChaosMode
 }

--- a/src/ServiceDeskTools/Public/New-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/New-SDTicket.ps1
@@ -23,7 +23,7 @@ function New-SDTicket {
         return
     }
 
-    Write-STLog "New-SDTicket $Subject"
+    Write-STLog -Message "New-SDTicket $Subject"
     $body = @{ incident = @{ name = $Subject; description = $Description; requester_email = $RequesterEmail } }
     Invoke-SDRequest -Method 'POST' -Path '/incidents.json' -Body $body -ChaosMode:$ChaosMode
 }

--- a/src/ServiceDeskTools/Public/Search-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Search-SDTicket.ps1
@@ -17,7 +17,7 @@ function Search-SDTicket {
         return
     }
 
-    Write-STLog "Search-SDTicket $Query"
+    Write-STLog -Message "Search-SDTicket $Query"
     $encoded = [uri]::EscapeDataString($Query)
     Invoke-SDRequest -Method 'GET' -Path "/incidents.json?search=$encoded" -ChaosMode:$ChaosMode
 }

--- a/src/ServiceDeskTools/Public/Set-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicket.ps1
@@ -20,7 +20,7 @@ function Set-SDTicket {
         return
     }
 
-    Write-STLog "Set-SDTicket $Id"
+    Write-STLog -Message "Set-SDTicket $Id"
     $body = @{ incident = $Fields }
     Invoke-SDRequest -Method 'PUT' -Path "/incidents/$Id.json" -Body $body -ChaosMode:$ChaosMode
 }

--- a/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
@@ -21,7 +21,7 @@ function Set-SDTicketBulk {
     }
 
     foreach ($ticketId in $Id) {
-        Write-STLog "Set-SDTicketBulk $ticketId"
+        Write-STLog -Message "Set-SDTicketBulk $ticketId"
         Set-SDTicket -Id $ticketId -Fields $Fields -ChaosMode:$ChaosMode
     }
 }

--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -64,7 +64,7 @@ function Invoke-ScriptFile {
         & $Path @Args
     } catch {
         Write-Error "Execution of '$Name' failed: $_"
-        Write-STLog "Execution of '$Name' failed: $_" -Level 'ERROR' -Structured -Metadata @{ version = $moduleVersion; script = $Name }
+        Write-STLog -Message "Execution of '$Name' failed: $_" -Level 'ERROR' -Structured -Metadata @{ version = $moduleVersion; script = $Name }
         $result = 'Failure'
         throw
     } finally {

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -56,7 +56,7 @@ function Show-SupportToolsBanner {
     Write-STStatus 'SUPPORTTOOLS MODULE ACTIVATED' -Level SUCCESS
     Write-STStatus '════════════════════════════════════════════' -Level INFO
     Write-STStatus "Run 'Get-Command -Module SupportTools' to view available tools." -Level SUB
-    Write-STLog 'SupportTools module loaded'
+    Write-STLog -Message 'SupportTools module loaded'
 }
 
 Show-SupportToolsBanner


### PR DESCRIPTION
## Summary
- enable `tests` path in Pester config and re‑enable code coverage
- remove obsolete dummy test
- fix calls to `Write-STLog` to use explicit `-Message` parameter
- avoid unavailable `Confirm-MgGraphScopes` in AddUsersToGroup

## Testing
- `pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684391368554832cbe34cccc01890af0