### PR TITLE
Add MSAL.PS dependency to GraphTools

### DIFF
--- a/docs/GraphTools.md
+++ b/docs/GraphTools.md
@@ -6,6 +6,12 @@ Commands that query Microsoft Graph for tenant data. Import the module:
 Import-Module ./src/GraphTools/GraphTools.psd1
 ```
 
+The module relies on the `MSAL.PS` library for obtaining access tokens. Install it from the PowerShell Gallery if needed:
+
+```powershell
+Install-Module MSAL.PS
+```
+
 ## Available Commands
 
 | Command | Description | Example |

--- a/src/GraphTools/GraphTools.psd1
+++ b/src/GraphTools/GraphTools.psd1
@@ -4,7 +4,7 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000012'
     Author = 'Contoso'
     Description = 'Microsoft Graph helper functions.'
-    RequiredModules = @('Logging','Telemetry')
+    RequiredModules = @('Logging','Telemetry','MSAL.PS')
     PrivateData = @{
         PSData = @{
             Tags = @('PowerShell','Graph','Internal')

--- a/tests/GraphTools.Tests.ps1
+++ b/tests/GraphTools.Tests.ps1
@@ -8,6 +8,14 @@ Describe 'GraphTools Module' {
         . $PSScriptRoot/../src/GraphTools/Private/Get-GraphAccessToken.ps1
     }
 
+    Context 'Module import' {
+        It 'imports when MSAL.PS is installed' {
+            Remove-Module GraphTools -ErrorAction SilentlyContinue
+            Import-Module MSAL.PS -ErrorAction Stop
+            { Import-Module $PSScriptRoot/../src/GraphTools/GraphTools.psd1 -Force } | Should -Not -Throw
+        }
+    }
+
     Context 'Exported commands' {
         It 'Exports Get-GraphUserDetails' {
             (Get-Command -Module GraphTools).Name | Should -Contain 'Get-GraphUserDetails'


### PR DESCRIPTION
## Summary
- include `MSAL.PS` in GraphTools required modules
- document dependency in module docs
- test import succeeds with MSAL.PS present

## Testing
- `pwsh -NoLogo -Command 'Install-Module MSAL.PS -Scope CurrentUser -Force -AllowClobber'`
- `pwsh -NoLogo -Command 'Install-Module Pester -MinimumVersion 5.0 -Scope CurrentUser -Force'`
- `pwsh -NoLogo -Command '$cfg = Import-PowerShellDataFile "./PesterConfiguration.psd1"; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_6845c857f0c8832ca6cf096ee921c5e9