### PR TITLE
Promote SharePointTools module to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository packages a collection of scripts into reusable modules.
 | Module | Status |
 | ------ | ------ |
 | SupportTools | Stable |
-| SharePointTools | Beta |
+| SharePointTools | Stable |
 | ServiceDeskTools | Experimental |
 | PerformanceTools | Experimental |
 | GraphTools | Experimental |

--- a/docs/Stewardship.md
+++ b/docs/Stewardship.md
@@ -13,7 +13,7 @@ This guide explains how to keep the PowerShell modules healthy over time and pre
 | Module            | Status       |
 |-------------------|-------------|
 | SupportTools      | Stable      |
-| SharePointTools   | Beta        |
+| SharePointTools   | Stable      |
 | ServiceDeskTools  | Experimental|
 
 ## Backup Strategy


### PR DESCRIPTION
## Summary
- update module maturity table to mark SharePointTools as Stable
- apply the same change in the stewardship guide

## Testing
- `Invoke-Pester -Path tests -CI` *(fails: some modules missing but tests start)*

------
https://chatgpt.com/codex/tasks/task_e_6845b1da1758832c9fdfc2b531222edc