### PR TITLE
Fix Pester test for Set-SharedMailboxAutoReply

### DIFF
--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -146,7 +146,9 @@ Describe 'SupportTools Module' {
 
                 $result = Set-SharedMailboxAutoReply -MailboxIdentity 'm' -StartTime (Get-Date) -EndTime (Get-Date).AddHours(1) -InternalMessage 'hello' -AdminUser 'admin'
 
-                Assert-MockCalled Set-MailboxAutoReplyConfiguration -ParameterFilter { $ExternalMessage -eq 'hello' } -Times 1
+                Assert-MockCalled Set-MailboxAutoReplyConfiguration -ParameterFilter {
+                    ($idx = [array]::IndexOf($args, '-ExternalMessage')) -ge 0 -and $args[$idx + 1] -eq 'hello'
+                } -Times 1
                 $result | Should -Be 'result'
             }
         }
@@ -160,6 +162,8 @@ Describe 'SupportTools Module' {
                 function Get-InstalledModule {}
                 function Find-Module {}
                 function Import-Module {}
+                function Set-MailboxAutoReplyConfiguration {}
+                function Get-MailboxAutoReplyConfiguration {}
 
                 Mock Connect-ExchangeOnline {} -ModuleName SupportTools
                 Mock Disconnect-ExchangeOnline {} -ModuleName SupportTools
@@ -173,7 +177,7 @@ Describe 'SupportTools Module' {
 
                 Set-SharedMailboxAutoReply -MailboxIdentity 'm' -StartTime (Get-Date) -EndTime (Get-Date).AddHours(1) -InternalMessage 'i' -ExternalMessage 'e' -AdminUser 'admin' -UseWebLogin
 
-                Assert-MockCalled Connect-ExchangeOnline -ParameterFilter { $UseWebLogin } -Times 1
+                Assert-MockCalled Connect-ExchangeOnline -ParameterFilter { $args -contains '-UseWebLogin' } -Times 1
             }
         }
     }


### PR DESCRIPTION
## Summary
- update Set-SharedMailboxAutoReply tests so the mocked commands exist
- check parameters using `$args` to work with parameterless mocks

## Testing
- `Invoke-Pester tests/SupportTools.Tests.ps1 -FullNameFilter 'SupportTools Module.Set-SharedMailboxAutoReply behavior.defaults ExternalMessage to InternalMessage','SupportTools Module.Set-SharedMailboxAutoReply behavior.uses web login when specified'`

------
https://chatgpt.com/codex/tasks/task_e_6843969148c0832c982162a183ca6107