### PR TITLE
Fix SupportTools floor creation test

### DIFF
--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -237,7 +237,7 @@ Describe 'SupportTools Module' {
                 function Get-Command {}
                 function Connect-MicrosoftPlaces {}
                 function Get-PlaceV3 { @() }
-                function New-Place {}
+                function New-Place { param($Type, $Name, $ParentId) }
                 function Write-Host {}
 
                 Mock Get-Command { @{ Name = 'Get-PlaceV3' } } -ModuleName SupportTools
@@ -245,7 +245,7 @@ Describe 'SupportTools Module' {
                 Mock Get-PlaceV3 { @() } -ModuleName SupportTools
                 Mock New-Place {
                     if ($Type -eq 'Building') { return @{ PlaceId = '1' } }
-                }
+                } -ModuleName SupportTools
                 Mock Write-Host {} -ModuleName SupportTools
 
                 Invoke-CompanyPlaceManagement -Action Create -DisplayName 'B1' -Type Building -AutoAddFloor


### PR DESCRIPTION
## Summary
- fix mocking for New-Place in AutoAddFloor test

## Testing
- `Invoke-Pester tests/SupportTools.Tests.ps1 -FullNameFilter 'SupportTools Module.Invoke-CompanyPlaceManagement behavior.adds default floor when creating a building with AutoAddFloor' -Output Detailed -PassThru | Format-Table -AutoSize`

------
https://chatgpt.com/codex/tasks/task_e_68439416b544832cb1e38aabdea93833