### PR TITLE
Add env var support to Graph auth

### DIFF
--- a/docs/GraphTools.md
+++ b/docs/GraphTools.md
@@ -13,3 +13,11 @@ Import-Module ./src/GraphTools/GraphTools.psd1
 | `Get-GraphUserDetails` | Retrieve metadata for a user | `Get-GraphUserDetails -UserPrincipalName user@contoso.com -TenantId <tenant> -ClientId <app>` |
 
 The command requires an Entra ID application registration. Provide the tenant ID, client ID and optional client secret for authentication.
+
+You can also set the following environment variables so parameters aren't required on every call:
+
+- `GRAPH_TENANT_ID` – the tenant ID to authenticate against
+- `GRAPH_CLIENT_ID` – the application (client) ID
+- `GRAPH_CLIENT_SECRET` – optional client secret
+
+When these variables are present, `Get-GraphUserDetails` and other commands will use them automatically.

--- a/src/GraphTools/Private/Get-GraphAccessToken.ps1
+++ b/src/GraphTools/Private/Get-GraphAccessToken.ps1
@@ -1,11 +1,18 @@
 function Get-GraphAccessToken {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$TenantId,
-        [Parameter(Mandatory)][string]$ClientId,
+        [string]$TenantId,
+        [string]$ClientId,
         [string]$ClientSecret,
         [string]$CachePath = "$env:USERPROFILE/.graphToken.json"
     )
+
+    if (-not $TenantId)     { $TenantId     = $env:GRAPH_TENANT_ID }
+    if (-not $ClientId)     { $ClientId     = $env:GRAPH_CLIENT_ID }
+    if (-not $ClientSecret) { $ClientSecret = $env:GRAPH_CLIENT_SECRET }
+
+    if (-not $TenantId) { throw 'TenantId is required. Provide -TenantId or set GRAPH_TENANT_ID.' }
+    if (-not $ClientId) { throw 'ClientId is required. Provide -ClientId or set GRAPH_CLIENT_ID.' }
     if (Test-Path $CachePath) {
         try {
             $cache = Get-Content $CachePath | ConvertFrom-Json

--- a/tests/GraphTools.Tests.ps1
+++ b/tests/GraphTools.Tests.ps1
@@ -1,8 +1,11 @@
+. $PSScriptRoot/TestHelpers.ps1
+
 Describe 'GraphTools Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force
         Import-Module $PSScriptRoot/../src/GraphTools/GraphTools.psd1 -Force
+        . $PSScriptRoot/../src/GraphTools/Private/Get-GraphAccessToken.ps1
     }
 
     Context 'Exported commands' {
@@ -20,6 +23,24 @@ Describe 'GraphTools Module' {
             Get-GraphUserDetails -UserPrincipalName 'u' -TenantId 'tid' -ClientId 'cid'
             Assert-MockCalled Write-STLog -ModuleName GraphTools -Times 1
             Assert-MockCalled Write-STTelemetryEvent -ModuleName GraphTools -Times 1
+        }
+    }
+
+    Context 'Environment variables' {
+        It 'uses GRAPH_* variables when parameters missing' {
+            $env:GRAPH_TENANT_ID = 'tidEnv'
+            $env:GRAPH_CLIENT_ID = 'cidEnv'
+            $env:GRAPH_CLIENT_SECRET = 'secEnv'
+            $cache = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+            try {
+                function Get-MsalToken { @{ AccessToken='tok'; ExpiresOn=(Get-Date).AddMinutes(30) } }
+                $token = Get-GraphAccessToken -CachePath $cache
+                $token | Should -Be 'tok'
+            } finally {
+                Remove-Item env:GRAPH_TENANT_ID -ErrorAction SilentlyContinue
+                Remove-Item env:GRAPH_CLIENT_ID -ErrorAction SilentlyContinue
+                Remove-Item env:GRAPH_CLIENT_SECRET -ErrorAction SilentlyContinue
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow `Get-GraphAccessToken` to read GRAPH_* environment variables
- document new variables in the GraphTools guide
- test token retrieval using environment variables

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Configuration (Import-PowerShellDataFile -Path ./PesterConfiguration.psd1)"`

------
https://chatgpt.com/codex/tasks/task_e_6845b5c4b854832c8210164e3fdf98bb