### PR TITLE
Update GraphTools status to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository packages a collection of scripts into reusable modules.
 | SharePointTools | Beta |
 | ServiceDeskTools | Beta |
 | PerformanceTools | Experimental |
-| GraphTools | Beta |
+| GraphTools | Stable |
 | ChaosTools | Experimental |
 
 ## Requirements 📋

--- a/src/GraphTools/GraphTools.psd1
+++ b/src/GraphTools/GraphTools.psd1
@@ -5,6 +5,11 @@
     Author = 'Contoso'
     Description = 'Microsoft Graph helper functions.'
     RequiredModules = @('Logging','Telemetry')
-    PrivateData = @{ PSData = @{ Tags = @('PowerShell','Graph','Internal') } }
+    PrivateData = @{
+        PSData = @{
+            Tags = @('PowerShell','Graph','Internal')
+            ReleaseNotes = 'Initial stable release of GraphTools.'
+        }
+    }
     FunctionsToExport = @('Get-GraphUserDetails','Get-GraphGroupDetails')
 }


### PR DESCRIPTION
## Summary
- mark GraphTools module as `Stable` in README
- add ReleaseNotes metadata to GraphTools.psd1

## Testing
- `pwsh -NoLogo -NoProfile -Command "Import-Module Pester -ErrorAction Stop; Invoke-Pester -Configuration PesterConfiguration.psd1"` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845c6a40f48832cbf9e34a3a91e6b47