### PR TITLE
Add Invoke-PerformanceAudit wrapper

### DIFF
--- a/docs/PerformanceTools.md
+++ b/docs/PerformanceTools.md
@@ -11,4 +11,4 @@ Import-Module ./src/PerformanceTools/PerformanceTools.psd1
 | Command | Description |
 |---------|-------------|
 | `Measure-STCommand` | Execute a script block and report duration, CPU time and memory delta. |
-| `Invoke-PerformanceAudit` | Collect system metrics and optionally open a Service Desk ticket when thresholds are exceeded. |
+| `Invoke-PerformanceAudit` | Wrapper around `scripts/Invoke-PerformanceAudit.ps1` that collects system metrics and optionally opens a Service Desk ticket when thresholds are exceeded. |

--- a/docs/PerformanceTools/Invoke-PerformanceAudit.md
+++ b/docs/PerformanceTools/Invoke-PerformanceAudit.md
@@ -16,7 +16,7 @@ Invoke-PerformanceAudit [-CpuThreshold <Int>] [-MemoryThreshold <Int>] [-DiskThr
 ```
 
 ## DESCRIPTION
-The script samples system counters to produce a short performance report. If any metric exceeds the specified threshold values an alert is written to the log. When `-CreateTicket` is supplied a Service Desk ticket is created using `ServiceDeskTools`.
+This command samples system counters to produce a short performance report. It wraps the `scripts/Invoke-PerformanceAudit.ps1` script from this repository. If any metric exceeds the specified threshold values an alert is written to the log. When `-CreateTicket` is supplied a Service Desk ticket is created using `ServiceDeskTools`.
 
 ## EXAMPLES
 ### Example 1

--- a/src/PerformanceTools/PerformanceTools.psd1
+++ b/src/PerformanceTools/PerformanceTools.psd1
@@ -6,5 +6,5 @@
     Description = 'Commands for measuring script performance.'
     RequiredModules = @('Logging')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','Performance','Internal') } }
-    FunctionsToExport = @('Measure-STCommand')
+    FunctionsToExport = @('Measure-STCommand','Invoke-PerformanceAudit')
 }

--- a/src/PerformanceTools/PerformanceTools.psm1
+++ b/src/PerformanceTools/PerformanceTools.psm1
@@ -61,7 +61,31 @@ function Measure-STCommand {
     return $result
 }
 
-Export-ModuleMember -Function 'Measure-STCommand'
+function Invoke-PerformanceAudit {
+    <#
+    .SYNOPSIS
+        Collects CPU, memory, disk and network usage and logs the results.
+    .DESCRIPTION
+        Wrapper function that executes the Invoke-PerformanceAudit.ps1 script
+        located under the repository's scripts folder.
+    #>
+    [CmdletBinding()]
+    param(
+        [int]$CpuThreshold = 80,
+        [int]$MemoryThreshold = 80,
+        [int]$DiskThreshold = 80,
+        [int]$NetworkThreshold = 100,
+        [switch]$CreateTicket,
+        [string]$RequesterEmail,
+        [string]$TranscriptPath
+    )
+    $scriptPath = Join-Path $PSScriptRoot '..' |
+                  Join-Path -ChildPath '..' |
+                  Join-Path -ChildPath 'scripts/Invoke-PerformanceAudit.ps1'
+    & $scriptPath @PSBoundParameters
+}
+
+Export-ModuleMember -Function 'Measure-STCommand','Invoke-PerformanceAudit'
 
 function Show-PerformanceToolsBanner {
     Write-STDivider 'PERFORMANCETOOLS MODULE LOADED' -Style heavy

--- a/tests/PerformanceTools.Tests.ps1
+++ b/tests/PerformanceTools.Tests.ps1
@@ -8,6 +8,10 @@ Describe 'PerformanceTools Module' {
         (Get-Command -Module PerformanceTools).Name | Should -Contain 'Measure-STCommand'
     }
 
+    It 'exports Invoke-PerformanceAudit' {
+        (Get-Command -Module PerformanceTools).Name | Should -Contain 'Invoke-PerformanceAudit'
+    }
+
     It 'measures a script block' {
         $result = Measure-STCommand { Start-Sleep -Milliseconds 50 }
         $result.DurationSeconds | Should -BeGreaterThan 0


### PR DESCRIPTION
## Summary
- expose Invoke-PerformanceAudit in the PerformanceTools module
- document the new wrapper and update help text
- verify export in module tests and update audit tests

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: unable to locate package)*
- `pwsh -NoLogo -Command "Invoke-Pester -Configuration PesterConfiguration.psd1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b633c414832c8ac5bf4e2d0f9bdd