### PR TITLE
Fix failing test for Set-SharedMailboxAutoReply

### DIFF
--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -131,10 +131,6 @@ Describe 'SupportTools Module' {
                 function Get-InstalledModule {}
                 function Find-Module {}
                 function Import-Module {}
-                function global:Set-MailboxAutoReplyConfiguration {}
-                function global:Get-MailboxAutoReplyConfiguration {}
-                function global:Set-MailboxAutoReplyConfiguration {}
-                function global:Get-MailboxAutoReplyConfiguration { 'result' }
                 function Set-MailboxAutoReplyConfiguration {}
                 function Get-MailboxAutoReplyConfiguration { 'result' }
 


### PR DESCRIPTION
## Summary
- remove global functions from Set-SharedMailboxAutoReply tests so the mocks work correctly

## Testing
- `pwsh -NoProfile -Command "echo hello"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439432383c832ca1f1369d868e8cbd