### PR TITLE
Graduate ServiceDeskTools module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Build script now uses the latest artifact upload action
 
+## [ServiceDeskTools 1.1.0] - 2024-04-29
+### Added
+- SupportsShouldProcess added to ticket management commands
+- Additional Pester tests for `-WhatIf` scenarios
+### Changed
+- Documentation updated to reflect stable status
+

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository packages a collection of scripts into reusable modules.
 | ------ | ------ |
 | SupportTools | Stable |
 | SharePointTools | Beta |
-| ServiceDeskTools | Beta |
+| ServiceDeskTools | Stable |
 | PerformanceTools | Experimental |
 | GraphTools | Beta |
 | ChaosTools | Experimental |

--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -1,6 +1,6 @@
 # ServiceDeskTools Module
 
-Commands for interacting with the Service Desk ticketing API.
+Commands for interacting with the Service Desk ticketing API. **ServiceDeskTools is now considered Stable** and is fully supported for production use.
 
 ## Available Commands
 
@@ -15,6 +15,7 @@ Commands for interacting with the Service Desk ticketing API.
 | `Submit-Ticket` | Create a Service Desk incident with minimal parameters | `Submit-Ticket -Subject 'Alert' -Description 'Issue detected' -RequesterEmail 'ops@example.com'` |
 
 `SD_API_TOKEN` must be set in the environment. Optionally set `SD_BASE_URI` if your Service Desk API uses a custom URL.
+For guidance on storing the token securely see [CredentialStorage.md](./CredentialStorage.md).
 
 ### Chaos Mode
 

--- a/docs/ServiceDeskTools/ReleaseNotes.md
+++ b/docs/ServiceDeskTools/ReleaseNotes.md
@@ -1,0 +1,6 @@
+# ServiceDeskTools Release Notes
+
+## 1.1.0 - 2024-04-29
+- Module graduated to **Stable** status.
+- Added `SupportsShouldProcess` to all ticket management commands.
+- Expanded Pester tests to cover `-WhatIf` behavior.

--- a/docs/Stewardship.md
+++ b/docs/Stewardship.md
@@ -14,7 +14,7 @@ This guide explains how to keep the PowerShell modules healthy over time and pre
 |-------------------|-------------|
 | SupportTools      | Stable      |
 | SharePointTools   | Beta        |
-| ServiceDeskTools  | Beta|
+| ServiceDeskTools  | Stable |
 
 
 ## Backup Strategy

--- a/src/ServiceDeskTools/Public/Get-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDTicket.ps1
@@ -5,7 +5,7 @@ function Get-SDTicket {
     .PARAMETER Id
         Incident ID to retrieve.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -22,5 +22,7 @@ function Get-SDTicket {
     }
 
     Write-STLog -Message "Get-SDTicket $Id"
-    Invoke-SDRequest -Method 'GET' -Path "/incidents/$Id.json" -ChaosMode:$ChaosMode
+    if ($PSCmdlet.ShouldProcess("ticket $Id", 'Get')) {
+        Invoke-SDRequest -Method 'GET' -Path "/incidents/$Id.json" -ChaosMode:$ChaosMode
+    }
 }

--- a/src/ServiceDeskTools/Public/Link-SDTicketToSPTask.ps1
+++ b/src/ServiceDeskTools/Public/Link-SDTicketToSPTask.ps1
@@ -9,7 +9,7 @@ function Link-SDTicketToSPTask {
     .PARAMETER FieldName
         Name of the incident field storing the task URL.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -33,5 +33,7 @@ function Link-SDTicketToSPTask {
 
     Write-STLog -Message "Link-SDTicketToSPTask $TicketId $TaskUrl"
     $fields = @{ $FieldName = $TaskUrl }
-    Set-SDTicket -Id $TicketId -Fields $fields -ChaosMode:$ChaosMode
+    if ($PSCmdlet.ShouldProcess("ticket $TicketId", 'Link to SP task')) {
+        Set-SDTicket -Id $TicketId -Fields $fields -ChaosMode:$ChaosMode
+    }
 }

--- a/src/ServiceDeskTools/Public/New-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/New-SDTicket.ps1
@@ -9,7 +9,7 @@ function New-SDTicket {
     .PARAMETER RequesterEmail
         Email address of the requester.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -33,5 +33,7 @@ function New-SDTicket {
 
     Write-STLog -Message "New-SDTicket $Subject"
     $body = @{ incident = @{ name = $Subject; description = $Description; requester_email = $RequesterEmail } }
-    Invoke-SDRequest -Method 'POST' -Path '/incidents.json' -Body $body -ChaosMode:$ChaosMode
+    if ($PSCmdlet.ShouldProcess("ticket $Subject", 'Create')) {
+        Invoke-SDRequest -Method 'POST' -Path '/incidents.json' -Body $body -ChaosMode:$ChaosMode
+    }
 }

--- a/src/ServiceDeskTools/Public/Search-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Search-SDTicket.ps1
@@ -5,7 +5,7 @@ function Search-SDTicket {
     .PARAMETER Query
         Text used to search incident subjects and descriptions.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -23,5 +23,7 @@ function Search-SDTicket {
 
     Write-STLog -Message "Search-SDTicket $Query"
     $encoded = [uri]::EscapeDataString($Query)
-    Invoke-SDRequest -Method 'GET' -Path "/incidents.json?search=$encoded" -ChaosMode:$ChaosMode
+    if ($PSCmdlet.ShouldProcess('incidents', "Search for $Query")) {
+        Invoke-SDRequest -Method 'GET' -Path "/incidents.json?search=$encoded" -ChaosMode:$ChaosMode
+    }
 }

--- a/src/ServiceDeskTools/Public/Set-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicket.ps1
@@ -7,7 +7,7 @@ function Set-SDTicket {
     .PARAMETER Fields
         Hashtable of fields to modify.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -28,5 +28,7 @@ function Set-SDTicket {
 
     Write-STLog -Message "Set-SDTicket $Id"
     $body = @{ incident = $Fields }
-    Invoke-SDRequest -Method 'PUT' -Path "/incidents/$Id.json" -Body $body -ChaosMode:$ChaosMode
+    if ($PSCmdlet.ShouldProcess("ticket $Id", 'Update')) {
+        Invoke-SDRequest -Method 'PUT' -Path "/incidents/$Id.json" -Body $body -ChaosMode:$ChaosMode
+    }
 }

--- a/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
@@ -7,7 +7,7 @@ function Set-SDTicketBulk {
     .PARAMETER Fields
         Hashtable of fields to modify on each incident.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -28,6 +28,8 @@ function Set-SDTicketBulk {
 
     foreach ($ticketId in $Id) {
         Write-STLog -Message "Set-SDTicketBulk $ticketId"
-        Set-SDTicket -Id $ticketId -Fields $Fields -ChaosMode:$ChaosMode
+        if ($PSCmdlet.ShouldProcess("ticket $ticketId", 'Update')) {
+            Set-SDTicket -Id $ticketId -Fields $Fields -ChaosMode:$ChaosMode
+        }
     }
 }

--- a/src/ServiceDeskTools/Public/Submit-Ticket.ps1
+++ b/src/ServiceDeskTools/Public/Submit-Ticket.ps1
@@ -5,7 +5,7 @@ function Submit-Ticket {
     .DESCRIPTION
         Wrapper around New-SDTicket providing a simpler command name.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -28,5 +28,7 @@ function Submit-Ticket {
     }
 
     Write-STLog -Message "Submit-Ticket $Subject"
-    New-SDTicket -Subject $Subject -Description $Description -RequesterEmail $RequesterEmail -ChaosMode:$ChaosMode
+    if ($PSCmdlet.ShouldProcess("ticket $Subject", 'Create')) {
+        New-SDTicket -Subject $Subject -Description $Description -RequesterEmail $RequesterEmail -ChaosMode:$ChaosMode
+    }
 }

--- a/src/ServiceDeskTools/ServiceDeskTools.psd1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'ServiceDeskTools.psm1'
-    ModuleVersion = '1.0.0'
+    ModuleVersion = '1.1.0'
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000003'
     Author = 'Contoso'
     Description = 'Commands for interacting with the Service Desk ticketing system.'

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -159,4 +159,17 @@ Describe 'ServiceDeskTools Module' {
             }
         }
     }
+
+    Context 'WhatIf support' {
+        It 'New-SDTicket does not invoke request when -WhatIf used' {
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
+            New-SDTicket -Subject 's' -Description 'd' -RequesterEmail 'a@b.com' -WhatIf
+            Assert-MockCalled Invoke-SDRequest -Times 0 -ModuleName ServiceDeskTools
+        }
+        It 'Set-SDTicket does not invoke request when -WhatIf used' {
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
+            Set-SDTicket -Id 1 -Fields @{status='Open'} -WhatIf
+            Assert-MockCalled Invoke-SDRequest -Times 0 -ModuleName ServiceDeskTools
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- graduate ServiceDeskTools module from Beta to Stable
- add release notes for ServiceDeskTools 1.1.0
- enable SupportsShouldProcess in ticket commands
- document stable status and credential guidance
- mark module Stable in Stewardship and README
- bump module version to 1.1.0 and update changelog
- test WhatIf behavior with new Pester tests

## Testing
- `pwsh -NoProfile -NonInteractive -Command '$config = Import-PowerShellDataFile "$(pwd)/PesterConfiguration.psd1"; Invoke-Pester -Configuration $config'`

------
https://chatgpt.com/codex/tasks/task_e_6845c5abcf98832cb02c23bd250c4d26