### PR TITLE
Refactor array handling in loops

### DIFF
--- a/scripts/AddUsersToGroup.ps1
+++ b/scripts/AddUsersToGroup.ps1
@@ -186,8 +186,8 @@ function Start-Main {
     $file = Import-Csv $filePath
     $users = $file.UPN
 
-    $addedUsers = @()
-    $skippedUsers = @()
+    $addedUsers = [System.Collections.Generic.List[object]]::new()
+    $skippedUsers = [System.Collections.Generic.List[object]]::new()
 
     # Check if user is in the group and add the user if not
     foreach ($user in $users)
@@ -196,7 +196,7 @@ function Start-Main {
         $userInfo = Get-UserID -UserPrincipalName $user
 
         if (-not $userInfo) {
-            $skippedUsers += $user
+            $skippedUsers.Add($user)
             Write-STStatus "User not found: $user" -Level WARN
             continue
         }
@@ -205,14 +205,14 @@ function Start-Main {
         if ($groupExistingMembers -contains $userInfo.UserPrincipalName)
         {
             Write-STStatus "UserIsInGroup: $($user) - $($group.DisplayName)" -Level WARN
-            $skippedUsers += $userInfo.UserPrincipalName
+            $skippedUsers.Add($userInfo.UserPrincipalName)
         }
         else {
             Write-STStatus "AddingUserToGroup: User: $($userInfo.DisplayName) - Group: $($group.DisplayName)" -Level INFO
             try {
                 New-MgGroupMember -GroupId $group.Id -DirectoryObjectId $userInfo.Id -ErrorAction Stop
                 Write-STStatus "[SUCCESS] AddingUserToGroup: User: $($userInfo.DisplayName) - Group: $($group.DisplayName)" -Level SUCCESS
-                $addedUsers += $userInfo.UserPrincipalName
+                $addedUsers.Add($userInfo.UserPrincipalName)
             }
             catch {
                 Write-Error "[FAIL] Error adding $($user) to $($group.Id)..."

--- a/scripts/CleanupArchive.ps1
+++ b/scripts/CleanupArchive.ps1
@@ -95,7 +95,7 @@ Write-STStatus ($ZzzArchiveProductionSharePointFolderItems | Format-Table | Out-
 [System.Collections.Generic.List[object]]$Files = $ZzzArchiveProductionSharePointFolderItems | where {$_.GetType().Name -eq "File"}
 
 # snapshot data list
-$snapshot = @()
+$snapshot = [System.Collections.Generic.List[object]]::new()
 
 # Delete all files
 foreach ($file in $Files)
@@ -112,7 +112,7 @@ foreach ($file in $Files)
     {
         Write-STStatus "WouldDeleteFile: $($file.ServerRelativeUrl)" -Level SUB
     }
-    $snapshot += $record
+    $snapshot.Add($record)
 }
 
 # Delete folders
@@ -132,7 +132,7 @@ while ($Folders)
         {
             Write-STStatus "WouldDelete: $($folder.Name)" -Level SUB
         }
-        $snapshot += $record
+        $snapshot.Add($record)
         $Folders.Remove($folder) | Out-Null
     }
     catch {
@@ -161,7 +161,7 @@ foreach ($folder in $ZzzArchiveProductionSharePointFolder)
         {
             Write-STStatus "WouldRemoveFile: $($folder.ServerRelativeUrl)" -Level SUB
         }
-        $snapshot += $record
+        $snapshot.Add($record)
     }
     if ($folder.GetType().Name -eq 'Folder')
     {
@@ -176,7 +176,7 @@ foreach ($folder in $ZzzArchiveProductionSharePointFolder)
         {
             Write-STStatus "WouldRemoveFolder: $($folder.ServerRelativeUrl)" -Level SUB
         }
-        $snapshot += $record
+        $snapshot.Add($record)
     }
 }
 

--- a/scripts/Sync-SDTickets.ps1
+++ b/scripts/Sync-SDTickets.ps1
@@ -41,7 +41,8 @@ if (-not (Test-Path $CachePath)) {
 
 $cache = Get-Content $CachePath -Raw | ConvertFrom-Json
 $lastFullSync = [datetime]$cache.lastFullSync
-$tickets = $cache.tickets
+$tickets = [System.Collections.Generic.List[object]]::new()
+if ($cache.tickets) { $tickets.AddRange($cache.tickets) }
 
 while ($true) {
     if ((Get-Date) -gt $lastFullSync.AddHours($FullSyncHours)) {
@@ -53,7 +54,7 @@ while ($true) {
         if ($latest) {
             $new = Get-NewTickets -Since ([datetime]$latest)
             if ($new) {
-                $tickets += $new
+                $tickets.AddRange($new)
                 Write-STStatus "Added $($new.Count) new tickets to cache." -Level SUCCESS -Log
             } else {
                 Write-STStatus 'No new tickets found.' -Level SUB -Log


### PR DESCRIPTION
## Summary
- avoid using `+=` to build arrays inside loops
- use `System.Collections.Generic.List[object]` for ticket sync, archive cleanup, and group management scripts

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Configuration ./PesterConfiguration.psd1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e5d93c68832ca21bc1c4f1afc000