### PR TITLE
Add categorized telemetry metrics

### DIFF
--- a/scripts/Invoke-DailyAuditWorkflow.ps1
+++ b/scripts/Invoke-DailyAuditWorkflow.ps1
@@ -76,6 +76,6 @@ try {
     throw
 } finally {
     $stopwatch.Stop()
-    Write-STTelemetryEvent -ScriptName $scriptName -Result $result -Duration $stopwatch.Elapsed
+    Send-STMetric -MetricName $scriptName -Category 'Audit' -Value $stopwatch.Elapsed.TotalSeconds -Details @{ Result = $result }
     if ($TranscriptPath) { Stop-Transcript | Out-Null }
 }

--- a/scripts/Run-JobBundle.ps1
+++ b/scripts/Run-JobBundle.ps1
@@ -60,7 +60,8 @@ try {
     throw
 } finally {
     $duration = (Get-Date) - $start
-    Write-STTelemetryEvent -ScriptName (Split-Path $scriptPath -Leaf) -Result $result -Duration $duration
+    $name = (Split-Path $scriptPath -Leaf)
+    Send-STMetric -MetricName $name -Category 'Deployment' -Value $duration.TotalSeconds -Details @{ Result = $result }
     Pop-Location
     Remove-Item $tempDir -Recurse -Force
 }

--- a/src/GraphTools/Public/Get-GraphUserDetails.ps1
+++ b/src/GraphTools/Public/Get-GraphUserDetails.ps1
@@ -54,6 +54,6 @@ function Get-GraphUserDetails {
         throw
     } finally {
         $sw.Stop()
-        Write-STTelemetryEvent -ScriptName 'Get-GraphUserDetails' -Result $result -Duration $sw.Elapsed
+        Send-STMetric -MetricName 'Get-GraphUserDetails' -Category 'Audit' -Value $sw.Elapsed.TotalSeconds -Details @{ Result = $result }
     }
 }

--- a/src/PerformanceTools/Invoke-PerformanceAudit.ps1
+++ b/src/PerformanceTools/Invoke-PerformanceAudit.ps1
@@ -115,7 +115,7 @@ try {
     throw
 } finally {
     $stopwatch.Stop()
-    Write-STTelemetryEvent -ScriptName $scriptName -Result $result -Duration $stopwatch.Elapsed
+    Send-STMetric -MetricName $scriptName -Category 'Audit' -Value $stopwatch.Elapsed.TotalSeconds -Details @{ Result = $result }
     if ($TranscriptPath) { Stop-Transcript | Out-Null }
     Write-STClosing
 }

--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -18,7 +18,8 @@ function Invoke-ScriptFile {
         [object]$Config,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [string]$Category = 'General'
     )
     Assert-ParameterNotNull $Name 'Name'
     # Retrieve the SupportTools module version for log metadata
@@ -93,7 +94,7 @@ function Invoke-ScriptFile {
         $sw.Stop()
         $duration = $sw.Elapsed
         Write-STLog -Metric 'Duration' -Value $duration.TotalSeconds
-        Write-STTelemetryEvent -ScriptName $Name -Result $result -Duration $duration
+        Send-STMetric -MetricName $Name -Category $Category -Value $duration.TotalSeconds -Details @{ Result = $result }
     }
     Write-STStatus "COMPLETED $Name" -Level FINAL -Log
 }

--- a/src/SupportTools/Public/Invoke-FullSystemAudit.ps1
+++ b/src/SupportTools/Public/Invoke-FullSystemAudit.ps1
@@ -42,8 +42,8 @@ function Invoke-FullSystemAudit {
                 $errors += [pscustomobject]@{ Stage = $Name; Error = $_.ToString() }
                 $result = 'Failure'
             } finally {
-                $sw.Stop()
-                Write-STTelemetryEvent -ScriptName $Name -Result $result -Duration $sw.Elapsed
+            $sw.Stop()
+            Send-STMetric -MetricName $Name -Category 'Audit' -Value $sw.Elapsed.TotalSeconds -Details @{ Result = $result }
             }
             return $out
         }

--- a/src/Telemetry/Telemetry.psd1
+++ b/src/Telemetry/Telemetry.psd1
@@ -4,5 +4,5 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000011'
     Author = 'Contoso'
     Description = 'Telemetry utilities.'
-    FunctionsToExport = @('Write-STTelemetryEvent','Get-STTelemetryMetrics')
+    FunctionsToExport = @('Write-STTelemetryEvent','Get-STTelemetryMetrics','Send-STMetric')
 }

--- a/tests/GraphTools.Tests.ps1
+++ b/tests/GraphTools.Tests.ps1
@@ -14,10 +14,10 @@ Describe 'GraphTools Module' {
             Mock Get-GraphAccessToken { 't' } -ModuleName GraphTools
             Mock Invoke-RestMethod { @{ id='1'; displayName='User'; userPrincipalName='u' } } -ModuleName GraphTools -ParameterFilter { $Method -eq 'GET' }
             Mock Write-STLog {} -ModuleName GraphTools
-            Mock Write-STTelemetryEvent {} -ModuleName GraphTools
+            Mock Send-STMetric {} -ModuleName GraphTools
             Get-GraphUserDetails -UserPrincipalName 'u' -TenantId 'tid' -ClientId 'cid'
             Assert-MockCalled Write-STLog -ModuleName GraphTools -Times 1
-            Assert-MockCalled Write-STTelemetryEvent -ModuleName GraphTools -Times 1
+            Assert-MockCalled Send-STMetric -ModuleName GraphTools -Times 1
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend Telemetry module with category & operationId fields
- add new `Send-STMetric` wrapper
- use `Send-STMetric` across SupportTools and PerformanceTools
- update tests

## Testing
- `Invoke-Pester -Output Detailed` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843af4a33d0832cb98a63775830679b