### PR TITLE
Allow SupportTools cmdlets to inject logging and telemetry modules

### DIFF
--- a/src/SupportTools/Public/Invoke-IncidentResponse.ps1
+++ b/src/SupportTools/Public/Invoke-IncidentResponse.ps1
@@ -11,9 +11,12 @@ function Invoke-IncidentResponse {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name 'Invoke-IncidentResponse.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Invoke-IncidentResponse.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/Public/Invoke-PerformanceAudit.ps1
+++ b/src/SupportTools/Public/Invoke-PerformanceAudit.ps1
@@ -11,9 +11,12 @@ function Invoke-PerformanceAudit {
         [object[]]$Arguments,
         [string]$TranscriptPath,
         [switch]$Simulate,
-        [switch]$Explain
+        [switch]$Explain,
+        [object]$Logger,
+        [object]$TelemetryClient,
+        [object]$Config
     )
     process {
-        Invoke-ScriptFile -Name 'Invoke-PerformanceAudit.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Invoke-PerformanceAudit.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -1,15 +1,16 @@
 @{
     RootModule = 'SupportTools.psm1'
-    ModuleVersion = '1.4.0'
+    ModuleVersion = '1.4.1'
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000001'
     Author = 'Contoso'
     Description = 'Collection of helper functions wrapping existing scripts.'
     RequiredModules = @('Logging','SharePointTools','ServiceDeskTools','Telemetry')
-    PrivateData = @{ 
-        PSData = @{ 
+    PrivateData = @{
+        PSData = @{
             Tags = @('PowerShell','SupportTools','SharePoint','ServiceDesk','Internal')
             ProjectUri = 'https://contoso.com/supporttools'
             LicenseUri = 'https://contoso.com/license'
+            ExternalInterfaces = @('Logging','Telemetry','Config')
         }
     }
 


### PR DESCRIPTION
## Summary
- add optional logger, telemetry and config parameters to performance and incident cmdlets
- wire parameters through FullSystemAudit and update internal imports
- note interface modules in SupportTools manifest and bump patch version

## Testing
- `pwsh -NoLogo -NoProfile -Command '$cfg = Import-PowerShellDataFile ./PesterConfiguration.psd1; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_68449627f494832c992c75efc33f63ae