### PR TITLE
Add script tests

### DIFF
--- a/tests/ScriptFiles.Tests.ps1
+++ b/tests/ScriptFiles.Tests.ps1
@@ -1,0 +1,22 @@
+Describe 'Standalone Scripts' {
+    It 'generates maintenance task XML without registering' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+        New-Item -ItemType Directory -Path $tempDir | Out-Null
+        Push-Location $tempDir
+        try {
+            & $PSScriptRoot/../scripts/Setup-ScheduledMaintenance.ps1
+            Test-Path 'WeeklyCleanupTask.xml' | Should -Be $true
+            Test-Path 'GroupMaintenanceTask.xml' | Should -Be $true
+            Test-Path 'PermissionAuditTask.xml' | Should -Be $true
+        } finally {
+            Pop-Location
+            Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'builds a function dependency graph' {
+        $result = & $PSScriptRoot/../scripts/Get-FunctionDependencyGraph.ps1 -Path $PSScriptRoot/../scripts/AddUsersToGroup.ps1 -Format Graphviz
+        $result | Should -Match 'digraph'
+        $result | Should -Match 'Start-Main'
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester tests exercising two standalone script files

## Testing
- `pwsh -NoProfile -Command Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a45974d4832c8c2100351e7c21f1