### PR TITLE
Fix Pester test for Measure-STCommand

### DIFF
--- a/tests/PerformanceTools.Tests.ps1
+++ b/tests/PerformanceTools.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'PerformanceTools Module' {
     It 'measures a script block' {
         $result = Measure-STCommand { Start-Sleep -Milliseconds 50 }
         $result.DurationSeconds | Should -BeGreaterThan 0
-        $result | Should -HaveProperty 'CpuSeconds'
-        $result | Should -HaveProperty 'MemoryDeltaMB'
+        $result.PSObject.Properties.Name | Should -Contain 'CpuSeconds'
+        $result.PSObject.Properties.Name | Should -Contain 'MemoryDeltaMB'
     }
 }


### PR DESCRIPTION
## Summary
- update test assertions to check property names instead of using unsupported `-HaveProperty`

## Testing
- `Invoke-Pester tests/PerformanceTools.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68439674f538832c96464f6b27da388d