### PR TITLE
Fill docs placeholders

### DIFF
--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Write-STLog
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Writes a message or metric to the SupportTools log.
 
 ## SYNTAX
 
@@ -20,7 +20,7 @@ Write-STLog [-Message] <String> [[-Level] <String>] [[-Path] <String>] [-Progres
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Used by scripts and modules to record log messages in a consistent format.
 
 ## EXAMPLES
 
@@ -36,7 +36,7 @@ Records how long the task took in seconds using a structured log entry.
 ## PARAMETERS
 
 ### -Level
-{{ Fill Level Description }}
+Specifies the log level such as INFO, WARN, or ERROR.
 
 ```yaml
 Type: String
@@ -52,7 +52,7 @@ Accept wildcard characters: False
 ```
 
 ### -Message
-{{ Fill Message Description }}
+The content of the log entry to record.
 
 ```yaml
 Type: String
@@ -139,7 +139,7 @@ Accept wildcard characters: False
 ```
 
 ### -ProgressAction
-{{ Fill ProgressAction Description }}
+Specifies how this cmdlet responds to progress updates.
 
 ```yaml
 Type: ActionPreference

--- a/docs/SharePointTools/Get-SPToolsSettings.md
+++ b/docs/SharePointTools/Get-SPToolsSettings.md
@@ -31,7 +31,7 @@ Demonstrates typical usage of Get-SPToolsSettings.
 ## PARAMETERS
 
 ### -ProgressAction
-{{ Fill ProgressAction Description }}
+Specifies how this cmdlet responds to progress updates.
 
 ```yaml
 Type: ActionPreference

--- a/docs/SharePointTools/Invoke-ArchiveCleanup.md
+++ b/docs/SharePointTools/Invoke-ArchiveCleanup.md
@@ -123,7 +123,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SharePointTools/Invoke-SharingLinkCleanup.md
+++ b/docs/SharePointTools/Invoke-SharingLinkCleanup.md
@@ -138,7 +138,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Add-UserToGroup.md
+++ b/docs/SupportTools/Add-UserToGroup.md
@@ -64,7 +64,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Clear-ArchiveFolder.md
+++ b/docs/SupportTools/Clear-ArchiveFolder.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Clear-TempFile.md
+++ b/docs/SupportTools/Clear-TempFile.md
@@ -47,7 +47,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Convert-ExcelToCsv.md
+++ b/docs/SupportTools/Convert-ExcelToCsv.md
@@ -49,7 +49,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Export-ProductKey.md
+++ b/docs/SupportTools/Export-ProductKey.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Get-FailedLogin.md
+++ b/docs/SupportTools/Get-FailedLogin.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Get-NetworkShare.md
+++ b/docs/SupportTools/Get-NetworkShare.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Get-UniquePermission.md
+++ b/docs/SupportTools/Get-UniquePermission.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Install-Font.md
+++ b/docs/SupportTools/Install-Font.md
@@ -49,7 +49,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Invoke-CompanyPlaceManagement.md
+++ b/docs/SupportTools/Invoke-CompanyPlaceManagement.md
@@ -177,7 +177,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Invoke-DeploymentTemplate.md
+++ b/docs/SupportTools/Invoke-DeploymentTemplate.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Invoke-ExchangeCalendarManager.md
+++ b/docs/SupportTools/Invoke-ExchangeCalendarManager.md
@@ -33,7 +33,7 @@ Demonstrates typical usage of Invoke-ExchangeCalendarManager.
 ## PARAMETERS
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Invoke-PostInstall.md
+++ b/docs/SupportTools/Invoke-PostInstall.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Restore-ArchiveFolder.md
+++ b/docs/SupportTools/Restore-ArchiveFolder.md
@@ -44,7 +44,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 ```
 Type: String
 Parameter Sets: (All)

--- a/docs/SupportTools/Search-ReadMe.md
+++ b/docs/SupportTools/Search-ReadMe.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Set-ComputerIPAddress.md
+++ b/docs/SupportTools/Set-ComputerIPAddress.md
@@ -47,7 +47,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Set-NetAdapterMetering.md
+++ b/docs/SupportTools/Set-NetAdapterMetering.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Set-SharedMailboxAutoReply.md
+++ b/docs/SupportTools/Set-SharedMailboxAutoReply.md
@@ -159,7 +159,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Set-TimeZoneEasternStandardTime.md
+++ b/docs/SupportTools/Set-TimeZoneEasternStandardTime.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Start-Countdown.md
+++ b/docs/SupportTools/Start-Countdown.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String

--- a/docs/SupportTools/Update-Sysmon.md
+++ b/docs/SupportTools/Update-Sysmon.md
@@ -47,7 +47,7 @@ Accept wildcard characters: False
 ```
 
 ### -TranscriptPath
-{{ Fill TranscriptPath Description }}
+File path used to capture a transcript of this command's output and actions.
 
 ```yaml
 Type: String


### PR DESCRIPTION
## Summary
- fill documentation placeholders for TranscriptPath parameter
- expand Write-STLog help text

## Testing
- `pwsh -NoProfile -Command Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b1e00604832c97f36fb99c2ca950