### PR TITLE
Fix test stub for Exchange cmdlets

### DIFF
--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -177,6 +177,8 @@ Describe 'SupportTools Module' {
                 function Get-InstalledModule {}
                 function Find-Module {}
                 function Import-Module {}
+                function Set-MailboxAutoReplyConfiguration {}
+                function Get-MailboxAutoReplyConfiguration {}
 
                 Mock Connect-ExchangeOnline {} -ModuleName SupportTools
                 Mock Disconnect-ExchangeOnline {} -ModuleName SupportTools


### PR DESCRIPTION
## Summary
- stub Set-MailboxAutoReplyConfiguration and Get-MailboxAutoReplyConfiguration in the web-login test

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration (Import-PowerShellDataFile -Path PesterConfiguration.psd1)"` *(fails: Could not find Command Start-Main)*

------
https://chatgpt.com/codex/tasks/task_e_6843983af084832cae8d6f45f1461f81