### PR TITLE
Fix Clear-ArchiveFolder duplicate parameter

### DIFF
--- a/src/SupportTools/Public/Clear-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Clear-ArchiveFolder.ps1
@@ -15,6 +15,6 @@ function Clear-ArchiveFolder {
         [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain -Explain:$Explain
+        Invoke-ScriptFile -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }


### PR DESCRIPTION
## Summary
- remove duplicate `-Explain` parameter when calling `Invoke-ScriptFile`

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: Tests Passed: 143, Failed: 5)*

------
https://chatgpt.com/codex/tasks/task_e_684398548498832c9c032a1f44348e30