### PR TITLE
Add CHAOSTOOLS_ENABLED toggle

### DIFF
--- a/docs/ChaosTools.md
+++ b/docs/ChaosTools.md
@@ -14,3 +14,5 @@ Import-Module ./src/ChaosTools/ChaosTools.psd1
 | `Invoke-ChaosTest` | Randomly delay or fail execution of a script block | `Invoke-ChaosTest -ScriptBlock { Get-Service } -FailureRate 0.2` |
 
 Use these tools to validate that your automation gracefully handles transient failures.
+Set the `CHAOSTOOLS_ENABLED` environment variable to `0` or `False` to disable
+the random delay and failure behavior.

--- a/docs/ChaosTools/Invoke-ChaosTest.md
+++ b/docs/ChaosTools/Invoke-ChaosTest.md
@@ -1,1 +1,3 @@
 Runs a script block with random delays and failures to simulate unstable conditions.
+Set the `CHAOSTOOLS_ENABLED` environment variable to `0` or `False` to skip the
+random delay and failure injection logic.

--- a/src/ChaosTools/Public/Invoke-ChaosTest.ps1
+++ b/src/ChaosTools/Public/Invoke-ChaosTest.ps1
@@ -5,6 +5,8 @@ function Invoke-ChaosTest {
     .DESCRIPTION
         Runs the given commands and randomly throws an error based on FailureRate.
         A random delay up to MaxDelaySeconds is introduced before execution.
+        Set the CHAOSTOOLS_ENABLED environment variable to 0 or False to
+        bypass chaos injection entirely.
     .PARAMETER ScriptBlock
         Commands to invoke.
     .PARAMETER FailureRate
@@ -23,6 +25,11 @@ function Invoke-ChaosTest {
     Assert-ParameterNotNull $ScriptBlock 'ScriptBlock'
     if ($FailureRate -lt 0 -or $FailureRate -gt 1) {
         throw 'FailureRate must be between 0 and 1.'
+    }
+    if ($env:CHAOSTOOLS_ENABLED -match '^(0|false)$') {
+        Write-STDebug 'ChaosTools disabled'
+        & $ScriptBlock
+        return
     }
     if ($MaxDelaySeconds -gt 0) {
         $delay = Get-Random -Minimum 0 -Maximum ($MaxDelaySeconds + 1)

--- a/tests/ChaosTools.Tests.ps1
+++ b/tests/ChaosTools.Tests.ps1
@@ -17,4 +17,26 @@ Describe 'ChaosTools Module' {
     It 'throws when failure rate is one' {
         { Invoke-ChaosTest -ScriptBlock { } -FailureRate 1 -MaxDelaySeconds 0 } | Should -Throw
     }
+
+    It 'bypasses chaos when CHAOSTOOLS_ENABLED=0' {
+        $script:ran = $false
+        try {
+            $env:CHAOSTOOLS_ENABLED = '0'
+            Invoke-ChaosTest -ScriptBlock { $script:ran = $true } -FailureRate 1 -MaxDelaySeconds 1
+            $script:ran | Should -BeTrue
+        } finally {
+            Remove-Item env:CHAOSTOOLS_ENABLED -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'bypasses chaos when CHAOSTOOLS_ENABLED=False' {
+        $script:ran = $false
+        try {
+            $env:CHAOSTOOLS_ENABLED = 'False'
+            Invoke-ChaosTest -ScriptBlock { $script:ran = $true } -FailureRate 1 -MaxDelaySeconds 1
+            $script:ran | Should -BeTrue
+        } finally {
+            Remove-Item env:CHAOSTOOLS_ENABLED -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add env check to Invoke-ChaosTest to disable chaos injection
- document CHAOSTOOLS_ENABLED env var
- test disabling behavior

## Testing
- `pwsh -NoLogo -NoProfile` with `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_6845b3b67fd8832cabc41a2a796bbbe1