### PR TITLE
Add incident response script

### DIFF
--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -12,6 +12,7 @@ Commands for interacting with the Service Desk ticketing API.
 | `Search-SDTicket` | Search incidents by keyword | `Search-SDTicket -Query 'printer'` |
 | `Set-SDTicketBulk` | Apply updates to multiple incidents | `Set-SDTicketBulk -Id 1,2,3 -Fields @{ status='Closed' }` |
 | `Link-SDTicketToSPTask` | Add a related SharePoint task link | `Link-SDTicketToSPTask -TicketId 42 -TaskUrl 'https://contoso.sharepoint.com/tasks/1'` |
+| `Submit-Ticket` | Create a Service Desk incident with minimal parameters | `Submit-Ticket -Subject 'Alert' -Description 'Issue detected' -RequesterEmail 'ops@example.com'` |
 
 `SD_API_TOKEN` must be set in the environment. Optionally set `SD_BASE_URI` if your Service Desk API uses a custom URL.
 

--- a/docs/ServiceDeskTools/Submit-Ticket.md
+++ b/docs/ServiceDeskTools/Submit-Ticket.md
@@ -1,0 +1,10 @@
+---
+external help file: ServiceDeskTools-help.xml
+Module Name: ServiceDeskTools
+online version:
+schema: 2.0.0
+---
+
+# Submit-Ticket
+
+Creates a Service Desk incident using the supplied subject, description and requester email. This is a wrapper around `New-SDTicket`.

--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -52,6 +52,7 @@ listed are forwarded to the underlying script unchanged.
 | `Set-TimeZoneEasternStandardTime` | `Set-TimeZoneEasternStandardTime.ps1` | *passthrough* | `Set-TimeZoneEasternStandardTime` |
 | `Start-Countdown` | `SimpleCountdown.ps1` | *passthrough* | `Start-Countdown -Seconds 30` |
 | `Update-Sysmon` | `Update-Sysmon.ps1` | *passthrough* | `Update-Sysmon -SourcePath D:\Tools` |
+| `Invoke-IncidentResponse` | `Invoke-IncidentResponse.ps1` | *passthrough* | `Invoke-IncidentResponse` |
 | `Invoke-CompanyPlaceManagement` | `Invoke-CompanyPlaceManagement.ps1` | `Action`, `DisplayName`, `[Type]`, `Street`, `City`, `State`, `PostalCode`, `CountryOrRegion`, `[AutoAddFloor]` | `Invoke-CompanyPlaceManagement -Action Create -DisplayName 'HQ' -Type Building -City Seattle` |
 | `Submit-SystemInfoTicket` | `Submit-SystemInfoTicket.ps1` | `SiteName`, `RequesterEmail`, `[Subject]`, `[Description]`, `[LibraryName]`, `[FolderPath]` | `Submit-SystemInfoTicket -SiteName IT -RequesterEmail 'user@contoso.com'` |
 | `New-SPUsageReport` | `Generate-SPUsageReport.ps1` | `[ItemThreshold]`, `[RequesterEmail]`, `[CsvPath]`, `[TranscriptPath]` | `New-SPUsageReport -RequesterEmail 'user@contoso.com'` |

--- a/docs/SupportTools/Invoke-IncidentResponse.md
+++ b/docs/SupportTools/Invoke-IncidentResponse.md
@@ -1,0 +1,23 @@
+---
+external help file: SupportTools-help.xml
+Module Name: SupportTools
+online version:
+schema: 2.0.0
+---
+
+# Invoke-IncidentResponse
+
+## SYNOPSIS
+Collect incident response data and optionally submit a Service Desk ticket.
+
+## SYNTAX
+```
+Invoke-IncidentResponse [[-Arguments] <Object[]>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Wraps the `Invoke-IncidentResponse.ps1` script. The command gathers recent event logs,
+process details, network connections and other information into a timestamped folder.
+If unsigned processes are found running from temporary directories a ticket is created
+via `Submit-Ticket` in the ServiceDeskTools module.

--- a/scripts/Invoke-IncidentResponse.ps1
+++ b/scripts/Invoke-IncidentResponse.ps1
@@ -1,0 +1,94 @@
+<#+
+.SYNOPSIS
+    Consolidate forensic data for immediate incident response.
+.DESCRIPTION
+    Collects recent Security and System event logs, running process
+    details with file hashes and signatures, logged in users, network
+    connections, local administrators, services and startup items.
+    Results are saved to a timestamped folder. If unsigned processes
+    executing from temporary directories are detected, the script
+    triggers Submit-Ticket from the ServiceDeskTools module.
+.PARAMETER OutputDirectory
+    Directory to store collected data. Defaults to a folder in TEMP.
+.PARAMETER RequesterEmail
+    Email address used when submitting a Service Desk ticket.
+.PARAMETER TranscriptPath
+    Optional transcript log path.
+#>
+[CmdletBinding()]
+param(
+    [string]$OutputDirectory = (Join-Path $env:TEMP "IR_$((Get-Date).ToString('yyyyMMdd_HHmmss'))"),
+    [string]$RequesterEmail,
+    [string]$TranscriptPath
+)
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction SilentlyContinue
+
+if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+
+try {
+    New-Item -Path $OutputDirectory -ItemType Directory -Force | Out-Null
+    Write-STStatus "Collecting event logs" -Level INFO -Log
+    Get-WinEvent -LogName Security -MaxEvents 200 | Export-Clixml -Path (Join-Path $OutputDirectory 'Security.xml')
+    Get-WinEvent -LogName System   -MaxEvents 200 | Export-Clixml -Path (Join-Path $OutputDirectory 'System.xml')
+
+    Write-STStatus "Gathering process information" -Level INFO -Log
+    $processes = Get-Process | ForEach-Object {
+        $path = $_.Path
+        $hash = $null
+        $signer = $null
+        if ($path) {
+            try { $hash = (Get-FileHash -Algorithm SHA256 -Path $path).Hash } catch {}
+            try {
+                $sig = Get-AuthenticodeSignature -FilePath $path
+                if ($sig.SignerCertificate) { $signer = $sig.SignerCertificate.Subject }
+            } catch {}
+        }
+        [pscustomobject]@{
+            Name   = $_.ProcessName
+            Id     = $_.Id
+            Path   = $path
+            Hash   = $hash
+            Signer = $signer
+        }
+    }
+    $procPath = Join-Path $OutputDirectory 'Processes.csv'
+    $processes | Export-Csv -NoTypeInformation -Path $procPath -Encoding utf8
+
+    Write-STStatus "Capturing user sessions" -Level INFO -Log
+    try { qwinsta | Out-File -FilePath (Join-Path $OutputDirectory 'LoggedInUsers.txt') -Encoding utf8 }
+    catch { Write-STStatus "qwinsta failed: $_" -Level WARN -Log }
+
+    Write-STStatus "Listing network connections" -Level INFO -Log
+    Get-NetTCPConnection | Select-Object LocalAddress,LocalPort,RemoteAddress,RemotePort,State |
+        Export-Csv -NoTypeInformation -Path (Join-Path $OutputDirectory 'NetConnections.csv') -Encoding utf8
+
+    Write-STStatus "Enumerating local administrators" -Level INFO -Log
+    try {
+        Get-LocalGroupMember -Group 'Administrators' |
+            Select-Object Name,SID |
+            Export-Csv -NoTypeInformation -Path (Join-Path $OutputDirectory 'LocalAdmins.csv') -Encoding utf8
+    } catch {
+        Write-STStatus "Failed to list local admins: $_" -Level WARN -Log
+    }
+
+    Write-STStatus "Recording services and startup items" -Level INFO -Log
+    Get-Service | Select-Object Name,DisplayName,Status,StartType |
+        Export-Csv -NoTypeInformation -Path (Join-Path $OutputDirectory 'Services.csv') -Encoding utf8
+    Get-CimInstance Win32_StartupCommand | Select-Object Name,Command,Location,User |
+        Export-Csv -NoTypeInformation -Path (Join-Path $OutputDirectory 'StartupItems.csv') -Encoding utf8
+
+    $highRisk = $processes | Where-Object { -not $_.Signer -and $_.Path -match '(?i)\\temp\\' }
+    if ($highRisk.Count -gt 0 -and $RequesterEmail) {
+        Write-STStatus "High-risk processes detected" -Level ERROR -Log
+        $desc = "Unsigned processes found in temp locations on $env:COMPUTERNAME.`n`n" +
+                 ($highRisk | Format-Table Name,Path -AutoSize | Out-String) +
+                 "`nReport folder: $OutputDirectory"
+        Submit-Ticket -Subject "Incident Response - $env:COMPUTERNAME" -Description $desc -RequesterEmail $RequesterEmail | Out-Null
+    }
+
+    Write-STStatus "Incident response data saved to $OutputDirectory" -Level SUCCESS -Log
+} finally {
+    if ($TranscriptPath) { Stop-Transcript | Out-Null }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,6 +23,7 @@ The following table provides a brief description of each script.
 | **Set-TimeZoneEasternStandardTime.ps1** | Sets the system time zone to Eastern Standard Time. |
 | **SimpleCountdown.ps1** | Outputs a simple countdown from 10 to 1. |
 | **Update-Sysmon.ps1** | Reinstalls Sysmon from a removable drive and verifies it is running. |
+| **Invoke-IncidentResponse.ps1** | Collects forensic data for immediate incident response and submits a ticket when threats are detected. |
 | **Submit-SystemInfoTicket.ps1** | Collects system info, uploads it to SharePoint and opens a Service Desk ticket. |
 | **SS_DEPLOYMENT_TEMPLATE.ps1** | Template for sneaker net deployments that installs agents and configures a system. |
 | **Configure-SharePointTools.ps1** | Prompts for SharePoint application values and saves them to a settings file. |

--- a/src/ServiceDeskTools/Public/Submit-Ticket.ps1
+++ b/src/ServiceDeskTools/Public/Submit-Ticket.ps1
@@ -1,0 +1,24 @@
+function Submit-Ticket {
+    <#
+    .SYNOPSIS
+        Creates a basic Service Desk incident.
+    .DESCRIPTION
+        Wrapper around New-SDTicket providing a simpler command name.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Subject,
+        [Parameter(Mandatory)][string]$Description,
+        [Parameter(Mandatory)][string]$RequesterEmail,
+        [switch]$ChaosMode,
+        [switch]$Explain
+    )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
+
+    Write-STLog -Message "Submit-Ticket $Subject"
+    New-SDTicket -Subject $Subject -Description $Description -RequesterEmail $RequesterEmail -ChaosMode:$ChaosMode
+}

--- a/src/SupportTools/Public/Invoke-IncidentResponse.ps1
+++ b/src/SupportTools/Public/Invoke-IncidentResponse.ps1
@@ -1,0 +1,19 @@
+function Invoke-IncidentResponse {
+    <#
+    .SYNOPSIS
+        Gather forensic data for incident response triage.
+    .DESCRIPTION
+        Wraps the Invoke-IncidentResponse.ps1 script located in the scripts folder.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments=$true, ValueFromPipeline=$true)]
+        [object[]]$Arguments,
+        [string]$TranscriptPath,
+        [switch]$Simulate,
+        [switch]$Explain
+    )
+    process {
+        Invoke-ScriptFile -Name 'Invoke-IncidentResponse.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+    }
+}

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -31,6 +31,7 @@
         'Set-SharedMailboxAutoReply',
         'Set-TimeZoneEasternStandardTime',
         'Start-Countdown',
+        'Invoke-IncidentResponse',
         'Submit-SystemInfoTicket',
         'Sync-SupportTools',
         'Update-Sysmon'

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -45,6 +45,7 @@ Export-ModuleMember -Function @(
     'Set-SharedMailboxAutoReply',
     'Set-TimeZoneEasternStandardTime',
     'Start-Countdown',
+    'Invoke-IncidentResponse',
     'Submit-SystemInfoTicket',
     'Sync-SupportTools',
     'Update-Sysmon'

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -27,6 +27,7 @@ Describe 'SupportTools Module' {
             'Set-SharedMailboxAutoReply',
             'Invoke-ExchangeCalendarManager',
             'Invoke-CompanyPlaceManagement',
+            'Invoke-IncidentResponse',
             'Submit-SystemInfoTicket',
             'New-SPUsageReport'
             'Install-MaintenanceTasks'
@@ -63,6 +64,7 @@ Describe 'SupportTools Module' {
             Set_TimeZoneEasternStandardTime = 'Set-TimeZoneEasternStandardTime.ps1'
             Start_Countdown              = 'SimpleCountdown.ps1'
             Update_Sysmon                = 'Update-Sysmon.ps1'
+            Invoke_IncidentResponse      = 'Invoke-IncidentResponse.ps1'
             Submit_SystemInfoTicket      = 'Submit-SystemInfoTicket.ps1'
             New_SPUsageReport            = 'Generate-SPUsageReport.ps1'
             Install_MaintenanceTasks = 'Setup-ScheduledMaintenance.ps1'


### PR DESCRIPTION
## Summary
- add incident response collection script and wrapper
- allow ServiceDeskTools to submit tickets via new `Submit-Ticket`
- document new commands
- export the new wrapper from SupportTools
- cover wrapper in tests

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a8a57cac832c8d399f2fa91e44c5