### PR TITLE
Refresh module banners

### DIFF
--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -172,3 +172,11 @@ function Write-STClosing {
 }
 
 Export-ModuleMember -Function 'Write-STLog','Write-STRichLog','Write-STStatus','Show-STPrompt','Write-STDivider','Write-STBlock','Write-STClosing'
+
+function Show-LoggingBanner {
+    Write-STDivider 'LOGGING MODULE LOADED' -Style heavy
+    Write-STStatus "Run 'Get-Command -Module Logging' to view available tools." -Level SUB
+    Write-STLog -Message 'Logging module loaded'
+}
+
+Show-LoggingBanner

--- a/src/PerformanceTools/PerformanceTools.psm1
+++ b/src/PerformanceTools/PerformanceTools.psm1
@@ -46,3 +46,11 @@ function Measure-STCommand {
 }
 
 Export-ModuleMember -Function 'Measure-STCommand'
+
+function Show-PerformanceToolsBanner {
+    Write-STDivider 'PERFORMANCETOOLS MODULE LOADED' -Style heavy
+    Write-STStatus "Run 'Get-Command -Module PerformanceTools' to view available tools." -Level SUB
+    Write-STLog -Message 'PerformanceTools module loaded'
+}
+
+Show-PerformanceToolsBanner

--- a/src/ServiceDeskTools/ServiceDeskTools.psm1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psm1
@@ -11,3 +11,11 @@ Get-ChildItem -Path "$PublicDir" -Filter *.ps1 -ErrorAction SilentlyContinue |
 Export-ModuleMember -Function (
     Get-ChildItem "$PublicDir/*.ps1" -ErrorAction SilentlyContinue
 ).BaseName
+
+function Show-ServiceDeskToolsBanner {
+    Write-STDivider 'SERVICEDESKTOOLS MODULE LOADED' -Style heavy
+    Write-STStatus "Run 'Get-Command -Module ServiceDeskTools' to view available tools." -Level SUB
+    Write-STLog -Message 'ServiceDeskTools module loaded'
+}
+
+Show-ServiceDeskToolsBanner

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -903,9 +903,7 @@ function Register-SPToolsCompleters {
 }
 
 function Show-SharePointToolsBanner {
-    Write-STStatus '════════════════════════════════════════════' -Level INFO
-    Write-STStatus 'SHAREPOINTTOOLS MODULE ACTIVATED' -Level SUCCESS
-    Write-STStatus '════════════════════════════════════════════' -Level INFO
+    Write-STDivider 'SHAREPOINTTOOLS MODULE LOADED' -Style heavy
     Write-STStatus "Run 'Get-Command -Module SharePointTools' to view available tools." -Level SUB
     Write-STLog -Message 'SharePointTools module loaded'
 }

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -52,9 +52,7 @@ Export-ModuleMember -Function @(
 
 
 function Show-SupportToolsBanner {
-    Write-STStatus '════════════════════════════════════════════' -Level INFO
-    Write-STStatus 'SUPPORTTOOLS MODULE ACTIVATED' -Level SUCCESS
-    Write-STStatus '════════════════════════════════════════════' -Level INFO
+    Write-STDivider 'SUPPORTTOOLS MODULE LOADED' -Style heavy
     Write-STStatus "Run 'Get-Command -Module SupportTools' to view available tools." -Level SUB
     Write-STLog -Message 'SupportTools module loaded'
 }

--- a/src/Telemetry/Telemetry.psm1
+++ b/src/Telemetry/Telemetry.psm1
@@ -1,4 +1,7 @@
 
+$loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+Import-Module $loggingModule -ErrorAction SilentlyContinue
+
 function Write-STTelemetryEvent {
     [CmdletBinding()]
     param(
@@ -84,3 +87,11 @@ function Get-STTelemetryMetrics {
 }
 
 Export-ModuleMember -Function 'Write-STTelemetryEvent','Get-STTelemetryMetrics'
+
+function Show-TelemetryBanner {
+    Write-STDivider 'TELEMETRY MODULE LOADED' -Style heavy
+    Write-STStatus "Run 'Get-Command -Module Telemetry' to view available tools." -Level SUB
+    Write-STLog -Message 'Telemetry module loaded'
+}
+
+Show-TelemetryBanner


### PR DESCRIPTION
## Summary
- modernize module activation banners
- use `Write-STDivider` for consistent style across modules
- add missing banners to Logging, PerformanceTools, ServiceDeskTools, and Telemetry modules

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: unable to locate package)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration ./PesterConfiguration.psd1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a4274e14832c8138a7900a24fc45