### PR TITLE
Add Invoke-RemoteAudit cmdlet

### DIFF
--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -58,6 +58,7 @@ listed are forwarded to the underlying script unchanged.
 | `New-SPUsageReport` | `Generate-SPUsageReport.ps1` | `[ItemThreshold]`, `[RequesterEmail]`, `[CsvPath]`, `[TranscriptPath]` | `New-SPUsageReport -RequesterEmail 'user@contoso.com'` |
 | `Install-MaintenanceTasks` | `Setup-ScheduledMaintenance.ps1` | `[Register]` | `Install-MaintenanceTasks -Register` |
 | `Sync-SupportTools` | *git* | `[RepositoryUrl]`, `[InstallPath]` | `Sync-SupportTools` |
+| `Invoke-RemoteAudit` | *built-in* | `ComputerName` | `Invoke-RemoteAudit -ComputerName PC1` |
 
 For details on what each script does see [scripts/README.md](../scripts/README.md).
 

--- a/docs/SupportTools/Invoke-RemoteAudit.md
+++ b/docs/SupportTools/Invoke-RemoteAudit.md
@@ -1,0 +1,56 @@
+---
+external help file: SupportTools-help.xml
+Module Name: SupportTools
+online version:
+schema: 2.0.0
+---
+
+# Invoke-RemoteAudit
+
+## SYNOPSIS
+Collects common system information from remote computers.
+
+## SYNTAX
+```
+Invoke-RemoteAudit [-ComputerName] <String[]> [-Credential <PSCredential>] [-UseSSL] [-Port <Int>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Uses PowerShell remoting to run `Get-CommonSystemInfo` on each specified computer. The command
+returns an object for every target containing either the collected information or the error
+encountered.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Invoke-RemoteAudit -ComputerName PC1,PC2
+```
+Collect system information from two remote computers.
+
+## PARAMETERS
+### -ComputerName
+One or more computer names to audit.
+
+### -Credential
+Credential for the remote session.
+
+### -UseSSL
+Use HTTPS/SSL for the remote session.
+
+### -Port
+Alternate remoting port. Defaults to `5985`.
+
+### CommonParameters
+This cmdlet supports the common parameters. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+## OUTPUTS
+### System.Management.Automation.PSCustomObject
+Each object contains `ComputerName`, `Success`, and either `Info` or `Error` fields.
+
+## NOTES
+## RELATED LINKS
+Get-CommonSystemInfo

--- a/src/SupportTools/Public/Invoke-RemoteAudit.ps1
+++ b/src/SupportTools/Public/Invoke-RemoteAudit.ps1
@@ -1,0 +1,52 @@
+function Invoke-RemoteAudit {
+    <#
+    .SYNOPSIS
+        Collects common system information from remote computers.
+    .DESCRIPTION
+        Uses PowerShell remoting to run Get-CommonSystemInfo on one or more
+        target computers. The command returns an object for each computer
+        containing the collected information or the error encountered.
+    .PARAMETER ComputerName
+        One or more computer names to audit remotely.
+    .PARAMETER Credential
+        Credential to use for the remote session.
+    .PARAMETER UseSSL
+        Use HTTPS/SSL for the remoting session.
+    .PARAMETER Port
+        Alternate port number for the remote session.
+    .OUTPUTS
+        PSCustomObject with ComputerName, Success, and either Info or Error
+        properties describing the result for each computer.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position=0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [string[]]$ComputerName,
+        [Parameter()]
+        [System.Management.Automation.PSCredential]$Credential,
+        [switch]$UseSSL,
+        [int]$Port = 5985
+    )
+    process {
+        foreach ($comp in $ComputerName) {
+            $invokeParams = @{ ComputerName = $comp }
+            if ($PSBoundParameters.ContainsKey('Credential')) { $invokeParams.Credential = $Credential }
+            if ($UseSSL) { $invokeParams.UseSSL = $true }
+            if ($PSBoundParameters.ContainsKey('Port')) { $invokeParams.Port = $Port }
+            try {
+                $info = Invoke-Command @invokeParams -ScriptBlock { Get-CommonSystemInfo }
+                [pscustomobject]@{
+                    ComputerName = $comp
+                    Info         = $info
+                    Success      = $true
+                }
+            } catch {
+                [pscustomobject]@{
+                    ComputerName = $comp
+                    Error        = $_.Exception.Message
+                    Success      = $false
+                }
+            }
+        }
+    }
+}

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -38,6 +38,7 @@
         'Invoke-JobBundle',
         'Invoke-PostInstall',
         'Invoke-PerformanceAudit',
+        'Invoke-RemoteAudit',
         'Invoke-FullSystemAudit',
         'Restore-ArchiveFolder',
         'Search-ReadMe',

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -41,6 +41,7 @@ Export-ModuleMember -Function @(
     'Invoke-JobBundle',
     'Invoke-PostInstall',
     'Invoke-PerformanceAudit',
+    'Invoke-RemoteAudit',
     'Invoke-FullSystemAudit',
     'Restore-ArchiveFolder',
     'Search-ReadMe',

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -39,6 +39,7 @@ Describe 'SupportTools Module' {
             'Sync-SupportTools',
             'Invoke-JobBundle',
             'Invoke-PerformanceAudit',
+            'Invoke-RemoteAudit',
             'Invoke-FullSystemAudit'
         )
 
@@ -177,6 +178,22 @@ Describe 'SupportTools Module' {
                 $result.Processor    | Should -Be 'CPU'
                 $result.Memory       | Should -Be (1048576 / 1MB)
                 $result.DiskSpace    | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'Invoke-RemoteAudit behavior' {
+        It 'runs Get-CommonSystemInfo on the remote computer' {
+            InModuleScope SupportTools {
+                function Invoke-Command { param($ComputerName) }
+                Mock Invoke-Command { [pscustomobject]@{ Test='ok' } } -ModuleName SupportTools
+
+                $result = Invoke-RemoteAudit -ComputerName 'PC1'
+
+                Assert-MockCalled Invoke-Command -ModuleName SupportTools -Times 1 -ParameterFilter { $ComputerName -eq 'PC1' }
+                $result.ComputerName | Should -Be 'PC1'
+                $result.Success | Should -Be $true
+                $result.Info.Test | Should -Be 'ok'
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `Invoke-RemoteAudit` command
- export command in module
- document usage of new cmdlet
- update tests for export and behaviour

## Testing
- `Invoke-Pester -Configuration PesterConfiguration.psd1` *(fails: `pwsh` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684497de27cc832c902fad1f2c48b50c