### PR TITLE
Fix Get-CommonSystemInfo test without CIM

### DIFF
--- a/src/SupportTools/Public/Get-CommonSystemInfo.ps1
+++ b/src/SupportTools/Public/Get-CommonSystemInfo.ps1
@@ -14,10 +14,19 @@ function Get-CommonSystemInfo {
 
         Write-STStatus 'Collecting system information...' -Level INFO
 
-        $operatingSystemInfo = Get-CimInstance -ClassName Win32_OperatingSystem
-        $processorInfo       = Get-CimInstance -ClassName Win32_Processor
-        $diskInfo            = Get-CimInstance -ClassName Win32_LogicalDisk -Filter "DriveType = 3"
-        $memoryInfo          = Get-CimInstance -ClassName Win32_PhysicalMemory
+        if (Get-Command -Name Get-CimInstance -ErrorAction SilentlyContinue) {
+            $operatingSystemInfo = Get-CimInstance -ClassName Win32_OperatingSystem
+            $processorInfo       = Get-CimInstance -ClassName Win32_Processor
+            $diskInfo            = Get-CimInstance -ClassName Win32_LogicalDisk -Filter "DriveType = 3"
+            $memoryInfo          = Get-CimInstance -ClassName Win32_PhysicalMemory
+        } elseif (Get-Command -Name Get-WmiObject -ErrorAction SilentlyContinue) {
+            $operatingSystemInfo = Get-WmiObject -Class Win32_OperatingSystem
+            $processorInfo       = Get-WmiObject -Class Win32_Processor
+            $diskInfo            = Get-WmiObject -Class Win32_LogicalDisk -Filter "DriveType = 3"
+            $memoryInfo          = Get-WmiObject -Class Win32_PhysicalMemory
+        } else {
+            throw "CIM or WMI cmdlets are not available"
+        }
 
         $commonSystemInfoObj = [pscustomobject]@{
             ComputerName = $operatingSystemInfo.CSName

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -140,6 +140,9 @@ Describe 'SupportTools Module' {
     Context 'Get-CommonSystemInfo collection' {
         It 'returns system information object' {
             InModuleScope SupportTools {
+                function Get-CimInstance {
+                    param($ClassName)
+                }
                 Mock Get-CimInstance {
                     switch ($ClassName) {
                         'Win32_OperatingSystem' { [pscustomobject]@{ CSName='PC'; Caption='OS'; BuildNumber='1'; TotalVisibleMemorySize=1048576 } }


### PR DESCRIPTION
## Summary
- support environments without Get-CimInstance by falling back to Get-WmiObject
- update test to stub Get-CimInstance with proper parameter so Pester mock works

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)`

------
https://chatgpt.com/codex/tasks/task_e_68439b454b90832c8b4ffc71fbeb0c19