### PR TITLE
Add MSAL dependency for GraphTools

### DIFF
--- a/docs/GraphTools.md
+++ b/docs/GraphTools.md
@@ -6,6 +6,12 @@ Commands that query Microsoft Graph for tenant data. Import the module:
 Import-Module ./src/GraphTools/GraphTools.psd1
 ```
 
+This module depends on the `MSAL.PS` module for authentication. Install it first if needed:
+
+```powershell
+Install-Module MSAL.PS -Scope CurrentUser
+```
+
 ## Available Commands
 
 | Command | Description | Example |

--- a/src/GraphTools/GraphTools.psd1
+++ b/src/GraphTools/GraphTools.psd1
@@ -4,7 +4,7 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000012'
     Author = 'Contoso'
     Description = 'Microsoft Graph helper functions.'
-    RequiredModules = @('Logging','Telemetry')
+    RequiredModules = @('Logging','Telemetry','MSAL.PS')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','Graph','Internal') } }
     FunctionsToExport = @('Get-GraphUserDetails','Get-GraphGroupDetails')
 }

--- a/tests/GraphTools.Tests.ps1
+++ b/tests/GraphTools.Tests.ps1
@@ -8,6 +8,16 @@ Describe 'GraphTools Module' {
         . $PSScriptRoot/../src/GraphTools/Private/Get-GraphAccessToken.ps1
     }
 
+    Context 'Module import' {
+        It 'imports successfully when MSAL.PS installed' {
+            Remove-Module GraphTools -ErrorAction SilentlyContinue
+            if (-not (Get-Module -ListAvailable -Name MSAL.PS)) {
+                try { Install-Module -Name MSAL.PS -Force -Scope CurrentUser -ErrorAction Stop } catch {}
+            }
+            { Import-Module $PSScriptRoot/../src/GraphTools/GraphTools.psd1 -Force } | Should -Not -Throw
+        }
+    }
+
     Context 'Exported commands' {
         It 'Exports Get-GraphUserDetails' {
             (Get-Command -Module GraphTools).Name | Should -Contain 'Get-GraphUserDetails'


### PR DESCRIPTION
## Summary
- require MSAL.PS for GraphTools
- document the MSAL.PS requirement
- test that the module loads when MSAL.PS is installed

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1`

------
https://chatgpt.com/codex/tasks/task_e_6845c6a044c4832c9baf37c51564b595