### PR TITLE
Add full docs for Invoke-ChaosTest

### DIFF
--- a/docs/ChaosTools.md
+++ b/docs/ChaosTools.md
@@ -13,4 +13,11 @@ Import-Module ./src/ChaosTools/ChaosTools.psd1
 |---------|-------------|---------|
 | `Invoke-ChaosTest` | Randomly delay or fail execution of a script block | `Invoke-ChaosTest -ScriptBlock { Get-Service } -FailureRate 0.2` |
 
+Chaos behavior can also be triggered in other modules. Set the `ST_CHAOS_MODE`
+environment variable to `1` (or use the `-ChaosMode` switch where available) to
+have commands automatically wrap API calls with `Invoke-ChaosTest`.
+
+See [ChaosTools/Invoke-ChaosTest.md](ChaosTools/Invoke-ChaosTest.md) for full
+command documentation.
+
 Use these tools to validate that your automation gracefully handles transient failures.

--- a/docs/ChaosTools/Invoke-ChaosTest.md
+++ b/docs/ChaosTools/Invoke-ChaosTest.md
@@ -1,1 +1,69 @@
-Runs a script block with random delays and failures to simulate unstable conditions.
+---
+external help file: ChaosTools-help.xml
+Module Name: ChaosTools
+online version:
+schema: 2.0.0
+---
+
+# Invoke-ChaosTest
+
+## SYNOPSIS
+Runs a script block with randomized delays and failures.
+
+## SYNTAX
+
+```powershell
+Invoke-ChaosTest -ScriptBlock <scriptblock> [-FailureRate <double>] [-MaxDelaySeconds <int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+`Invoke-ChaosTest` waits up to `MaxDelaySeconds` seconds and then randomly throws
+an exception based on `FailureRate` before running the provided script block.
+This helps verify that your automation gracefully handles transient errors and
+slower responses.
+
+While the cmdlet does not use environment variables directly, other modules such
+as **ServiceDeskTools** honor the `ST_CHAOS_MODE` environment variable and call
+`Invoke-ChaosTest` internally when it is set to `1`.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Invoke-ChaosTest -ScriptBlock { Get-Service } -FailureRate 0.2
+```
+Randomly fails twenty percent of the time after a short delay.
+
+### Example 2
+```powershell
+$sb = { Invoke-RestMethod -Uri $Uri }
+Invoke-ChaosTest -ScriptBlock $sb -FailureRate 0.5 -MaxDelaySeconds 10
+```
+Pauses up to ten seconds before running and fails half the time.
+
+## PARAMETERS
+
+### -ScriptBlock
+Commands to invoke.
+
+### -FailureRate
+Probability from `0` to `1` that a failure is injected. Defaults to `0.3`.
+
+### -MaxDelaySeconds
+Maximum random delay before execution. Defaults to `5`.
+
+### CommonParameters
+This cmdlet supports the common parameters. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+None.
+
+## OUTPUTS
+Any output from the script block.
+
+## NOTES
+Set `ST_CHAOS_MODE=1` to automatically enable chaos testing in other modules
+that support it.
+
+## RELATED LINKS


### PR DESCRIPTION
## Summary
- write detailed `Invoke-ChaosTest` help page
- reference chaos mode environment variable in `ChaosTools.md`

## Testing
- `pwsh -NoLogo -Command '$cfg = Import-PowerShellDataFile ./PesterConfiguration.psd1; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_6845b3b579d8832ca67c383515ea2858