### PR TITLE
Fix module scope in new tests

### DIFF
--- a/tests/PerformanceTools/Measure-STCommand.Tests.ps1
+++ b/tests/PerformanceTools/Measure-STCommand.Tests.ps1
@@ -1,0 +1,31 @@
+Describe 'Measure-STCommand function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/PerformanceTools/PerformanceTools.psd1 -Force
+    }
+
+    It 'returns timing metrics' {
+        InModuleScope PerformanceTools {
+            Mock Write-STStatus {}
+            $result = Measure-STCommand -ScriptBlock { Start-Sleep -Milliseconds 5 }
+            $result | Should -Not -BeNull
+            $result.DurationSeconds | Should -BeGreaterThan 0
+            $result.CpuSeconds | Should -BeGreaterOrEqual 0
+        }
+    }
+
+    It 'writes status messages when not quiet' {
+        InModuleScope PerformanceTools {
+            Mock Write-STStatus {} -Verifiable
+            Measure-STCommand -ScriptBlock { }
+            Assert-MockCalled Write-STStatus -Times 3
+        }
+    }
+
+    It 'suppresses status when Quiet' {
+        InModuleScope PerformanceTools {
+            Mock Write-STStatus {}
+            Measure-STCommand -ScriptBlock { } -Quiet
+            Assert-MockCalled Write-STStatus -Times 0
+        }
+    }
+}

--- a/tests/SharePointTools/Get-SPToolsSiteUrl.Tests.ps1
+++ b/tests/SharePointTools/Get-SPToolsSiteUrl.Tests.ps1
@@ -1,0 +1,41 @@
+Describe 'Get-SPToolsSiteUrl function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/SharePointTools/SharePointTools.psd1 -Force
+    }
+
+    BeforeEach {}
+
+    It 'returns the matching URL' {
+        InModuleScope SharePointTools {
+            $ExecutionContext.SessionState.PSVariable.Set('SharePointToolsSettings', @{ Sites = @{ A='https://a'; B='https://b' } })
+            Mock Write-SPToolsHacker {}
+            Get-SPToolsSiteUrl -SiteName 'A' | Should -Be 'https://a'
+        }
+    }
+
+    It 'supports pipeline input' {
+        InModuleScope SharePointTools {
+            $ExecutionContext.SessionState.PSVariable.Set('SharePointToolsSettings', @{ Sites = @{ A='https://a'; B='https://b' } })
+            Mock Write-SPToolsHacker {}
+            [pscustomobject]@{ SiteName='B' } | Get-SPToolsSiteUrl | Should -Be 'https://b'
+        }
+    }
+
+    It 'throws when site is missing' {
+        InModuleScope SharePointTools {
+            $ExecutionContext.SessionState.PSVariable.Set('SharePointToolsSettings', @{ Sites = @{ A='https://a' } })
+            Mock Write-SPToolsHacker {}
+            { Get-SPToolsSiteUrl -SiteName 'C' } | Should -Throw
+        }
+    }
+
+    It 'logs lookup messages' {
+        InModuleScope SharePointTools {
+            $ExecutionContext.SessionState.PSVariable.Set('SharePointToolsSettings', @{ Sites = @{ A='https://a' } })
+            Mock Write-SPToolsHacker {}
+            Get-SPToolsSiteUrl -SiteName 'A' | Out-Null
+            Assert-MockCalled Write-SPToolsHacker -Times 1 -ParameterFilter { $Message -eq 'Looking up A' }
+            Assert-MockCalled Write-SPToolsHacker -Times 1 -ParameterFilter { $Message -eq 'URL found: https://a' }
+        }
+    }
+}

--- a/tests/SupportTools/Add-UserToGroup.Tests.ps1
+++ b/tests/SupportTools/Add-UserToGroup.Tests.ps1
@@ -1,0 +1,35 @@
+Describe 'Add-UserToGroup function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force
+    }
+
+    It 'passes parameters to Invoke-ScriptFile' {
+        InModuleScope SupportTools {
+            Mock Invoke-ScriptFile {} -ModuleName SupportTools
+            Add-UserToGroup -CsvPath 'users.csv' -GroupName 'TeamA'
+            Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -Times 1 -ParameterFilter {
+                $Name -eq 'AddUsersToGroup.ps1'
+            }
+        }
+    }
+
+    It 'accepts pipeline input' {
+        InModuleScope SupportTools {
+            Mock Invoke-ScriptFile {} -ModuleName SupportTools
+            [pscustomobject]@{ CsvPath='input.csv'; GroupName='G1' } | Add-UserToGroup
+            Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -Times 1 -ParameterFilter {
+                $Name -eq 'AddUsersToGroup.ps1'
+            }
+        }
+    }
+
+    It 'forwards transcript and switches' {
+        InModuleScope SupportTools {
+            Mock Invoke-ScriptFile {} -ModuleName SupportTools
+            Add-UserToGroup -TranscriptPath 't.log' -Simulate -Explain
+            Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -Times 1 -ParameterFilter {
+                $TranscriptPath -eq 't.log' -and $Simulate -and $Explain
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- import each module before using `InModuleScope`
- move `InModuleScope` blocks inside individual tests

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)` *(fails: parameter validation for Get-SPToolsSiteUrl)*

------
https://chatgpt.com/codex/tasks/task_e_6843a9b953ac832c978dcafc7df17cbd