### PR TITLE
Add ChaosTools module for chaos testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository packages a collection of scripts into reusable modules.
 * **SharePointTools** – commands for SharePoint cleanup tasks such as removing archives or sharing links.
 * **ServiceDeskTools** – interact with the Service Desk ticketing system.
 * **PerformanceTools** – measure script runtime and resource usage.
+* **ChaosTools** – inject random failures to validate error handling.
 
 ### Module Maturity
 
@@ -17,6 +18,7 @@ This repository packages a collection of scripts into reusable modules.
 | SharePointTools | Beta |
 | ServiceDeskTools | Experimental |
 | PerformanceTools | Experimental |
+| ChaosTools | Experimental |
 
 ## Requirements 📋
 
@@ -51,6 +53,7 @@ This repository packages a collection of scripts into reusable modules.
    Import-Module ./src/SupportTools/SupportTools.psd1
    Import-Module ./src/SharePointTools/SharePointTools.psd1
    Import-Module ./src/ServiceDeskTools/ServiceDeskTools.psd1
+   Import-Module ./src/ChaosTools/ChaosTools.psd1
    ```
 
 4. Run the SharePoint configuration script once to store tenant information:
@@ -77,7 +80,7 @@ Invoke-YFArchiveCleanup -Verbose
 Get-SPToolsAllLibraryReports | Format-Table
 ```
 
-See [docs/SupportTools.md](docs/SupportTools.md), [docs/SharePointTools.md](docs/SharePointTools.md), [docs/ServiceDeskTools.md](docs/ServiceDeskTools.md) and [docs/PerformanceTools.md](docs/PerformanceTools.md) for a full list of commands. For a short introduction refer to [docs/Quickstart.md](docs/Quickstart.md). For detailed deployment guidance see [docs/UserGuide.md](docs/UserGuide.md).
+See [docs/SupportTools.md](docs/SupportTools.md), [docs/SharePointTools.md](docs/SharePointTools.md), [docs/ServiceDeskTools.md](docs/ServiceDeskTools.md), [docs/PerformanceTools.md](docs/PerformanceTools.md) and [docs/ChaosTools.md](docs/ChaosTools.md) for a full list of commands. For a short introduction refer to [docs/Quickstart.md](docs/Quickstart.md). For detailed deployment guidance see [docs/UserGuide.md](docs/UserGuide.md).
 
 The module also provides `Set-SharedMailboxAutoReply` for configuring automatic
 out-of-office replies on a shared mailbox.

--- a/docs/ChaosTools.md
+++ b/docs/ChaosTools.md
@@ -1,0 +1,15 @@
+# ChaosTools Module
+
+Provides utilities for injecting random failures to test robustness of scripts.
+Import the module manifest and run `Invoke-ChaosTest` with a script block that
+executes the commands you want to exercise.
+
+```powershell
+Import-Module ./src/ChaosTools/ChaosTools.psd1
+Invoke-ChaosTest -ScriptBlock { Get-ChildItem -Path . } -Scope 'Get-ChildItem'
+```
+
+The `-Scope` parameter lists the cmdlets that should be wrapped. During
+test execution the wrapper randomly delays execution, throws transient
+errors, or tweaks parameter values. All chaos injections are written to
+the log using `Write-STLog` so failures can be traced easily.

--- a/src/ChaosTools/ChaosTools.psd1
+++ b/src/ChaosTools/ChaosTools.psd1
@@ -1,0 +1,8 @@
+@{
+    RootModule = 'ChaosTools.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000099'
+    Author = 'Contoso'
+    Description = 'Chaos testing utilities.'
+    FunctionsToExport = @('Invoke-ChaosTest')
+}

--- a/src/ChaosTools/ChaosTools.psm1
+++ b/src/ChaosTools/ChaosTools.psm1
@@ -1,0 +1,72 @@
+$loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+Import-Module $loggingModule -ErrorAction SilentlyContinue
+$telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
+Import-Module $telemetryModule -ErrorAction SilentlyContinue
+
+function Invoke-ChaosTest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [scriptblock]$ScriptBlock,
+        [string[]]$Scope = @()
+    )
+
+    $wrapped = @()
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        foreach ($cmd in $Scope) {
+            $command = Get-Command $cmd -ErrorAction SilentlyContinue
+            if (-not $command) {
+                Write-STStatus "[Chaos] Command $cmd not found" -Level WARN -Log
+                continue
+            }
+            $qualified = if ($command.Source) { "$($command.Source)\$($command.Name)" } else { $command.Name }
+            $code = @"
+param([object[]]`$Args)
+Write-STLog -Message '[Chaos] Intercepted $cmd' -Structured
+`$rand = Get-Random -Minimum 1 -Maximum 101
+if (`$rand -le 30) {
+    `$delay = Get-Random -Minimum 1 -Maximum 3
+    Write-STStatus "[Chaos] Delay $cmd by $delay sec" -Level WARN -Log
+    Start-Sleep -Seconds `$delay
+} elseif (`$rand -le 60) {
+    Write-STStatus "[Chaos] Throwing transient error for $cmd" -Level ERROR -Log
+    throw 'ChaosTest simulated transient error'
+} elseif (`$rand -le 90) {
+    Write-STStatus "[Chaos] Modifying parameters for $cmd" -Level WARN -Log
+    `$Args = `$Args | ForEach-Object {
+        if (`$_ -is [int]) { `$_ + 1 }
+        elseif (`$_ -is [double]) { `$_ + 1 }
+        elseif (`$_ -is [string]) { "`$_-typo" }
+        else { `$_ }
+    }
+}
+& $qualified @Args
+"@
+            Set-Item -Path "function:$cmd" -Value ([scriptblock]::Create($code)) -Force
+            $wrapped += $cmd
+        }
+
+        & $ScriptBlock
+        $sw.Stop()
+        Write-STTelemetryEvent -ScriptName 'Invoke-ChaosTest' -Result 'Success' -Duration $sw.Elapsed
+    } catch {
+        $sw.Stop()
+        Write-STTelemetryEvent -ScriptName 'Invoke-ChaosTest' -Result 'Failure' -Duration $sw.Elapsed
+        throw
+    } finally {
+        foreach ($cmd in $wrapped) {
+            Remove-Item -Path "function:$cmd" -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Export-ModuleMember -Function 'Invoke-ChaosTest'
+
+function Show-ChaosToolsBanner {
+    Write-STDivider 'CHAOSTOOLS MODULE LOADED' -Style heavy
+    Write-STStatus "Run 'Get-Command -Module ChaosTools' to view available tools." -Level SUB
+    Write-STLog -Message 'ChaosTools module loaded'
+}
+
+Show-ChaosToolsBanner


### PR DESCRIPTION
## Summary
- add new ChaosTools module containing `Invoke-ChaosTest`
- document ChaosTools module
- mention ChaosTools in README module list and examples

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile './PesterConfiguration.psd1')`

------
https://chatgpt.com/codex/tasks/task_e_6843a9553830832cb0f13966b82a2e5b