### PR TITLE
Add Pester helper and guidelines

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ The key guides are:
 - [Telemetry Metrics](./Telemetry/Get-STTelemetryMetrics.md) – summarize execution statistics and output to CSV or SQLite.
 - [Get-FunctionDependencyGraph](./Get-FunctionDependencyGraph.md) – generate a visual map of function calls in a script.
 - [Local Mock API](./LocalMockApi.md) – run a lightweight HTTP server for offline tests.
+- [Testing Guidelines](./TestingGuidelines.md) – conventions for writing robust Pester tests.
 - [Stewardship](./Stewardship.md) – how to maintain and hand off the project.
 - [Roadmap](./Roadmap.md) – upcoming features and goals.
 

--- a/docs/TestingGuidelines.md
+++ b/docs/TestingGuidelines.md
@@ -1,0 +1,17 @@
+# Testing Guidelines
+
+This repository uses Pester for unit tests. New tests should wrap assertions in
+`Safe-It` instead of `It` to ensure failures are reported with clear context and
+do not break unrelated cases.
+
+```powershell
+. $PSScriptRoot/../TestHelpers.ps1
+Safe-It 'does something' {
+    # test code
+}
+```
+
+`Safe-It` catches any exception thrown within the block and rethrows a simplified
+message that includes the failing test name and the error line number. Use
+`TestDrive:` for temporary files and mock external calls so tests do not depend
+on the local environment.

--- a/tests/TestHelpers.ps1
+++ b/tests/TestHelpers.ps1
@@ -1,0 +1,20 @@
+function Safe-It {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][scriptblock]$ScriptBlock,
+        [object[]]$ForEach
+    )
+    $itParams = @{ Name = $Name }
+    if ($PSBoundParameters.ContainsKey('ForEach')) { $itParams.ForEach = $ForEach }
+    It @itParams {
+        param($case)
+        try {
+            if ($PSBoundParameters.ContainsKey('ForEach')) { & $ScriptBlock $case } else { & $ScriptBlock }
+        } catch {
+            $err = $_
+            $line = $err.InvocationInfo.ScriptLineNumber
+            $msg = $err.Exception.Message
+            throw "Test failed in ${Name}: [$msg] at line $line"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `Safe-It` helper for tests
- document robust test practices in new TestingGuidelines document
- link Testing Guidelines from docs overview

## Testing
- `pwsh -NoLogo -NoProfile -Command '$cfg = Import-PowerShellDataFile ./PesterConfiguration.psd1; Invoke-Pester -Configuration $cfg'` *(fails: `Tests Passed: 0, Failed: 161`)*

------
https://chatgpt.com/codex/tasks/task_e_6843b3e14598832c89f1bbf91a93146f