### PR TITLE
Add fallback to local module import

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This repository packages a collection of scripts into reusable modules.
    # or pin a specific build
    Install-Module -Name SupportTools -RequiredVersion 1.0.4
    ```
+   The script attempts to download each module from the gallery and falls back
+   to importing the versions under `src` if the gallery cannot be reached.
 
 3. Import the module manifest files from the `src` folder:
 

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -17,4 +17,4 @@ Once published, install the entire suite on a fresh system using the helper scri
 ./scripts/Install-SupportTools.ps1 -SupportToolsVersion 1.0.4
 ```
 
-The script downloads `Logging`, `SharePointTools`, `ServiceDeskTools` and the specified version of `SupportTools` from the gallery.
+The script downloads `Logging`, `SharePointTools`, `ServiceDeskTools` and the specified version of `SupportTools` from the gallery. If the gallery can't be reached it imports the local copies from `src` instead.

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -19,6 +19,8 @@ This short guide shows the basic steps to start using the modules in this reposi
    ```powershell
    ./scripts/Install-SupportTools.ps1 -SupportToolsVersion 1.3.0
    ```
+   If the gallery is unavailable the script automatically imports the modules
+   from the `src` folder instead.
 5. **Import the modules**
    ```powershell
    Import-Module ./src/SupportTools/SupportTools.psd1

--- a/scripts/Install-SupportTools.ps1
+++ b/scripts/Install-SupportTools.ps1
@@ -4,6 +4,7 @@
 .DESCRIPTION
     Downloads SupportTools, SharePointTools, ServiceDeskTools and Logging from the gallery.
     If a version is specified for SupportTools it will be pinned using -RequiredVersion.
+    If the gallery is unavailable the modules are imported from the local src folder.
 .PARAMETER SupportToolsVersion
     Version of SupportTools to install. Defaults to the latest available version.
 .PARAMETER Scope
@@ -19,10 +20,23 @@ param(
 
 $modules = @('Logging','SharePointTools','ServiceDeskTools','SupportTools')
 
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+
 foreach ($module in $modules) {
-    if ($module -eq 'SupportTools' -and $SupportToolsVersion) {
-        Install-Module -Name $module -RequiredVersion $SupportToolsVersion -Scope $Scope -Force -AllowClobber
-    } else {
-        Install-Module -Name $module -Scope $Scope -Force -AllowClobber
+    try {
+        if ($module -eq 'SupportTools' -and $SupportToolsVersion) {
+            Install-Module -Name $module -RequiredVersion $SupportToolsVersion -Scope $Scope -Force -AllowClobber -ErrorAction Stop
+        } else {
+            Install-Module -Name $module -Scope $Scope -Force -AllowClobber -ErrorAction Stop
+        }
+    } catch {
+        Write-Warning "Failed to install $module from gallery: $($_.Exception.Message)"
+        $localPath = Join-Path $PSScriptRoot '..' 'src' $module "$module.psd1"
+        if (Test-Path $localPath) {
+            Import-Module $localPath -Force
+            Write-Warning "Imported $module from $localPath"
+        } else {
+            Write-Warning "Could not find $module in src"
+        }
     }
 }


### PR DESCRIPTION
## Summary
- import Logging and catch install failures in Install-SupportTools.ps1
- mention fallback behavior in docs

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile './PesterConfiguration.psd1')`


------
https://chatgpt.com/codex/tasks/task_e_68439ace16e8832cbd14bbeb0a0d16cd