### PR TITLE
Add SharePointTools prereq validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ This repository packages a collection of scripts into reusable modules.
    Import-Module ./src/GraphTools/GraphTools.psd1
    ```
 
-4. Run the SharePoint configuration script once to store tenant information:
+4. Validate the SharePoint dependency and save tenant information:
 
    ```powershell
-   ./scripts/Configure-SharePointTools.ps1
+   ./scripts/Test-SPToolsPrereqs.ps1 -Install
+   ./scripts/Configure-SharePointTools.ps1 -ClientId <appId> -TenantId <tenantId> -CertPath <path>
    ```
 
 ## Usage 💡

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -27,14 +27,18 @@ This short guide shows the basic steps to start using the modules in this reposi
    Import-Module ./src/SharePointTools/SharePointTools.psd1
    Import-Module ./src/ServiceDeskTools/ServiceDeskTools.psd1
    ```
-6. **Run configuration** (for SharePoint functions)
+6. **Validate SharePoint prerequisites**
+   ```powershell
+   ./scripts/Test-SPToolsPrereqs.ps1 -Install
+   ```
+7. **Run configuration** (for SharePoint functions)
    ```powershell
    ./scripts/Configure-SharePointTools.ps1
    ```
-7. **Load credentials** (optional)
+8. **Load credentials** (optional)
    Refer to [CredentialStorage.md](CredentialStorage.md) for a step‑by‑step
    walkthrough of using SecretManagement to load environment variables.
-8. **Try a few common commands**
+9. **Try a few common commands**
    ```powershell
    # System information
    Get-CommonSystemInfo | Format-Table

--- a/docs/SharePointTools.md
+++ b/docs/SharePointTools.md
@@ -6,7 +6,13 @@ This module provides SharePoint cleanup and reporting utilities. Import the modu
 Import-Module ./src/SharePointTools/SharePointTools.psd1
 ```
 
-Before running any command ensure the settings file has been configured using `./scripts/Configure-SharePointTools.ps1` or by setting the environment variables `SPTOOLS_CLIENT_ID`, `SPTOOLS_TENANT_ID` and `SPTOOLS_CERT_PATH`.
+Validate prerequisites using `Test-SPToolsPrereqs`:
+
+```powershell
+Test-SPToolsPrereqs -Install
+```
+
+Before running any command ensure the settings file has been configured using `./scripts/Configure-SharePointTools.ps1` (parameters can be passed for unattended use) or by setting the environment variables `SPTOOLS_CLIENT_ID`, `SPTOOLS_TENANT_ID` and `SPTOOLS_CERT_PATH`.
 
 All functions emit short, high contrast messages following the style in [ModuleStyleGuide.md](ModuleStyleGuide.md).
 
@@ -16,6 +22,7 @@ All functions emit short, high contrast messages following the style in [ModuleS
 |---------|-------------|---------------|---------|
 | `Save-SPToolsSettings` | Persist the current configuration to disk. | none | `Save-SPToolsSettings` |
 | `Get-SPToolsSettings` | Return the loaded configuration. | none | `Get-SPToolsSettings` |
+| `Test-SPToolsPrereqs` | Verify PnP.PowerShell dependency. Use `-Install` to install. | `[Install]` | `Test-SPToolsPrereqs -Install` |
 | `Get-SPToolsSiteUrl` | Retrieve a site URL by friendly name. | `SiteName` | `Get-SPToolsSiteUrl -SiteName HR` |
 | `Add-SPToolsSite` | Add a SharePoint site entry. | `Name`, `Url` | `Add-SPToolsSite -Name HR -Url https://contoso.sharepoint.com/sites/hr` |
 | `Set-SPToolsSite` | Update an existing site entry. | `Name`, `Url` | `Set-SPToolsSite -Name HR -Url https://contoso.sharepoint.com/sites/hr2` |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -42,7 +42,8 @@ Import-Module ./src/SharePointTools/SharePointTools.psd1
 Run the configuration script once to store your SharePoint application details and configure the SharePoint site URLs to target:
 
 ```powershell
-./scripts/Configure-SharePointTools.ps1
+./scripts/Test-SPToolsPrereqs.ps1 -Install
+./scripts/Configure-SharePointTools.ps1 -ClientId <appId> -TenantId <tenantId> -CertPath <path>
 ```
 
 You can place these commands in your profile or deployment scripts so the functions are available in each session.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,6 +27,7 @@ The following table provides a brief description of each script.
 | **Submit-SystemInfoTicket.ps1** | Collects system info, uploads it to SharePoint and opens a Service Desk ticket. |
 | **SS_DEPLOYMENT_TEMPLATE.ps1** | Template for sneaker net deployments that installs agents and configures a system. |
 | **Configure-SharePointTools.ps1** | Prompts for SharePoint application values and saves them to a settings file. |
+| **Test-SPToolsPrereqs.ps1** | Checks for PnP.PowerShell and installs it if requested. |
 | **CleanupTempFiles.ps1** | Removes .tmp files and empty logs from the repository. |
 | **SupportToolsMenu.ps1** | Interactive menu for common SupportTools tasks. |
 | **ScriptLauncher.ps1** | Menu to browse and run any script in this folder. |

--- a/scripts/Test-SPToolsPrereqs.ps1
+++ b/scripts/Test-SPToolsPrereqs.ps1
@@ -1,0 +1,21 @@
+<##
+.SYNOPSIS
+    Validates SharePointTools prerequisites.
+.DESCRIPTION
+    Checks if the PnP.PowerShell module is installed and optionally installs it from the PowerShell Gallery.
+.PARAMETER Install
+    If specified, missing modules are installed automatically without prompting.
+.EXAMPLE
+    ./Test-SPToolsPrereqs.ps1
+    Checks for required modules and prompts to install.
+.EXAMPLE
+    ./Test-SPToolsPrereqs.ps1 -Install
+    Installs PnP.PowerShell automatically when missing.
+##>
+param(
+    [switch]$Install
+)
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src' 'SharePointTools' 'SharePointTools.psd1') -ErrorAction SilentlyContinue
+
+Test-SPToolsPrereqs -Install:$Install

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -56,6 +56,39 @@ function Save-SPToolsSettings {
     }
 }
 
+function Test-SPToolsPrereqs {
+    <#
+    .SYNOPSIS
+        Validates required modules for SharePoint tools.
+    .DESCRIPTION
+        Checks that the PnP.PowerShell module is available. Use -Install to
+        automatically install it from the PowerShell Gallery when missing.
+    .PARAMETER Install
+        If specified, missing modules are installed without prompting.
+    #>
+    [CmdletBinding()]
+    param(
+        [switch]$Install
+    )
+    process {
+        if (-not (Get-Module -ListAvailable -Name 'PnP.PowerShell')) {
+            Write-SPToolsHacker 'PnP.PowerShell module not found.' -Level WARN
+            if ($Install) {
+                try {
+                    Install-Module -Name 'PnP.PowerShell' -Scope CurrentUser -Force -ErrorAction Stop
+                    Write-SPToolsHacker 'Installed PnP.PowerShell' -Level SUCCESS
+                } catch {
+                    Write-SPToolsHacker "Failed to install PnP.PowerShell: $($_.Exception.Message)" -Level ERROR
+                }
+            } else {
+                Write-SPToolsHacker "Run 'Test-SPToolsPrereqs -Install' to install." -Level SUB
+            }
+        } else {
+            Write-SPToolsHacker 'PnP.PowerShell module present.' -Level SUCCESS
+        }
+    }
+}
+
 function Get-SPToolsSettings {
     <#
     .SYNOPSIS
@@ -893,7 +926,7 @@ function List-OneDriveUsage {
     Write-SPToolsHacker 'Report complete'
     $report
 }
-Export-ModuleMember -Function 'Invoke-YFArchiveCleanup','Invoke-IBCCentralFilesArchiveCleanup','Invoke-MexCentralFilesArchiveCleanup','Invoke-ArchiveCleanup','Invoke-YFFileVersionCleanup','Invoke-IBCCentralFilesFileVersionCleanup','Invoke-MexCentralFilesFileVersionCleanup','Invoke-FileVersionCleanup','Invoke-SharingLinkCleanup','Invoke-YFSharingLinkCleanup','Invoke-IBCCentralFilesSharingLinkCleanup','Invoke-MexCentralFilesSharingLinkCleanup','Get-SPToolsSettings','Get-SPToolsSiteUrl','Add-SPToolsSite','Set-SPToolsSite','Remove-SPToolsSite','Get-SPToolsLibraryReport','Get-SPToolsAllLibraryReports','Get-SPToolsRecycleBinReport','Clear-SPToolsRecycleBin','Get-SPToolsAllRecycleBinReports','Get-SPToolsFileReport','Get-SPToolsPreservationHoldReport','Get-SPToolsAllPreservationHoldReports','Get-SPPermissionsReport','Clean-SPVersionHistory','Find-OrphanedSPFiles','Select-SPToolsFolder','List-OneDriveUsage' -Variable 'SharePointToolsSettings'
+Export-ModuleMember -Function 'Invoke-YFArchiveCleanup','Invoke-IBCCentralFilesArchiveCleanup','Invoke-MexCentralFilesArchiveCleanup','Invoke-ArchiveCleanup','Invoke-YFFileVersionCleanup','Invoke-IBCCentralFilesFileVersionCleanup','Invoke-MexCentralFilesFileVersionCleanup','Invoke-FileVersionCleanup','Invoke-SharingLinkCleanup','Invoke-YFSharingLinkCleanup','Invoke-IBCCentralFilesSharingLinkCleanup','Invoke-MexCentralFilesSharingLinkCleanup','Get-SPToolsSettings','Get-SPToolsSiteUrl','Add-SPToolsSite','Set-SPToolsSite','Remove-SPToolsSite','Get-SPToolsLibraryReport','Get-SPToolsAllLibraryReports','Get-SPToolsRecycleBinReport','Clear-SPToolsRecycleBin','Get-SPToolsAllRecycleBinReports','Get-SPToolsFileReport','Get-SPToolsPreservationHoldReport','Get-SPToolsAllPreservationHoldReports','Get-SPPermissionsReport','Clean-SPVersionHistory','Find-OrphanedSPFiles','Select-SPToolsFolder','List-OneDriveUsage','Test-SPToolsPrereqs' -Variable 'SharePointToolsSettings'
 
 function Register-SPToolsCompleters {
     $siteCmds = 'Get-SPToolsSiteUrl','Get-SPToolsLibraryReport','Get-SPToolsRecycleBinReport','Clear-SPToolsRecycleBin','Get-SPToolsPreservationHoldReport','Get-SPToolsAllLibraryReports','Get-SPToolsAllRecycleBinReports','Get-SPToolsFileReport','Select-SPToolsFolder'


### PR DESCRIPTION
## Summary
- add `Test-SPToolsPrereqs` function and export
- expose unattended options for `Configure-SharePointTools.ps1`
- script wrapper `Test-SPToolsPrereqs.ps1`
- document new usage in README, Quickstart, SharePointTools, UserGuide and script docs

## Testing
- `Invoke-Pester` *(fails: `pwsh` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68449ec2b80c832cae9c695a20ac8b84