### PR TITLE
Refactor Get-CommonSystemInfo

### DIFF
--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -37,7 +37,7 @@ listed are forwarded to the underlying script unchanged.
 | `Restore-ArchiveFolder` | `RollbackArchive.ps1` | `SnapshotPath`, `SiteUrl` | `Restore-ArchiveFolder -SiteUrl https://contoso.sharepoint.com/sites/Files -SnapshotPath preDeleteLog.json` |
 | `Convert-ExcelToCsv` | `Convert-ExcelToCsv.ps1` | *passthrough* | `Convert-ExcelToCsv -Path workbook.xlsx` |
 | `Export-ProductKey` | `ProductKey.ps1` | *passthrough* | `Export-ProductKey` |
-| `Get-CommonSystemInfo` | `Get-CommonSystemInfo.ps1` | *passthrough* | `Get-CommonSystemInfo` |
+| `Get-CommonSystemInfo` | *built-in* | - | `Get-CommonSystemInfo` |
 | `Get-FailedLogin` | `Get-FailedLogins.ps1` | *passthrough* | `Get-FailedLogin -ComputerName PC1` |
 | `Get-NetworkShare` | `Get-NetworkShares.ps1` | *passthrough* | `Get-NetworkShare -ComputerName FS01` |
 | `Get-UniquePermission` | `Get-UniquePermissions.ps1` | *passthrough* | `Get-UniquePermission -SiteUrl https://contoso.sharepoint.com/sites/HR` |

--- a/docs/SupportTools/Get-CommonSystemInfo.md
+++ b/docs/SupportTools/Get-CommonSystemInfo.md
@@ -13,13 +13,12 @@ Returns common system information such as OS and hardware details.
 ## SYNTAX
 
 ```
-Get-CommonSystemInfo [[-Arguments] <Object[]>] [[-TranscriptPath] <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-CommonSystemInfo [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Wraps the Get-CommonSystemInfo.ps1 script in the scripts folder and
-forwards any provided arguments.
+Collects operating system, processor, disk and memory information and
+returns it as a custom object.
 
 ## EXAMPLES
 
@@ -30,55 +29,6 @@ PS C:\> Get-CommonSystemInfo | Format-Table -AutoSize
 
 Demonstrates typical usage of Get-CommonSystemInfo.
 
-## PARAMETERS
-
-### -Arguments
-Arguments passed directly to the underlying script.
-
-```yaml
-Type: Object[]
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 1
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -TranscriptPath
-{{ Fill TranscriptPath Description }}
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 2
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ProgressAction
-Specifies how progress is displayed.
-
-```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: proga
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 


### PR DESCRIPTION
## Summary
- embed data collection logic directly inside `Get-CommonSystemInfo`
- update docs to show the command is built-in
- adjust tests and add coverage for the new behavior

## Testing
- `pwsh -NoLogo -Command '$cfg = Import-PowerShellDataFile "./PesterConfiguration.psd1"; Invoke-Pester -Configuration $cfg'` *(fails: BeforeAll \ AfterAll failed)*

------
https://chatgpt.com/codex/tasks/task_e_684398062864832c87e9f37e861e337a