### PR TITLE
Add AuditTools module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository packages a collection of scripts into reusable modules.
 * **SharePointTools** – commands for SharePoint cleanup tasks such as removing archives or sharing links.
 * **ServiceDeskTools** – interact with the Service Desk ticketing system.
 * **PerformanceTools** – measure script runtime and resource usage.
+* **AuditTools** – summarize audit findings via an OpenAI endpoint.
 
 ### Module Maturity
 
@@ -17,6 +18,7 @@ This repository packages a collection of scripts into reusable modules.
 | SharePointTools | Beta |
 | ServiceDeskTools | Experimental |
 | PerformanceTools | Experimental |
+| AuditTools | Experimental |
 
 ## Requirements 📋
 
@@ -51,6 +53,7 @@ This repository packages a collection of scripts into reusable modules.
    Import-Module ./src/SupportTools/SupportTools.psd1
    Import-Module ./src/SharePointTools/SharePointTools.psd1
    Import-Module ./src/ServiceDeskTools/ServiceDeskTools.psd1
+   Import-Module ./src/AuditTools/AuditTools.psd1
    ```
 
 4. Run the SharePoint configuration script once to store tenant information:
@@ -77,7 +80,7 @@ Invoke-YFArchiveCleanup -Verbose
 Get-SPToolsAllLibraryReports | Format-Table
 ```
 
-See [docs/SupportTools.md](docs/SupportTools.md), [docs/SharePointTools.md](docs/SharePointTools.md), [docs/ServiceDeskTools.md](docs/ServiceDeskTools.md) and [docs/PerformanceTools.md](docs/PerformanceTools.md) for a full list of commands. For a short introduction refer to [docs/Quickstart.md](docs/Quickstart.md). For detailed deployment guidance see [docs/UserGuide.md](docs/UserGuide.md).
+See [docs/SupportTools.md](docs/SupportTools.md), [docs/SharePointTools.md](docs/SharePointTools.md), [docs/ServiceDeskTools.md](docs/ServiceDeskTools.md), [docs/AuditTools.md](docs/AuditTools.md) and [docs/PerformanceTools.md](docs/PerformanceTools.md) for a full list of commands. For a short introduction refer to [docs/Quickstart.md](docs/Quickstart.md). For detailed deployment guidance see [docs/UserGuide.md](docs/UserGuide.md).
 
 The module also provides `Set-SharedMailboxAutoReply` for configuring automatic
 out-of-office replies on a shared mailbox.

--- a/docs/AuditTools.md
+++ b/docs/AuditTools.md
@@ -1,0 +1,13 @@
+# AuditTools Module
+
+Provides commands for summarizing audit data using an OpenAI-compatible API. Import the module using its manifest:
+
+```powershell
+Import-Module ./src/AuditTools/AuditTools.psd1
+```
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `Summarize-AuditFindings` | Send audit data to an API endpoint and generate an executive summary. |

--- a/docs/AuditTools/Summarize-AuditFindings.md
+++ b/docs/AuditTools/Summarize-AuditFindings.md
@@ -1,0 +1,66 @@
+---
+external help file: AuditTools-help.xml
+Module Name: AuditTools
+online version:
+schema: 2.0.0
+---
+
+# Summarize-AuditFindings
+
+## SYNOPSIS
+Creates a plain-language summary of audit findings using an OpenAI-compatible endpoint.
+
+## SYNTAX
+```
+Summarize-AuditFindings [-InputObject] <Object> [-EndpointUri <String>] [-ApiKey <String>] [-Model <String>] [-SystemMessage <String>] [-Template <String>] [-Format <String>] [-OutputPath <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Accepts structured audit results as objects or JSON strings. The data is inserted into a prompt template and sent to the specified API endpoint. The response text is returned or optionally written to a file in Markdown or HTML format.
+
+## PARAMETERS
+### -InputObject
+Audit object or JSON to summarize. Accepts pipeline input.
+
+### -EndpointUri
+Target API endpoint. Uses `$env:ST_OPENAI_ENDPOINT` if not specified.
+
+### -ApiKey
+Authentication key. Uses `$env:ST_OPENAI_KEY` if not specified.
+
+### -Model
+Model name to request. Defaults to `gpt-3.5-turbo`.
+
+### -SystemMessage
+System role description for the assistant.
+
+### -Template
+Prompt template containing the `{data}` placeholder.
+
+### -Format
+Output format: `Text`, `Markdown` or `Html`.
+
+### -OutputPath
+Optional path to save the generated summary.
+
+## EXAMPLES
+### Example 1
+```powershell
+Get-AuditReport | Summarize-AuditFindings -EndpointUri 'https://api.contoso.com/openai' -ApiKey $key -Format Markdown -OutputPath summary.md
+```
+
+### Example 2
+```powershell
+Summarize-AuditFindings -InputObject (Get-Content audit.json) -Format Html -OutputPath report.html
+```
+
+## INPUTS
+Objects
+
+## OUTPUTS
+String
+
+## NOTES
+
+## RELATED LINKS
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ The key guides are:
 
 - [Quickstart](./Quickstart.md) – short steps to install the modules and run common commands.
 - [User Guide](./UserGuide.md) – detailed deployment information and security notes.
-- [SupportTools](./SupportTools.md), [SharePointTools](./SharePointTools.md), [ServiceDeskTools](./ServiceDeskTools.md) – high level summaries of each module and the commands they expose.
+- [SupportTools](./SupportTools.md), [SharePointTools](./SharePointTools.md), [ServiceDeskTools](./ServiceDeskTools.md), [AuditTools](./AuditTools.md) – high level summaries of each module and the commands they expose.
 - [Credential Storage](./CredentialStorage.md) – recommended approach to store secrets securely.
 - [Module Style Guide](./ModuleStyleGuide.md) – how scripts display progress messages and log output.
 - [PerformanceTools](./PerformanceTools.md) – measure execution time and resource usage.
@@ -17,4 +17,4 @@ The key guides are:
 - [Roadmap](./Roadmap.md) – upcoming features and goals.
 
 
-Command specific help topics live in the `SupportTools`, `SharePointTools` and `ServiceDeskTools` subfolders.
+Command specific help topics live in the `SupportTools`, `SharePointTools`, `ServiceDeskTools` and `AuditTools` subfolders.

--- a/src/AuditTools/AuditTools.psd1
+++ b/src/AuditTools/AuditTools.psd1
@@ -1,0 +1,8 @@
+@{
+    RootModule = 'AuditTools.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000013'
+    Author = 'Contoso'
+    Description = 'Utilities for summarizing audit data using an OpenAI endpoint.'
+    FunctionsToExport = @('Summarize-AuditFindings')
+}

--- a/src/AuditTools/AuditTools.psm1
+++ b/src/AuditTools/AuditTools.psm1
@@ -1,0 +1,91 @@
+$loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+Import-Module $loggingModule -ErrorAction SilentlyContinue
+
+function Summarize-AuditFindings {
+    <#
+    .SYNOPSIS
+        Summarizes audit results using an OpenAI-compatible API.
+    .DESCRIPTION
+        Sends structured audit data to an API endpoint such as Azure OpenAI or a local service
+        and returns a plain-language executive summary with bullet points and recommended remediations.
+    .PARAMETER InputObject
+        Audit data object or JSON string. Accepts pipeline input.
+    .PARAMETER EndpointUri
+        API endpoint URI. Defaults to the ST_OPENAI_ENDPOINT environment variable.
+    .PARAMETER ApiKey
+        API authentication key. Defaults to the ST_OPENAI_KEY environment variable.
+    .PARAMETER Model
+        Model name for the API request. Defaults to gpt-3.5-turbo.
+    .PARAMETER SystemMessage
+        Custom system prompt describing the assistant's role.
+    .PARAMETER Template
+        Prompt template containing a {data} placeholder for the JSON payload.
+    .PARAMETER Format
+        Output format for the summary: Text, Markdown or Html.
+    .PARAMETER OutputPath
+        Optional path to save the summary output.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline=$true)]
+        [object]$InputObject,
+        [string]$EndpointUri,
+        [string]$ApiKey,
+        [string]$Model = 'gpt-3.5-turbo',
+        [string]$SystemMessage = 'You summarize audit findings for executives.',
+        [string]$Template = 'Summarize the following audit findings in plain language with bullet points and remediation steps:\n{data}',
+        [ValidateSet('Text','Markdown','Html')]
+        [string]$Format = 'Text',
+        [string]$OutputPath
+    )
+    begin { $items = @() }
+    process {
+        if ($null -ne $InputObject) {
+            if ($InputObject -is [string]) {
+                try { $items += ($InputObject | ConvertFrom-Json -ErrorAction Stop) }
+                catch { $items += $InputObject }
+            } else {
+                $items += $InputObject
+            }
+        }
+    }
+    end {
+        if (-not $EndpointUri) { $EndpointUri = $env:ST_OPENAI_ENDPOINT }
+        if (-not $ApiKey) { $ApiKey = $env:ST_OPENAI_KEY }
+        if (-not $EndpointUri) { throw 'EndpointUri is required.' }
+        if (-not $ApiKey) { throw 'ApiKey is required.' }
+
+        $json = $items | ConvertTo-Json -Depth 10
+        $prompt = $Template -replace '{data}', $json
+
+        $body = @{ model = $Model; messages = @(
+            @{ role = 'system'; content = $SystemMessage }
+            @{ role = 'user'; content = $prompt }
+        ) } | ConvertTo-Json -Depth 10
+
+        $headers = @{ Authorization = "Bearer $ApiKey" }
+
+        Write-STLog -Message 'Summarizing audit findings' -Metadata @{endpoint=$EndpointUri}
+        $response = Invoke-RestMethod -Uri $EndpointUri -Method Post -Body $body -ContentType 'application/json' -Headers $headers
+        $summary = $response.choices[0].message.content
+
+        if ($Format -eq 'Html') {
+            $output = ConvertTo-Html -Title 'Audit Summary' -Body $summary
+        } else {
+            $output = $summary
+        }
+
+        if ($OutputPath) { Set-Content -Path $OutputPath -Value $output }
+        return $output
+    }
+}
+
+Export-ModuleMember -Function 'Summarize-AuditFindings'
+
+function Show-AuditToolsBanner {
+    Write-STDivider 'AUDITTOOLS MODULE LOADED' -Style heavy
+    Write-STStatus "Run 'Get-Command -Module AuditTools' to view available tools." -Level SUB
+    Write-STLog -Message 'AuditTools module loaded'
+}
+
+Show-AuditToolsBanner

--- a/tests/AuditTools.Tests.ps1
+++ b/tests/AuditTools.Tests.ps1
@@ -1,0 +1,26 @@
+Describe 'AuditTools Module' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/AuditTools/AuditTools.psd1 -Force
+    }
+
+    It 'exports Summarize-AuditFindings' {
+        (Get-Command -Module AuditTools).Name | Should -Contain 'Summarize-AuditFindings'
+    }
+
+    It 'sends audit data to the endpoint' {
+        InModuleScope AuditTools {
+            Mock Invoke-RestMethod { @{ choices = @(@{ message = @{ content = 'summary' } }) } }
+            $data = @{ result = 'ok' }
+            Summarize-AuditFindings -InputObject $data -EndpointUri 'https://test' -ApiKey 'key'
+            Assert-MockCalled Invoke-RestMethod -ModuleName AuditTools -Times 1 -ParameterFilter { $Uri -eq 'https://test' }
+        }
+    }
+
+    It 'writes HTML when Format Html' {
+        InModuleScope AuditTools {
+            Mock Invoke-RestMethod { @{ choices = @(@{ message = @{ content = 'summary' } }) } }
+            $result = Summarize-AuditFindings -InputObject @{a=1} -EndpointUri 'https://test' -ApiKey 'k' -Format Html
+            $result | Should -Match '<html>'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new AuditTools module with Summarize-AuditFindings cmdlet
- document AuditTools commands and help
- mention AuditTools in main README and docs overview
- show AuditTools manifest import in README

## Testing
- `pwsh -NoProfile -Command "$cfg=Import-PowerShellDataFile ./PesterConfiguration.psd1; Invoke-Pester -Configuration $cfg"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a960a254832c97b48cf3b2e2f969