### PR TITLE
Fix version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository packages a collection of scripts into reusable modules.
    ```powershell
    ./scripts/Install-SupportTools.ps1 -SupportToolsVersion 1.3.0
    # or pin a specific build
-   Install-Module -Name SupportTools -RequiredVersion 1.0.4
+   Install-Module -Name SupportTools -RequiredVersion 1.3.0
    ```
    The script attempts to download each module from the gallery and falls back
    to importing the versions under `src` if the gallery cannot be reached.

--- a/SupportTools.nuspec
+++ b/SupportTools.nuspec
@@ -12,7 +12,7 @@
     <dependencies>
       <dependency id="SharePointTools" version="[1.1.0]" />
       <dependency id="ServiceDeskTools" version="[1.0.0]" />
-      <dependency id="Logging" version="[1.2.0]" />
+      <dependency id="Logging" version="[1.3.0]" />
     </dependencies>
   </metadata>
   <files>

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -14,7 +14,7 @@ Once published, install the entire suite on a fresh system using the helper scri
 
 ```powershell
 # Pin SupportTools to a specific version
-./scripts/Install-SupportTools.ps1 -SupportToolsVersion 1.0.4
+./scripts/Install-SupportTools.ps1 -SupportToolsVersion 1.3.0
 ```
 
 The script downloads `Logging`, `SharePointTools`, `ServiceDeskTools` and the specified version of `SupportTools` from the gallery. If the gallery can't be reached it imports the local copies from `src` instead.

--- a/scripts/Install-SupportTools.ps1
+++ b/scripts/Install-SupportTools.ps1
@@ -10,7 +10,7 @@
 .PARAMETER Scope
     Scope to install the modules. Defaults to CurrentUser.
 .EXAMPLE
-    ./Install-SupportTools.ps1 -SupportToolsVersion 1.0.4
+    ./Install-SupportTools.ps1 -SupportToolsVersion 1.3.0
 #>
 param(
     [string]$SupportToolsVersion,


### PR DESCRIPTION
## Summary
- bump Logging dependency version in the packaging file
- standardize example version numbers in docs and scripts

## Testing
- `pwsh -NoLogo -NoProfile -Command "$cfg = Import-PowerShellDataFile ./PesterConfiguration.psd1; Invoke-Pester -Configuration $cfg"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439e28c62c832cbb6ee22eaa598c68