### PR TITLE
Add CmdletBinding and help templates to banners

### DIFF
--- a/src/ChaosTools/ChaosTools.psm1
+++ b/src/ChaosTools/ChaosTools.psm1
@@ -9,6 +9,12 @@ Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-O
 Export-ModuleMember -Function 'Invoke-ChaosTest'
 
 function Show-ChaosToolsBanner {
+    <#
+    .SYNOPSIS
+        Displays the ChaosTools module banner.
+    #>
+    [CmdletBinding()]
+    param()
     Write-STDivider 'CHAOSTOOLS MODULE LOADED' -Style heavy
     Write-STStatus "Run 'Get-Command -Module ChaosTools' to view available tools." -Level SUB
     Write-STLog -Message 'ChaosTools module loaded'

--- a/src/GraphTools/GraphTools.psm1
+++ b/src/GraphTools/GraphTools.psm1
@@ -11,6 +11,12 @@ Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-O
 Export-ModuleMember -Function 'Get-GraphUserDetails','Get-GraphGroupDetails'
 
 function Show-GraphToolsBanner {
+    <#
+    .SYNOPSIS
+        Displays the GraphTools module banner.
+    #>
+    [CmdletBinding()]
+    param()
     Write-STDivider 'GRAPHTOOLS MODULE LOADED' -Style heavy
     Write-STStatus "Run 'Get-Command -Module GraphTools' to view available tools." -Level SUB
     Write-STLog -Message 'GraphTools module loaded'

--- a/src/GraphTools/Private/Get-GraphAccessToken.ps1
+++ b/src/GraphTools/Private/Get-GraphAccessToken.ps1
@@ -1,9 +1,17 @@
 function Get-GraphAccessToken {
+    <#
+    .SYNOPSIS
+        Retrieves and caches a Microsoft Graph access token.
+    #>
     [CmdletBinding()]
     param(
+        [ValidateNotNullOrEmpty()]
         [string]$TenantId,
+        [ValidateNotNullOrEmpty()]
         [string]$ClientId,
+        [ValidateNotNullOrEmpty()]
         [string]$ClientSecret,
+        [ValidateNotNullOrEmpty()]
         [string]$CachePath = "$env:USERPROFILE/.graphToken.json"
     )
 

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -217,6 +217,12 @@ function Write-STClosing {
 Export-ModuleMember -Function 'Write-STLog','Write-STRichLog','Write-STStatus','Show-STPrompt','Write-STDivider','Write-STBlock','Write-STClosing'
 
 function Show-LoggingBanner {
+    <#
+    .SYNOPSIS
+        Displays the Logging module banner.
+    #>
+    [CmdletBinding()]
+    param()
     Write-STDivider 'LOGGING MODULE LOADED' -Style heavy
     Write-STStatus "Run 'Get-Command -Module Logging' to view available tools." -Level SUB
     Write-STLog -Message 'Logging module loaded'

--- a/src/PerformanceTools/PerformanceTools.psm1
+++ b/src/PerformanceTools/PerformanceTools.psm1
@@ -87,6 +87,12 @@ function Invoke-PerformanceAudit {
 Export-ModuleMember -Function 'Measure-STCommand','Invoke-PerformanceAudit'
 
 function Show-PerformanceToolsBanner {
+    <#
+    .SYNOPSIS
+        Displays the PerformanceTools module banner.
+    #>
+    [CmdletBinding()]
+    param()
     Write-STDivider 'PERFORMANCETOOLS MODULE LOADED' -Style heavy
     Write-STStatus "Run 'Get-Command -Module PerformanceTools' to view available tools." -Level SUB
     Write-STLog -Message 'PerformanceTools module loaded'

--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -57,6 +57,12 @@ function Test-IsElevated {
 Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','Write-STDebug','Test-IsElevated'
 
 function Show-STCoreBanner {
+    <#
+    .SYNOPSIS
+        Displays the STCore module banner.
+    #>
+    [CmdletBinding()]
+    param()
     Write-Host 'STCore module loaded' -ForegroundColor DarkGray
 }
 

--- a/src/ServiceDeskTools/ServiceDeskTools.psm1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psm1
@@ -16,6 +16,12 @@ Export-ModuleMember -Function (
 ).BaseName
 
 function Show-ServiceDeskToolsBanner {
+    <#
+    .SYNOPSIS
+        Displays the ServiceDeskTools module banner.
+    #>
+    [CmdletBinding()]
+    param()
     Write-STDivider 'SERVICEDESKTOOLS MODULE LOADED' -Style heavy
     Write-STStatus "Run 'Get-Command -Module ServiceDeskTools' to view available tools." -Level SUB
     Write-STLog -Message 'ServiceDeskTools module loaded'

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -1252,6 +1252,8 @@ function Show-SharePointToolsBanner {
     .EXAMPLE
         Show-SharePointToolsBanner
     #>
+    [CmdletBinding()]
+    param()
     Write-STDivider 'SHAREPOINTTOOLS MODULE LOADED' -Style heavy
     Write-STStatus "Run 'Get-Command -Module SharePointTools' to view available tools." -Level SUB
     Write-STLog -Message 'SharePointTools module loaded'

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -58,6 +58,12 @@ Export-ModuleMember -Function @(
 
 
 function Show-SupportToolsBanner {
+    <#
+    .SYNOPSIS
+        Displays the SupportTools module banner.
+    #>
+    [CmdletBinding()]
+    param()
     Write-STDivider 'SUPPORTTOOLS MODULE LOADED' -Style heavy
     Write-STStatus "Run 'Get-Command -Module SupportTools' to view available tools." -Level SUB
     Write-STLog -Message 'SupportTools module loaded'

--- a/src/Telemetry/Telemetry.psm1
+++ b/src/Telemetry/Telemetry.psm1
@@ -136,6 +136,12 @@ function Get-STTelemetryMetrics {
 Export-ModuleMember -Function 'Write-STTelemetryEvent','Get-STTelemetryMetrics','Send-STMetric'
 
 function Show-TelemetryBanner {
+    <#
+    .SYNOPSIS
+        Displays the Telemetry module banner.
+    #>
+    [CmdletBinding()]
+    param()
     Write-STDivider 'TELEMETRY MODULE LOADED' -Style heavy
     Write-STStatus "Run 'Get-Command -Module Telemetry' to view available tools." -Level SUB
     Write-STLog -Message 'Telemetry module loaded'


### PR DESCRIPTION
## Summary
- add CmdletBinding() blocks and comment-based help for all module banner functions
- validate parameters and add help for `Get-GraphAccessToken`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration ./.github/workflows/pesterConfiguration.psd1"` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845e5ef07f8832c8f8f8424714fa461