### PR TITLE
Fix external auto reply default

### DIFF
--- a/docs/SupportTools/Set-SharedMailboxAutoReply.md
+++ b/docs/SupportTools/Set-SharedMailboxAutoReply.md
@@ -99,6 +99,7 @@ Accept wildcard characters: False
 
 ### -ExternalMessage
 External auto-reply message.
+If omitted or blank, the internal message will also be used externally.
 
 ```yaml
 Type: String

--- a/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
+++ b/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
@@ -45,7 +45,9 @@ function Set-SharedMailboxAutoReply {
         return $mock
     }
 
-    if (-not $ExternalMessage) { $ExternalMessage = $InternalMessage }
+    if ([string]::IsNullOrWhiteSpace($ExternalMessage)) {
+        $ExternalMessage = $InternalMessage
+    }
 
     Write-Verbose 'Checking ExchangeOnlineManagement module...'
     $module = Get-InstalledModule ExchangeOnlineManagement -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- better default when ExternalMessage not specified
- document the external message behavior

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI -Output Detailed"` *(fails: Parameter errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843969e86d4832c9687942a124504a5