### PR TITLE
Add Get-GraphGroupDetails command

### DIFF
--- a/docs/GraphTools.md
+++ b/docs/GraphTools.md
@@ -11,5 +11,6 @@ Import-Module ./src/GraphTools/GraphTools.psd1
 | Command | Description | Example |
 |---------|-------------|---------|
 | `Get-GraphUserDetails` | Retrieve metadata for a user | `Get-GraphUserDetails -UserPrincipalName user@contoso.com -TenantId <tenant> -ClientId <app>` |
+| `Get-GraphGroupDetails` | Retrieve metadata for a group | `Get-GraphGroupDetails -GroupId <id> -TenantId <tenant> -ClientId <app>` |
 
 The command requires an Entra ID application registration. Provide the tenant ID, client ID and optional client secret for authentication.

--- a/docs/GraphTools/Get-GraphGroupDetails.md
+++ b/docs/GraphTools/Get-GraphGroupDetails.md
@@ -1,0 +1,1 @@
+Retrieves the group's name, description and members via the Microsoft Graph API.

--- a/src/GraphTools/GraphTools.psd1
+++ b/src/GraphTools/GraphTools.psd1
@@ -6,5 +6,5 @@
     Description = 'Microsoft Graph helper functions.'
     RequiredModules = @('Logging','Telemetry')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','Graph','Internal') } }
-    FunctionsToExport = @('Get-GraphUserDetails')
+    FunctionsToExport = @('Get-GraphUserDetails','Get-GraphGroupDetails')
 }

--- a/src/GraphTools/GraphTools.psm1
+++ b/src/GraphTools/GraphTools.psm1
@@ -8,7 +8,7 @@ Import-Module $telemetryModule -ErrorAction SilentlyContinue
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Get-GraphUserDetails'
+Export-ModuleMember -Function 'Get-GraphUserDetails','Get-GraphGroupDetails'
 
 function Show-GraphToolsBanner {
     Write-STDivider 'GRAPHTOOLS MODULE LOADED' -Style heavy

--- a/src/GraphTools/Public/Get-GraphGroupDetails.ps1
+++ b/src/GraphTools/Public/Get-GraphGroupDetails.ps1
@@ -1,0 +1,51 @@
+function Get-GraphGroupDetails {
+    <#
+    .SYNOPSIS
+        Retrieves group details from Microsoft Graph.
+    .DESCRIPTION
+        Queries Graph for the group's basic info and membership. Activity is logged and telemetry is recorded.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$GroupId,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TenantId,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ClientId,
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$ClientSecret
+    )
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    Write-STLog -Message "Get-GraphGroupDetails $GroupId" -Structured -Metadata @{ group = $GroupId }
+    $result = 'Success'
+    try {
+        $token = Get-GraphAccessToken -TenantId $TenantId -ClientId $ClientId -ClientSecret $ClientSecret
+        $headers = @{ Authorization = "Bearer $token" }
+
+        $groupUrl = "https://graph.microsoft.com/v1.0/groups/$GroupId?`$select=displayName,description"
+        $group = Invoke-RestMethod -Uri $groupUrl -Headers $headers -Method Get
+
+        $membersUrl = "https://graph.microsoft.com/v1.0/groups/$GroupId/members?`$select=displayName"
+        $members = Invoke-RestMethod -Uri $membersUrl -Headers $headers -Method Get
+
+        return [pscustomobject]@{
+            GroupId     = $GroupId
+            DisplayName = $group.displayName
+            Description = $group.description
+            Members     = ($members.value.displayName -join ',')
+        }
+    } catch {
+        $result = 'Failure'
+        Write-STLog -Message "Get-GraphGroupDetails failed: $_" -Level ERROR
+        throw
+    } finally {
+        $sw.Stop()
+        Write-STTelemetryEvent -ScriptName 'Get-GraphGroupDetails' -Result $result -Duration $sw.Elapsed
+    }
+}

--- a/tests/GraphTools.Tests.ps1
+++ b/tests/GraphTools.Tests.ps1
@@ -9,6 +9,9 @@ Describe 'GraphTools Module' {
         It 'Exports Get-GraphUserDetails' {
             (Get-Command -Module GraphTools).Name | Should -Contain 'Get-GraphUserDetails'
         }
+        It 'Exports Get-GraphGroupDetails' {
+            (Get-Command -Module GraphTools).Name | Should -Contain 'Get-GraphGroupDetails'
+        }
     }
 
     Context 'Logging and telemetry' {
@@ -18,6 +21,16 @@ Describe 'GraphTools Module' {
             Mock Write-STLog {} -ModuleName GraphTools
             Mock Write-STTelemetryEvent {} -ModuleName GraphTools
             Get-GraphUserDetails -UserPrincipalName 'u' -TenantId 'tid' -ClientId 'cid'
+            Assert-MockCalled Write-STLog -ModuleName GraphTools -Times 1
+            Assert-MockCalled Write-STTelemetryEvent -ModuleName GraphTools -Times 1
+        }
+
+        It 'Logs group requests and writes telemetry' {
+            Mock Get-GraphAccessToken { 't' } -ModuleName GraphTools
+            Mock Invoke-RestMethod { @{ displayName='G'; description='D'; value=@(@{displayName='U'}) } } -ModuleName GraphTools -ParameterFilter { $Method -eq 'GET' }
+            Mock Write-STLog {} -ModuleName GraphTools
+            Mock Write-STTelemetryEvent {} -ModuleName GraphTools
+            Get-GraphGroupDetails -GroupId 'gid' -TenantId 'tid' -ClientId 'cid'
             Assert-MockCalled Write-STLog -ModuleName GraphTools -Times 1
             Assert-MockCalled Write-STTelemetryEvent -ModuleName GraphTools -Times 1
         }


### PR DESCRIPTION
## Summary
- add `Get-GraphGroupDetails` script to query group info
- export and load the new command from GraphTools
- document `Get-GraphGroupDetails` usage
- update GraphTools command table
- test command export and logging/telemetry

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile -Path PesterConfiguration.psd1)`

------
https://chatgpt.com/codex/tasks/task_e_6845b5c62740832c898a65bb6141f0ba