### PR TITLE
Add ChaosTools module for chaos testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository packages a collection of scripts into reusable modules.
 * **ServiceDeskTools** – interact with the Service Desk ticketing system.
 * **PerformanceTools** – measure script runtime and resource usage.
 * **GraphTools** – query Microsoft Graph for common account information.
+* **ChaosTools** – simulate failures to test error handling.
 
 ### Module Maturity
 
@@ -19,6 +20,7 @@ This repository packages a collection of scripts into reusable modules.
 | ServiceDeskTools | Experimental |
 | PerformanceTools | Experimental |
 | GraphTools | Experimental |
+| ChaosTools | Experimental |
 
 ## Requirements 📋
 
@@ -54,6 +56,7 @@ This repository packages a collection of scripts into reusable modules.
    Import-Module ./src/SharePointTools/SharePointTools.psd1
    Import-Module ./src/ServiceDeskTools/ServiceDeskTools.psd1
    Import-Module ./src/GraphTools/GraphTools.psd1
+   Import-Module ./src/ChaosTools/ChaosTools.psd1
    ```
 
 4. Run the SharePoint configuration script once to store tenant information:
@@ -80,7 +83,13 @@ Invoke-YFArchiveCleanup -Verbose
 Get-SPToolsAllLibraryReports | Format-Table
 ```
 
-See [docs/SupportTools.md](docs/SupportTools.md), [docs/SharePointTools.md](docs/SharePointTools.md), [docs/ServiceDeskTools.md](docs/ServiceDeskTools.md), [docs/PerformanceTools.md](docs/PerformanceTools.md) and [docs/GraphTools.md](docs/GraphTools.md) for a full list of commands. For a short introduction refer to [docs/Quickstart.md](docs/Quickstart.md). For detailed deployment guidance see [docs/UserGuide.md](docs/UserGuide.md).
+### ChaosTools example
+
+```powershell
+Invoke-ChaosTest -Iterations 2 -ChaosMode
+```
+
+See [docs/SupportTools.md](docs/SupportTools.md), [docs/SharePointTools.md](docs/SharePointTools.md), [docs/ServiceDeskTools.md](docs/ServiceDeskTools.md), [docs/PerformanceTools.md](docs/PerformanceTools.md), [docs/GraphTools.md](docs/GraphTools.md) and [docs/ChaosTools.md](docs/ChaosTools.md) for a full list of commands. For a short introduction refer to [docs/Quickstart.md](docs/Quickstart.md). For detailed deployment guidance see [docs/UserGuide.md](docs/UserGuide.md).
 
 The module also provides `Set-SharedMailboxAutoReply` for configuring automatic
 out-of-office replies on a shared mailbox.

--- a/docs/ChaosTools.md
+++ b/docs/ChaosTools.md
@@ -1,0 +1,15 @@
+# ChaosTools Module
+
+Utilities for chaos engineering and fault injection. Import using its manifest:
+
+```powershell
+Import-Module ./src/ChaosTools/ChaosTools.psd1
+```
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `Invoke-ChaosTest` | Run randomized delays and optional errors to validate retry logic. |
+
+Use the `-ChaosMode` switch or set `ST_CHAOS_MODE=1` to enable failures.

--- a/docs/ChaosTools/Invoke-ChaosTest.md
+++ b/docs/ChaosTools/Invoke-ChaosTest.md
@@ -1,0 +1,37 @@
+---
+external help file: ChaosTools-help.xml
+Module Name: ChaosTools
+online version:
+schema: 2.0.0
+---
+
+# Invoke-ChaosTest
+
+## SYNOPSIS
+Run randomized delays and failures to test error handling.
+
+## SYNTAX
+Invoke-ChaosTest [[-Iterations] <Int32>] [[-MaxDelaySeconds] <Int32>] [[-FailureRate] <Int32>] [-ChaosMode] [<CommonParameters>]
+
+## DESCRIPTION
+`Invoke-ChaosTest` introduces random waits and optional failures. Use it during development to validate retry logic and monitoring alerts. Pass `-ChaosMode` or set the `ST_CHAOS_MODE` environment variable to enable error injection.
+
+## PARAMETERS
+### -Iterations
+Number of loops to perform. Default is `5`.
+### -MaxDelaySeconds
+Upper bound on the delay between iterations. Default is `5` seconds.
+### -FailureRate
+Percentage chance that an iteration throws when chaos mode is enabled. Default is `20`.
+### -ChaosMode
+Switch to force chaos mode regardless of `ST_CHAOS_MODE`.
+
+## EXAMPLES
+### Example 1
+```powershell
+Invoke-ChaosTest -Iterations 3 -MaxDelaySeconds 2 -FailureRate 10 -ChaosMode
+```
+Runs three cycles with up to two seconds delay and a 10% chance to throw an error each loop.
+
+## RELATED LINKS
+[docs/ChaosTools.md](../ChaosTools.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ The key guides are:
 - [Credential Storage](./CredentialStorage.md) – recommended approach to store secrets securely.
 - [Module Style Guide](./ModuleStyleGuide.md) – how scripts display progress messages and log output.
 - [PerformanceTools](./PerformanceTools.md) – measure execution time and resource usage.
+- [ChaosTools](./ChaosTools.md) – run fault-injection tests during development.
 - [Telemetry Metrics](./Telemetry/Get-STTelemetryMetrics.md) – summarize execution statistics and output to CSV or SQLite.
 - [Get-FunctionDependencyGraph](./Get-FunctionDependencyGraph.md) – generate a visual map of function calls in a script.
 - [Local Mock API](./LocalMockApi.md) – run a lightweight HTTP server for offline tests.

--- a/src/ChaosTools/ChaosTools.psd1
+++ b/src/ChaosTools/ChaosTools.psd1
@@ -1,0 +1,10 @@
+@{
+    RootModule = 'ChaosTools.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000013'
+    Author = 'Contoso'
+    Description = 'Tools for chaos engineering and fault injection.'
+    RequiredModules = @('Logging','Telemetry')
+    PrivateData = @{ PSData = @{ Tags = @('PowerShell','Chaos','Testing','Internal') } }
+    FunctionsToExport = @('Invoke-ChaosTest')
+}

--- a/src/ChaosTools/ChaosTools.psm1
+++ b/src/ChaosTools/ChaosTools.psm1
@@ -1,0 +1,55 @@
+$coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
+Import-Module $coreModule -ErrorAction SilentlyContinue
+$loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+Import-Module $loggingModule -ErrorAction SilentlyContinue
+$telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
+Import-Module $telemetryModule -ErrorAction SilentlyContinue
+
+function Invoke-ChaosTest {
+    <#
+    .SYNOPSIS
+        Run randomized delays and optional failures for resilience testing.
+    .DESCRIPTION
+        Generates pauses and randomly throws errors when `-ChaosMode` or the `ST_CHAOS_MODE` environment variable is set. Use to validate retry logic and monitoring alerts.
+    .PARAMETER Iterations
+        Number of iterations to execute.
+    .PARAMETER MaxDelaySeconds
+        Maximum delay in seconds for each iteration.
+    .PARAMETER FailureRate
+        Percent chance of throwing an error each iteration.
+    .PARAMETER ChaosMode
+        Force chaos behavior regardless of environment variable.
+    .EXAMPLE
+        Invoke-ChaosTest -Iterations 3 -MaxDelaySeconds 2 -FailureRate 10
+
+        Run three cycles with up to two seconds delay and a 10% failure chance.
+    #>
+    [CmdletBinding()]
+    param(
+        [int]$Iterations = 5,
+        [int]$MaxDelaySeconds = 5,
+        [int]$FailureRate = 20,
+        [switch]$ChaosMode
+    )
+    if (-not $ChaosMode) { $ChaosMode = [bool]$env:ST_CHAOS_MODE }
+    for ($i = 1; $i -le $Iterations; $i++) {
+        $delayMs = Get-Random -Minimum 100 -Maximum ($MaxDelaySeconds * 1000)
+        Write-STStatus "[>] Iteration $i delaying $delayMs ms" -Level SUB -Log
+        Start-Sleep -Milliseconds $delayMs
+        if ($ChaosMode -and (Get-Random -Minimum 1 -Maximum 100) -le $FailureRate) {
+            Write-STLog -Message "Chaos failure at iteration $i" -Level ERROR -Structured
+            throw "ChaosMode failure during iteration $i"
+        }
+    }
+    Write-STStatus 'Chaos test completed' -Level FINAL -Log
+}
+
+Export-ModuleMember -Function 'Invoke-ChaosTest'
+
+function Show-ChaosBanner {
+    Write-STDivider 'CHAOSTOOLS MODULE LOADED' -Style heavy
+    Write-STStatus "Run 'Invoke-ChaosTest' to begin fault injection." -Level SUB
+    Write-STLog -Message 'ChaosTools module loaded'
+}
+
+Show-ChaosBanner

--- a/tests/ChaosTools.Tests.ps1
+++ b/tests/ChaosTools.Tests.ps1
@@ -1,0 +1,17 @@
+Describe 'ChaosTools Module' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../src/ChaosTools/ChaosTools.psd1 -Force
+    }
+
+    It 'exports Invoke-ChaosTest' {
+        (Get-Command -Module ChaosTools).Name | Should -Contain 'Invoke-ChaosTest'
+    }
+
+    It 'runs without error when ChaosMode disabled' {
+        InModuleScope ChaosTools {
+            Invoke-ChaosTest -Iterations 1 -MaxDelaySeconds 0 -FailureRate 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce new ChaosTools module with `Invoke-ChaosTest`
- document ChaosTools module and command
- reference ChaosTools in docs index
- update README with ChaosTools module info and example
- add Pester tests for ChaosTools

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844982e20c4832c8f3ef87f95c0fe4e