### PR TITLE
Fix Clear-ArchiveFolder flag duplication and test setup

### DIFF
--- a/src/SupportTools/Public/Clear-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Clear-ArchiveFolder.ps1
@@ -15,6 +15,6 @@ function Clear-ArchiveFolder {
         [switch]$Explain
     )
     process {
-        Invoke-ScriptFile -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain -Explain:$Explain
+        Invoke-ScriptFile -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -163,7 +163,7 @@ Describe 'SupportTools Module' {
 
                 $result = Set-SharedMailboxAutoReply -MailboxIdentity 'm' -StartTime (Get-Date) -EndTime (Get-Date).AddHours(1) -InternalMessage 'hello' -AdminUser 'admin'
 
-                Assert-MockCalled Set-MailboxAutoReplyConfiguration -ParameterFilter { $ExternalMessage -eq 'hello' } -Times 1
+                Assert-MockCalled Set-MailboxAutoReplyConfiguration -ParameterFilter { $ExternalMessage -eq 'hello' } -Times 1 -ModuleName SupportTools
                 $result | Should -Be 'result'
             }
         }
@@ -177,6 +177,8 @@ Describe 'SupportTools Module' {
                 function Get-InstalledModule {}
                 function Find-Module {}
                 function Import-Module {}
+                function Set-MailboxAutoReplyConfiguration {}
+                function Get-MailboxAutoReplyConfiguration {}
 
                 Mock Connect-ExchangeOnline {} -ModuleName SupportTools
                 Mock Disconnect-ExchangeOnline {} -ModuleName SupportTools
@@ -190,7 +192,7 @@ Describe 'SupportTools Module' {
 
                 Set-SharedMailboxAutoReply -MailboxIdentity 'm' -StartTime (Get-Date) -EndTime (Get-Date).AddHours(1) -InternalMessage 'i' -ExternalMessage 'e' -AdminUser 'admin' -UseWebLogin
 
-                Assert-MockCalled Connect-ExchangeOnline -ParameterFilter { $UseWebLogin } -Times 1
+                Assert-MockCalled Connect-ExchangeOnline -ParameterFilter { $UseWebLogin } -Times 1 -ModuleName SupportTools
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove duplicated `-Explain` argument in `Clear-ArchiveFolder`
- update tests to prepare required mocks

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester tests/SupportTools.Tests.ps1 -Output Detailed"` *(fails: 58 passed, 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68439844d950832c84069a2595c56d2b