### PR TITLE
Support pipeline input for SP site commands

### DIFF
--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -246,7 +246,7 @@ function Add-SPToolsSite {
     #>
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ValidatePattern('^[A-Za-z0-9_-]+$')]
         [string]$Name,
         [Parameter(Mandatory = $true)]
@@ -276,7 +276,7 @@ function Set-SPToolsSite {
     #>
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ValidatePattern('^[A-Za-z0-9_-]+$')]
         [string]$Name,
         [Parameter(Mandatory = $true)]
@@ -304,7 +304,7 @@ function Remove-SPToolsSite {
     #>
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ValidatePattern('^[A-Za-z0-9_-]+$')]
         [string]$Name
     )
@@ -1206,6 +1206,12 @@ function Register-SPToolsCompleters {
     #>
     $siteCmds = 'Get-SPToolsSiteUrl','Get-SPToolsLibraryReport','Get-SPToolsRecycleBinReport','Clear-SPToolsRecycleBin','Get-SPToolsPreservationHoldReport','Get-SPToolsAllLibraryReports','Get-SPToolsAllRecycleBinReports','Get-SPToolsFileReport','Select-SPToolsFolder'
     Register-ArgumentCompleter -CommandName $siteCmds -ParameterName SiteName -ScriptBlock {
+        param($commandName,$parameterName,$wordToComplete)
+        $SharePointToolsSettings.Sites.Keys | Where-Object { $_ -like "$wordToComplete*" } |
+            ForEach-Object { [System.Management.Automation.CompletionResult]::new($_,$_, 'ParameterValue', $_) }
+    }
+    $nameCmds = 'Set-SPToolsSite','Remove-SPToolsSite','Add-SPToolsSite'
+    Register-ArgumentCompleter -CommandName $nameCmds -ParameterName Name -ScriptBlock {
         param($commandName,$parameterName,$wordToComplete)
         $SharePointToolsSettings.Sites.Keys | Where-Object { $_ -like "$wordToComplete*" } |
             ForEach-Object { [System.Management.Automation.CompletionResult]::new($_,$_, 'ParameterValue', $_) }

--- a/tests/ArchiveCleanup.Tests.ps1
+++ b/tests/ArchiveCleanup.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'Invoke-ArchiveCleanup' {
             function Get-PnPListItem { $script:testItems }
             function Remove-PnPFile {}
             function Remove-PnPFolder {}
+            Set-Variable -Scope Script -Name SharePointToolsSettings -Value @{ ClientId='id'; TenantId='tid'; CertPath='path'; Sites=@{} }
             Mock Connect-PnPOnline {}
             Mock Get-PnPListItem { $script:testItems }
             Mock Remove-PnPFile {}

--- a/tests/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools.Tests.ps1
@@ -144,6 +144,35 @@ Describe 'SharePointTools Module' {
             }
         }
 
+        It 'Add-SPToolsSite accepts pipeline input for Name' {
+            InModuleScope SharePointTools {
+                Mock Save-SPToolsSettings {}
+                'PipeSite' | Add-SPToolsSite -Url 'https://pipe'
+                $SharePointToolsSettings.Sites['PipeSite'] | Should -Be 'https://pipe'
+                Assert-MockCalled Save-SPToolsSettings -Times 1
+            }
+        }
+
+        It 'Set-SPToolsSite accepts pipeline input for Name' {
+            InModuleScope SharePointTools {
+                Mock Save-SPToolsSettings {}
+                $SharePointToolsSettings.Sites['PipeSite'] = 'https://old'
+                'PipeSite' | Set-SPToolsSite -Url 'https://new'
+                $SharePointToolsSettings.Sites['PipeSite'] | Should -Be 'https://new'
+                Assert-MockCalled Save-SPToolsSettings -Times 1
+            }
+        }
+
+        It 'Remove-SPToolsSite accepts pipeline input' {
+            InModuleScope SharePointTools {
+                Mock Save-SPToolsSettings {}
+                $SharePointToolsSettings.Sites['PipeSite'] = 'https://contoso'
+                'PipeSite' | Remove-SPToolsSite
+                $SharePointToolsSettings.Sites.ContainsKey('PipeSite') | Should -BeFalse
+                Assert-MockCalled Save-SPToolsSettings -Times 1
+            }
+        }
+
         It 'Get-SPToolsSiteUrl returns the url and throws when missing' {
             InModuleScope SharePointTools {
                 $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso'

--- a/tests/SharePointTools/Integration.Tests.ps1
+++ b/tests/SharePointTools/Integration.Tests.ps1
@@ -4,6 +4,12 @@ Describe 'SharePointTools Integration Functions' {
         Import-Module $PSScriptRoot/../../src/SharePointTools/SharePointTools.psd1 -Force
     }
 
+    BeforeEach {
+        InModuleScope SharePointTools {
+            Set-Variable -Scope Script -Name SharePointToolsSettings -Value @{ ClientId='id'; TenantId='tid'; CertPath='path'; Sites=@{} }
+        }
+    }
+
     Context 'Get-SPToolsLibraryReport' {
         It 'returns library information' {
             InModuleScope SharePointTools {


### PR DESCRIPTION
## Summary
- allow Add-SPToolsSite, Set-SPToolsSite and Remove-SPToolsSite to accept pipeline names
- update Register-SPToolsCompleters to also tab-complete Name
- add Pester tests covering pipeline scenarios

## Testing
- `pwsh -NoLogo -NoProfile -Command '$cfg=Import-PowerShellDataFile ./PesterConfiguration.psd1; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_684594125f58832ca1476511fe2ee722