### PR TITLE
Add ChaosTools module for chaos testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository packages a collection of scripts into reusable modules.
 * **ServiceDeskTools** – interact with the Service Desk ticketing system.
 * **PerformanceTools** – measure script runtime and resource usage.
 * **GraphTools** – query Microsoft Graph for common account information.
+* **ChaosTools** – inject random delays and failures to test error handling.
 
 ### Module Maturity
 
@@ -19,6 +20,7 @@ This repository packages a collection of scripts into reusable modules.
 | ServiceDeskTools | Experimental |
 | PerformanceTools | Experimental |
 | GraphTools | Experimental |
+| ChaosTools | Experimental |
 
 ## Requirements 📋
 
@@ -80,7 +82,13 @@ Invoke-YFArchiveCleanup -Verbose
 Get-SPToolsAllLibraryReports | Format-Table
 ```
 
-See [docs/SupportTools.md](docs/SupportTools.md), [docs/SharePointTools.md](docs/SharePointTools.md), [docs/ServiceDeskTools.md](docs/ServiceDeskTools.md), [docs/PerformanceTools.md](docs/PerformanceTools.md) and [docs/GraphTools.md](docs/GraphTools.md) for a full list of commands. For a short introduction refer to [docs/Quickstart.md](docs/Quickstart.md). For detailed deployment guidance see [docs/UserGuide.md](docs/UserGuide.md).
+### ChaosTools example
+
+```powershell
+Invoke-ChaosTest -ScriptBlock { Get-Service } -FailureRate 0.2
+```
+
+See [docs/SupportTools.md](docs/SupportTools.md), [docs/SharePointTools.md](docs/SharePointTools.md), [docs/ServiceDeskTools.md](docs/ServiceDeskTools.md), [docs/PerformanceTools.md](docs/PerformanceTools.md), [docs/GraphTools.md](docs/GraphTools.md) and [docs/ChaosTools.md](docs/ChaosTools.md) for a full list of commands. For a short introduction refer to [docs/Quickstart.md](docs/Quickstart.md). For detailed deployment guidance see [docs/UserGuide.md](docs/UserGuide.md).
 
 The module also provides `Set-SharedMailboxAutoReply` for configuring automatic
 out-of-office replies on a shared mailbox.

--- a/docs/ChaosTools.md
+++ b/docs/ChaosTools.md
@@ -1,0 +1,16 @@
+# ChaosTools Module
+
+Provides helpers for chaos testing and fault injection.
+Import the module with its manifest:
+
+```powershell
+Import-Module ./src/ChaosTools/ChaosTools.psd1
+```
+
+## Available Commands
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `Invoke-ChaosTest` | Randomly delay or fail execution of a script block | `Invoke-ChaosTest -ScriptBlock { Get-Service } -FailureRate 0.2` |
+
+Use these tools to validate that your automation gracefully handles transient failures.

--- a/docs/ChaosTools/Invoke-ChaosTest.md
+++ b/docs/ChaosTools/Invoke-ChaosTest.md
@@ -1,0 +1,1 @@
+Runs a script block with random delays and failures to simulate unstable conditions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ The key guides are:
 
 - [Quickstart](./Quickstart.md) – short steps to install the modules and run common commands.
 - [User Guide](./UserGuide.md) – detailed deployment information and security notes.
-- [SupportTools](./SupportTools.md), [SharePointTools](./SharePointTools.md), [ServiceDeskTools](./ServiceDeskTools.md) – high level summaries of each module and the commands they expose.
+- [SupportTools](./SupportTools.md), [SharePointTools](./SharePointTools.md), [ServiceDeskTools](./ServiceDeskTools.md), [ChaosTools](./ChaosTools.md) – high level summaries of each module and the commands they expose.
 - [Credential Storage](./CredentialStorage.md) – recommended approach to store secrets securely.
 - [Module Style Guide](./ModuleStyleGuide.md) – how scripts display progress messages and log output.
 - [PerformanceTools](./PerformanceTools.md) – measure execution time and resource usage.

--- a/src/ChaosTools/ChaosTools.psd1
+++ b/src/ChaosTools/ChaosTools.psd1
@@ -1,0 +1,10 @@
+@{
+    RootModule = 'ChaosTools.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000013'
+    Author = 'Contoso'
+    Description = 'Chaos testing helpers.'
+    RequiredModules = @('Logging')
+    PrivateData = @{ PSData = @{ Tags = @('PowerShell','Chaos','Internal') } }
+    FunctionsToExport = @('Invoke-ChaosTest')
+}

--- a/src/ChaosTools/ChaosTools.psm1
+++ b/src/ChaosTools/ChaosTools.psm1
@@ -1,0 +1,17 @@
+$coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
+$loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+Import-Module $coreModule -ErrorAction SilentlyContinue
+Import-Module $loggingModule -ErrorAction SilentlyContinue
+
+$PublicDir = Join-Path $PSScriptRoot 'Public'
+Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
+
+Export-ModuleMember -Function 'Invoke-ChaosTest'
+
+function Show-ChaosToolsBanner {
+    Write-STDivider 'CHAOSTOOLS MODULE LOADED' -Style heavy
+    Write-STStatus "Run 'Get-Command -Module ChaosTools' to view available tools." -Level SUB
+    Write-STLog -Message 'ChaosTools module loaded'
+}
+
+Show-ChaosToolsBanner

--- a/src/ChaosTools/Public/Invoke-ChaosTest.ps1
+++ b/src/ChaosTools/Public/Invoke-ChaosTest.ps1
@@ -1,0 +1,41 @@
+function Invoke-ChaosTest {
+    <#
+    .SYNOPSIS
+        Executes a script block with random failures.
+    .DESCRIPTION
+        Runs the given commands and randomly throws an error based on FailureRate.
+        A random delay up to MaxDelaySeconds is introduced before execution.
+    .PARAMETER ScriptBlock
+        Commands to invoke.
+    .PARAMETER FailureRate
+        Probability from 0 to 1 of injecting a failure.
+    .PARAMETER MaxDelaySeconds
+        Maximum random delay before execution.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [scriptblock]$ScriptBlock,
+        [double]$FailureRate = 0.3,
+        [int]$MaxDelaySeconds = 5
+    )
+
+    Assert-ParameterNotNull $ScriptBlock 'ScriptBlock'
+    if ($FailureRate -lt 0 -or $FailureRate -gt 1) {
+        throw 'FailureRate must be between 0 and 1.'
+    }
+    if ($MaxDelaySeconds -gt 0) {
+        $delay = Get-Random -Minimum 0 -Maximum ($MaxDelaySeconds + 1)
+        Start-Sleep -Seconds $delay
+    }
+
+    $threshold = [int]([int]::MaxValue * $FailureRate)
+    $rand = Get-Random
+    if ($rand -lt $threshold) {
+        Write-STStatus 'Chaos failure injected.' -Level ERROR -Log
+        throw 'Chaos test failure.'
+    }
+
+    Write-STStatus 'Executing chaos test script block.' -Level INFO -Log
+    & $ScriptBlock
+}

--- a/tests/ChaosTools.Tests.ps1
+++ b/tests/ChaosTools.Tests.ps1
@@ -1,0 +1,20 @@
+Describe 'ChaosTools Module' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../src/ChaosTools/ChaosTools.psd1 -Force
+    }
+
+    It 'exports Invoke-ChaosTest' {
+        (Get-Command -Module ChaosTools).Name | Should -Contain 'Invoke-ChaosTest'
+    }
+
+    It 'executes a script block when failure rate is zero' {
+        $ran = $false
+        Invoke-ChaosTest -ScriptBlock { $script:ran = $true } -FailureRate 0 -MaxDelaySeconds 0
+        $ran | Should -BeTrue
+    }
+
+    It 'throws when failure rate is one' {
+        { Invoke-ChaosTest -ScriptBlock { } -FailureRate 1 -MaxDelaySeconds 0 } | Should -Throw
+    }
+}


### PR DESCRIPTION
## Summary
- add new ChaosTools module with Invoke-ChaosTest
- document ChaosTools in docs and README
- include ChaosTools in module maturity table and examples
- add Pester tests for ChaosTools

## Testing
- `pwsh -NoProfile -Command Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684497e97510832c9645c8c08c8d9e37