### PR TITLE
Fix AddUsersToGroup Start-Main load issue

### DIFF
--- a/scripts/AddUsersToGroup.ps1
+++ b/scripts/AddUsersToGroup.ps1
@@ -29,17 +29,16 @@ This script requires Microsoft Graph API permissions and assumes the user has th
 This example runs the script with explicit parameters to process the provided CSV file and add the listed users to the specified Microsoft 365 group.
 #>
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
-
 param(
     [Parameter()]
-    [ValidateScript({ Test-Path $_ -PathType Leaf })]
     [string]$CsvPath,
 
     [Parameter()]
     [ValidateNotNullOrEmpty()]
     [string]$GroupName
 )
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
 
 # Import necessary .NET assemblies
 Add-Type -AssemblyName PresentationFramework, System.Windows.Forms
@@ -233,4 +232,6 @@ function Start-Main {
     }
 }
 
-Start-Main -CsvPath $CsvPath -GroupName $GroupName
+if ($MyInvocation.InvocationName -ne '.') {
+    Start-Main -CsvPath $CsvPath -GroupName $GroupName
+}


### PR DESCRIPTION
## Summary
- position the `param` block before other code
- drop file validation for `CsvPath`
- run `Start-Main` only when script is invoked directly

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI -Output Detailed"`

------
https://chatgpt.com/codex/tasks/task_e_6843985e3e54832cadc97a86a14e54bf