### PR TITLE
Improve ServiceDeskTools request handling

### DIFF
--- a/docs/ServiceDeskTools/ReleaseNotes.md
+++ b/docs/ServiceDeskTools/ReleaseNotes.md
@@ -4,3 +4,6 @@
 - Module graduated to **Stable** status.
 - Added `SupportsShouldProcess` to all ticket management commands.
 - Expanded Pester tests to cover `-WhatIf` behavior.
+
+## 1.2.0 - 2025-06-08
+- Improved `Invoke-SDRequest` with rate limiting, retry logic and verbose logging.

--- a/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
+++ b/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
@@ -24,22 +24,61 @@ function Invoke-SDRequest {
         elseif ($roll -le 20) { throw 'ChaosMode: simulated server error (500 Internal Server Error)' }
     }
 
+    $rateLimit = if ($env:SD_RATE_LIMIT_PER_MINUTE) { [int]$env:SD_RATE_LIMIT_PER_MINUTE } else { $null }
+    if ($rateLimit) {
+        if (-not $script:SDRequestHistory) { $script:SDRequestHistory = @() }
+        $now = Get-Date
+        $script:SDRequestHistory = $script:SDRequestHistory | Where-Object { $_ -gt $now.AddMinutes(-1) }
+        if ($script:SDRequestHistory.Count -ge $rateLimit) {
+            $oldest = $script:SDRequestHistory[0]
+            if ($oldest) {
+                $wait = 60 - ($now - $oldest).TotalSeconds
+                if ($wait -gt 0) {
+                    Write-Verbose "Rate limit reached, pausing for $wait seconds"
+                    Start-Sleep -Seconds [math]::Ceiling($wait)
+                }
+            }
+        }
+        $script:SDRequestHistory += $now
+    }
+
     $headers = @{ 'X-Samanage-Authorization' = "Bearer $token"; Accept = 'application/json' }
     $uri = $baseUri.TrimEnd('/') + $Path
     Write-STLog -Message "SDRequest $Method $uri"
-    if ($Body) {
-        $json = $Body | ConvertTo-Json -Depth 10
+    Write-Verbose "Invoking $Method $uri"
+    $json = if ($Body) { $Body | ConvertTo-Json -Depth 10 } else { $null }
+    $maxRetries = 3
+    $attempt = 1
+    while ($true) {
         try {
-            Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers -Body $json -ContentType 'application/json'
+            if ($json) {
+                $response = Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers -Body $json -ContentType 'application/json'
+            } else {
+                $response = Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers
+            }
             Write-STLog -Message "SUCCESS $Method $uri"
-        } catch {
-            Write-STLog -Message "ERROR $Method $uri :: $_" -Level 'ERROR'
-            throw
-        }
-    } else {
-        try {
-            Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers
-            Write-STLog -Message "SUCCESS $Method $uri"
+            return $response
+        } catch [System.Net.WebException],[Microsoft.PowerShell.Commands.HttpResponseException] {
+            $status = $_.Exception.Response.StatusCode.value__
+            $msg    = $_.Exception.Message
+            Write-STLog -Message "HTTP $status $msg" -Level 'ERROR'
+            if ($status -eq 429 -or ($status -ge 500 -and $status -lt 600)) {
+                if ($attempt -lt $maxRetries) {
+                    $retryAfter = $_.Exception.Response.Headers['Retry-After']
+                    if ($retryAfter) {
+                        $delay = [int]$retryAfter
+                    } else {
+                        $delay = [math]::Pow(2, $attempt)
+                    }
+                    Write-STLog -Message "Retry $attempt in $delay sec" -Level WARN
+                    Write-Verbose "Retrying in $delay seconds"
+                    Start-Sleep -Seconds $delay
+                    $attempt++
+                    continue
+                }
+            }
+            $errorObj = New-STErrorObject -Message "HTTP $status $msg" -Category 'HTTP'
+            throw $errorObj
         } catch {
             Write-STLog -Message "ERROR $Method $uri :: $_" -Level 'ERROR'
             throw


### PR DESCRIPTION
## Summary
- handle rate limits and transient errors in Invoke-SDRequest
- add exponential backoff retry logic
- log verbose output and respect Retry-After header

## Testing
- `Invoke-Pester -Script tests/ServiceDeskTools.Tests.ps1 -PassThru`
- `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)`

------
https://chatgpt.com/codex/tasks/task_e_6845d4b03e4c832c88c6ec486bfb2f57