### PR TITLE
Add CHAOSTOOLS_ENABLED opt‑out

### DIFF
--- a/docs/ChaosTools.md
+++ b/docs/ChaosTools.md
@@ -15,7 +15,9 @@ Import-Module ./src/ChaosTools/ChaosTools.psd1
 
 Chaos behavior can also be triggered in other modules. Set the `ST_CHAOS_MODE`
 environment variable to `1` (or use the `-ChaosMode` switch where available) to
-have commands automatically wrap API calls with `Invoke-ChaosTest`.
+have commands automatically wrap API calls with `Invoke-ChaosTest`. Set
+`CHAOSTOOLS_ENABLED` to `0` or `False` to bypass delays and failures when calling
+`Invoke-ChaosTest` directly.
 
 See [ChaosTools/Invoke-ChaosTest.md](ChaosTools/Invoke-ChaosTest.md) for full
 command documentation.

--- a/docs/ChaosTools/Invoke-ChaosTest.md
+++ b/docs/ChaosTools/Invoke-ChaosTest.md
@@ -22,8 +22,9 @@ an exception based on `FailureRate` before running the provided script block.
 This helps verify that your automation gracefully handles transient errors and
 slower responses.
 
-While the cmdlet does not use environment variables directly, other modules such
-as **ServiceDeskTools** honor the `ST_CHAOS_MODE` environment variable and call
+If the `CHAOSTOOLS_ENABLED` environment variable is set to `0` or `False`, chaos
+injection is skipped and the script block runs normally. Other modules such as
+**ServiceDeskTools** honor the `ST_CHAOS_MODE` environment variable and call
 `Invoke-ChaosTest` internally when it is set to `1`.
 
 ## EXAMPLES

--- a/src/ChaosTools/Public/Invoke-ChaosTest.ps1
+++ b/src/ChaosTools/Public/Invoke-ChaosTest.ps1
@@ -4,7 +4,9 @@ function Invoke-ChaosTest {
         Executes a script block with random failures.
     .DESCRIPTION
         Runs the given commands and randomly throws an error based on FailureRate.
-        A random delay up to MaxDelaySeconds is introduced before execution.
+        A random delay up to MaxDelaySeconds is introduced before execution. Set
+        the CHAOSTOOLS_ENABLED environment variable to 0 or False to execute
+        the script block without any injected failures or delays.
     .PARAMETER ScriptBlock
         Commands to invoke.
     .PARAMETER FailureRate
@@ -24,6 +26,13 @@ function Invoke-ChaosTest {
     if ($FailureRate -lt 0 -or $FailureRate -gt 1) {
         throw 'FailureRate must be between 0 and 1.'
     }
+    $chaosEnabledVar = $env:CHAOSTOOLS_ENABLED
+    if ($chaosEnabledVar -ne $null -and $chaosEnabledVar -match '^(0|False)$') {
+        Write-STStatus 'ChaosTools disabled via CHAOSTOOLS_ENABLED.' -Level INFO -Log
+        & $ScriptBlock
+        return
+    }
+
     if ($MaxDelaySeconds -gt 0) {
         $delay = Get-Random -Minimum 0 -Maximum ($MaxDelaySeconds + 1)
         Start-Sleep -Seconds $delay

--- a/tests/ChaosTools.Tests.ps1
+++ b/tests/ChaosTools.Tests.ps1
@@ -17,4 +17,26 @@ Describe 'ChaosTools Module' {
     It 'throws when failure rate is one' {
         { Invoke-ChaosTest -ScriptBlock { } -FailureRate 1 -MaxDelaySeconds 0 } | Should -Throw
     }
+
+    It 'bypasses chaos when CHAOSTOOLS_ENABLED=0' {
+        $script:ran = $false
+        try {
+            $env:CHAOSTOOLS_ENABLED = '0'
+            Invoke-ChaosTest -ScriptBlock { $script:ran = $true } -FailureRate 1 -MaxDelaySeconds 0
+        } finally {
+            Remove-Item env:CHAOSTOOLS_ENABLED -ErrorAction SilentlyContinue
+        }
+        $script:ran | Should -BeTrue
+    }
+
+    It 'bypasses chaos when CHAOSTOOLS_ENABLED=False' {
+        $script:ran = $false
+        try {
+            $env:CHAOSTOOLS_ENABLED = 'False'
+            Invoke-ChaosTest -ScriptBlock { $script:ran = $true } -FailureRate 1 -MaxDelaySeconds 0
+        } finally {
+            Remove-Item env:CHAOSTOOLS_ENABLED -ErrorAction SilentlyContinue
+        }
+        $script:ran | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- allow `Invoke-ChaosTest` to skip failures when `CHAOSTOOLS_ENABLED` is `0` or `False`
- document the environment variable in module docs
- describe environment variable usage in command help
- test disabling chaos via environment variable

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)`

------
https://chatgpt.com/codex/tasks/task_e_6845b6ae78e8832caf04e86512a66e1d