### PR TITLE
Fix AddUsersToGroup test coverage

### DIFF
--- a/tests/AddUsersToGroup.Tests.ps1
+++ b/tests/AddUsersToGroup.Tests.ps1
@@ -11,6 +11,7 @@ Describe 'AddUsersToGroup Script' {
         function Get-CSVFilePath {}
         function Import-Csv { param([string]$Path) }
         function Get-UserID { param([string]$UserPrincipalName) }
+        function Write-STStatus { param([string]$Message, [string]$Level) }
         # Stub Add-Type so the script can be dot-sourced without loading GUI assemblies
         function Add-Type {}
         . $PSScriptRoot/../scripts/AddUsersToGroup.ps1

--- a/tests/AddUsersToGroup.Tests.ps1
+++ b/tests/AddUsersToGroup.Tests.ps1
@@ -11,21 +11,10 @@ Describe 'AddUsersToGroup Script' {
         function Get-CSVFilePath {}
         function Import-Csv { param([string]$Path) }
         function Get-UserID { param([string]$UserPrincipalName) }
-
-        function Start-Main {
-            param([string]$CsvPath, [string]$GroupName)
-            Connect-MgGraph
-            $group = Get-Group -GroupName $GroupName
-            $existing = Get-GroupExistingMembers -Group $group
-            $users = (Import-Csv $CsvPath).UPN
-            foreach ($u in $users) {
-                if ($existing -notcontains $u) {
-                    $userInfo = Get-UserID -UserPrincipalName $u
-                    if ($userInfo) { New-MgGroupMember }
-                }
-            }
-            Disconnect-MgGraph
-        }
+        # Stub Add-Type so the script can be dot-sourced without loading GUI assemblies
+        function Add-Type {}
+        . $PSScriptRoot/../scripts/AddUsersToGroup.ps1
+        Remove-Item function:Add-Type -ErrorAction SilentlyContinue
     }
     BeforeEach {
         Mock Connect-MgGraph {}


### PR DESCRIPTION
## Summary
- dot source AddUsersToGroup.ps1 so the real script is exercised
- keep helper stubs and mocks for external commands

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68439e615ba0832c978bfc101537e5aa