### PR TITLE
Add injectable interfaces for SupportTools cmdlets

### DIFF
--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -13,6 +13,9 @@ function Invoke-ScriptFile {
         [string]$Name,
         [Parameter(ValueFromRemainingArguments=$true)]
         [object[]]$Args,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config,
         [string]$TranscriptPath,
         [switch]$Simulate,
         [switch]$Explain
@@ -23,6 +26,22 @@ function Invoke-ScriptFile {
         (Import-PowerShellDataFile $manifest).ModuleVersion
     } catch {
         'unknown'
+    }
+
+    if ($Logger) {
+        Import-Module $Logger -ErrorAction SilentlyContinue
+    } elseif ($loggingModule) {
+        Import-Module $loggingModule -ErrorAction SilentlyContinue
+    }
+
+    if ($TelemetryClient) {
+        Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+    } elseif ($telemetryModule) {
+        Import-Module $telemetryModule -ErrorAction SilentlyContinue
+    }
+
+    if ($Config) {
+        Import-Module $Config -ErrorAction SilentlyContinue
     }
     $Path = Join-Path $PSScriptRoot '..' |
             Join-Path -ChildPath '..' |

--- a/src/SupportTools/Public/Add-UserToGroup.ps1
+++ b/src/SupportTools/Public/Add-UserToGroup.ps1
@@ -18,7 +18,10 @@ function Add-UserToGroup {
         [string]$GroupName,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
 
     process {
@@ -32,6 +35,6 @@ function Add-UserToGroup {
             $arguments += $GroupName
         }
 
-        Invoke-ScriptFile -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Clear-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Clear-ArchiveFolder.ps1
@@ -12,9 +12,12 @@ function Clear-ArchiveFolder {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Clear-TempFile.ps1
+++ b/src/SupportTools/Public/Clear-TempFile.ps1
@@ -11,9 +11,12 @@ function Clear-TempFile {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "CleanupTempFiles.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "CleanupTempFiles.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Convert-ExcelToCsv.ps1
+++ b/src/SupportTools/Public/Convert-ExcelToCsv.ps1
@@ -12,9 +12,12 @@ function Convert-ExcelToCsv {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "Convert-ExcelToCsv.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Convert-ExcelToCsv.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Export-ProductKey.ps1
+++ b/src/SupportTools/Public/Export-ProductKey.ps1
@@ -12,9 +12,12 @@ function Export-ProductKey {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "ProductKey.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "ProductKey.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Get-CommonSystemInfo.ps1
+++ b/src/SupportTools/Public/Get-CommonSystemInfo.ps1
@@ -7,10 +7,26 @@ function Get-CommonSystemInfo {
         CIM classes and returns it as a custom object.
     #>
     [CmdletBinding()]
-    param()
+    param(
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
+    )
 
     process {
-        Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -ErrorAction SilentlyContinue
+        if ($Logger) {
+            Import-Module $Logger -ErrorAction SilentlyContinue
+        } else {
+            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -ErrorAction SilentlyContinue
+        }
+        if ($TelemetryClient) {
+            Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+        } else {
+            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+        }
+        if ($Config) {
+            Import-Module $Config -ErrorAction SilentlyContinue
+        }
 
         Write-STStatus 'Collecting system information...' -Level INFO
 

--- a/src/SupportTools/Public/Get-FailedLogin.ps1
+++ b/src/SupportTools/Public/Get-FailedLogin.ps1
@@ -12,9 +12,12 @@ function Get-FailedLogin {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "Get-FailedLogins.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Get-FailedLogins.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Get-NetworkShare.ps1
+++ b/src/SupportTools/Public/Get-NetworkShare.ps1
@@ -12,9 +12,12 @@ function Get-NetworkShare {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "Get-NetworkShares.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Get-NetworkShares.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Get-UniquePermission.ps1
+++ b/src/SupportTools/Public/Get-UniquePermission.ps1
@@ -12,9 +12,12 @@ function Get-UniquePermission {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "Get-UniquePermissions.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Get-UniquePermissions.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Install-Font.ps1
+++ b/src/SupportTools/Public/Install-Font.ps1
@@ -12,9 +12,12 @@ function Install-Font {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "Install-Fonts.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Install-Fonts.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Install-MaintenanceTasks.ps1
+++ b/src/SupportTools/Public/Install-MaintenanceTasks.ps1
@@ -13,11 +13,14 @@ function Install-MaintenanceTasks {
         [switch]$Register,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
         $argsList = @()
         if ($Register) { $argsList += '-Register' }
-        Invoke-ScriptFile -Name 'Setup-ScheduledMaintenance.ps1' -Args $argsList -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Setup-ScheduledMaintenance.ps1' -Args $argsList -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Invoke-CompanyPlaceManagement.ps1
+++ b/src/SupportTools/Public/Invoke-CompanyPlaceManagement.ps1
@@ -30,8 +30,25 @@ function Invoke-CompanyPlaceManagement {
         [switch]$AutoAddFloor,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
+
+    if ($Logger) {
+        Import-Module $Logger -ErrorAction SilentlyContinue
+    } else {
+        Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -ErrorAction SilentlyContinue
+    }
+    if ($TelemetryClient) {
+        Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+    } else {
+        Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+    }
+    if ($Config) {
+        Import-Module $Config -ErrorAction SilentlyContinue
+    }
 
     if ($Explain) {
         Get-Help $MyInvocation.PSCommandPath -Full

--- a/src/SupportTools/Public/Invoke-DeploymentTemplate.ps1
+++ b/src/SupportTools/Public/Invoke-DeploymentTemplate.ps1
@@ -12,9 +12,12 @@ function Invoke-DeploymentTemplate {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "SS_DEPLOYMENT_TEMPLATE.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "SS_DEPLOYMENT_TEMPLATE.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/SupportTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -10,8 +10,25 @@ function Invoke-ExchangeCalendarManager {
     param(
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
+
+    if ($Logger) {
+        Import-Module $Logger -ErrorAction SilentlyContinue
+    } else {
+        Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -ErrorAction SilentlyContinue
+    }
+    if ($TelemetryClient) {
+        Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+    } else {
+        Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+    }
+    if ($Config) {
+        Import-Module $Config -ErrorAction SilentlyContinue
+    }
 
     if ($Explain) {
         Get-Help $MyInvocation.PSCommandPath -Full

--- a/src/SupportTools/Public/Invoke-GroupMembershipCleanup.ps1
+++ b/src/SupportTools/Public/Invoke-GroupMembershipCleanup.ps1
@@ -16,12 +16,15 @@ function Invoke-GroupMembershipCleanup {
         [Parameter(ValueFromPipelineByPropertyName=$true)]
         [string]$GroupName,
         [string]$TranscriptPath,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
         $arguments = @()
         if ($PSBoundParameters.ContainsKey('CsvPath')) { $arguments += '-CsvPath'; $arguments += $CsvPath }
         if ($PSBoundParameters.ContainsKey('GroupName')) { $arguments += '-GroupName'; $arguments += $GroupName }
-        Invoke-ScriptFile -Name 'CleanupGroupMembership.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'CleanupGroupMembership.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Invoke-JobBundle.ps1
+++ b/src/SupportTools/Public/Invoke-JobBundle.ps1
@@ -25,7 +25,7 @@ function Invoke-JobBundle {
 
         $transcript = [IO.Path]::GetTempFileName()
         $args = @('-BundlePath', $Path)
-        Invoke-ScriptFile -Name 'Run-JobBundle.ps1' -Args $args -TranscriptPath $transcript
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Run-JobBundle.ps1' -Args $args -TranscriptPath $transcript
 
         $logFile = if ($env:ST_LOG_PATH) {
             $env:ST_LOG_PATH

--- a/src/SupportTools/Public/Invoke-PostInstall.ps1
+++ b/src/SupportTools/Public/Invoke-PostInstall.ps1
@@ -12,9 +12,12 @@ function Invoke-PostInstall {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "PostInstallScript.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "PostInstallScript.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/New-SPUsageReport.ps1
+++ b/src/SupportTools/Public/New-SPUsageReport.ps1
@@ -11,9 +11,12 @@ function New-SPUsageReport {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name 'Generate-SPUsageReport.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Generate-SPUsageReport.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Restore-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Restore-ArchiveFolder.ps1
@@ -12,9 +12,12 @@ function Restore-ArchiveFolder {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "RollbackArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "RollbackArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Search-ReadMe.ps1
+++ b/src/SupportTools/Public/Search-ReadMe.ps1
@@ -12,9 +12,12 @@ function Search-ReadMe {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "Search-ReadMe.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Search-ReadMe.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Set-ComputerIPAddress.ps1
+++ b/src/SupportTools/Public/Set-ComputerIPAddress.ps1
@@ -11,9 +11,12 @@ function Set-ComputerIPAddress {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "Set-ComputerIPAddress.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Set-ComputerIPAddress.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Set-NetAdapterMetering.ps1
+++ b/src/SupportTools/Public/Set-NetAdapterMetering.ps1
@@ -12,9 +12,12 @@ function Set-NetAdapterMetering {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "Set-NetAdapterMetering.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Set-NetAdapterMetering.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
+++ b/src/SupportTools/Public/Set-SharedMailboxAutoReply.ps1
@@ -24,8 +24,25 @@ function Set-SharedMailboxAutoReply {
         [switch]$UseWebLogin,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
+
+    if ($Logger) {
+        Import-Module $Logger -ErrorAction SilentlyContinue
+    } else {
+        Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -ErrorAction SilentlyContinue
+    }
+    if ($TelemetryClient) {
+        Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+    } else {
+        Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+    }
+    if ($Config) {
+        Import-Module $Config -ErrorAction SilentlyContinue
+    }
 
     if ($Explain) {
         Get-Help $MyInvocation.PSCommandPath -Full

--- a/src/SupportTools/Public/Set-TimeZoneEasternStandardTime.ps1
+++ b/src/SupportTools/Public/Set-TimeZoneEasternStandardTime.ps1
@@ -12,9 +12,12 @@ function Set-TimeZoneEasternStandardTime {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "Set-TimeZoneEasternStandardTime.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Set-TimeZoneEasternStandardTime.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Start-Countdown.ps1
+++ b/src/SupportTools/Public/Start-Countdown.ps1
@@ -12,9 +12,12 @@ function Start-Countdown {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "SimpleCountdown.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "SimpleCountdown.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Submit-SystemInfoTicket.ps1
+++ b/src/SupportTools/Public/Submit-SystemInfoTicket.ps1
@@ -15,7 +15,10 @@ function Submit-SystemInfoTicket {
         [string]$FolderPath,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
         $arguments = @('-SiteName', $SiteName, '-RequesterEmail', $RequesterEmail)
@@ -23,6 +26,6 @@ function Submit-SystemInfoTicket {
         if ($PSBoundParameters.ContainsKey('Description')) { $arguments += @('-Description', $Description) }
         if ($PSBoundParameters.ContainsKey('LibraryName')) { $arguments += @('-LibraryName', $LibraryName) }
         if ($PSBoundParameters.ContainsKey('FolderPath'))  { $arguments += @('-FolderPath', $FolderPath) }
-        Invoke-ScriptFile -Name 'Submit-SystemInfoTicket.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Submit-SystemInfoTicket.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Sync-SupportTools.ps1
+++ b/src/SupportTools/Public/Sync-SupportTools.ps1
@@ -14,8 +14,25 @@ function Sync-SupportTools {
     param(
         [string]$RepositoryUrl = 'https://github.com/yourlastnamesoundslikeatypeofpasta/PowerShell.git',
         [string]$InstallPath = $(if ($env:USERPROFILE) { Join-Path $env:USERPROFILE 'SupportTools' } else { Join-Path $env:HOME 'SupportTools' }),
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
+
+    if ($Logger) {
+        Import-Module $Logger -ErrorAction SilentlyContinue
+    } else {
+        Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -ErrorAction SilentlyContinue
+    }
+    if ($TelemetryClient) {
+        Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+    } else {
+        Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+    }
+    if ($Config) {
+        Import-Module $Config -ErrorAction SilentlyContinue
+    }
 
     if ($Explain) {
         Get-Help $MyInvocation.PSCommandPath -Full

--- a/src/SupportTools/Public/Update-Sysmon.ps1
+++ b/src/SupportTools/Public/Update-Sysmon.ps1
@@ -11,9 +11,12 @@ function Update-Sysmon {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name "Update-Sysmon.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Update-Sysmon.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -1,9 +1,14 @@
 @{
     RootModule = 'SupportTools.psm1'
-    ModuleVersion = '1.3.0'
+    ModuleVersion = '1.4.0'
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000001'
     Author = 'Contoso'
     Description = 'Collection of helper functions wrapping existing scripts.'
+
+    NestedModules = @(
+        '../Logging/Logging.psd1',
+        '../Telemetry/Telemetry.psd1'
+    )
 
     FunctionsToExport = @(
         'Add-UserToGroup',


### PR DESCRIPTION
## Summary
- allow public cmdlets to receive `-Logger`, `-TelemetryClient` and `-Config`
- load custom modules when provided in `Invoke-ScriptFile`
- support external logging and telemetry modules in Get-CommonSystemInfo and other non-wrapper cmdlets
- include Logging and Telemetry as nested modules in manifest and bump version

## Testing
- `Invoke-Pester -CI` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843aa1f4010832ca67715dcdaddf2e5