### PR TITLE
Centralize config reading

### DIFF
--- a/scripts/Configure-SharePointTools.ps1
+++ b/scripts/Configure-SharePointTools.ps1
@@ -6,19 +6,17 @@ param(
 )
 
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/STCore/STCore.psd1') -ErrorAction SilentlyContinue
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 $settingsPath = Join-Path $repoRoot 'config/SharePointToolsSettings.psd1'
 
-if (Test-Path $settingsPath) {
-    try {
-        $settings = Import-PowerShellDataFile $settingsPath
-    } catch {
-        $settings = @{ ClientId=''; TenantId=''; CertPath=''; Sites=@{} }
-    }
-} else {
-    $settings = @{ ClientId=''; TenantId=''; CertPath=''; Sites=@{} }
-}
+$settings = Get-STConfig -Path $settingsPath
+if (-not $settings) { $settings = @{} }
+if (-not $settings.ContainsKey('ClientId')) { $settings.ClientId = '' }
+if (-not $settings.ContainsKey('TenantId')) { $settings.TenantId = '' }
+if (-not $settings.ContainsKey('CertPath')) { $settings.CertPath = '' }
+if (-not $settings.ContainsKey('Sites')) { $settings.Sites = @{} }
 
 if (-not $settings.ContainsKey('Sites')) { $settings.Sites = @{} }
 

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -2,9 +2,9 @@ $repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 Import-Module $coreModule -ErrorAction SilentlyContinue
 $configFile = Join-Path $repoRoot 'config/supporttools.json'
-$SupportToolsConfig = @{ maintenanceMode = $false }
-if (Test-Path $configFile) {
-    try { $SupportToolsConfig = Get-Content $configFile | ConvertFrom-Json } catch {}
+$SupportToolsConfig = Get-STConfig -Path $configFile
+if (-not $SupportToolsConfig.ContainsKey('maintenanceMode')) {
+    $SupportToolsConfig.maintenanceMode = $false
 }
 if ($SupportToolsConfig.maintenanceMode) {
     Write-Host 'SupportTools is currently in maintenance mode. Exiting.' -ForegroundColor Yellow

--- a/src/STCore/STCore.psd1
+++ b/src/STCore/STCore.psd1
@@ -4,5 +4,5 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000000'
     Author = 'Contoso'
     Description = 'Core utility functions.'
-    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','Write-STDebug','Test-IsElevated')
+    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','Write-STDebug','Test-IsElevated','Get-STConfig')
 }

--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -54,7 +54,28 @@ function Test-IsElevated {
     }
 }
 
-Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','Write-STDebug','Test-IsElevated'
+function Get-STConfig {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    if (-not (Test-Path $Path)) { return @{} }
+
+    try {
+        $ext = [IO.Path]::GetExtension($Path).ToLower()
+        switch ($ext) {
+            '.json' { return Get-Content $Path | ConvertFrom-Json }
+            '.psd1' { return Import-PowerShellDataFile $Path }
+            default { throw "Unsupported config type: $ext" }
+        }
+    } catch {
+        Write-STDebug "Failed to read config $Path: $_"
+        return @{}
+    }
+}
+
+Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','Write-STDebug','Test-IsElevated','Get-STConfig'
 
 function Show-STCoreBanner {
     Write-Host 'STCore module loaded' -ForegroundColor DarkGray

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -5,10 +5,12 @@ $repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 Import-Module $coreModule -ErrorAction SilentlyContinue
 $settingsFile = Join-Path $repoRoot 'config/SharePointToolsSettings.psd1'
-$SharePointToolsSettings = @{ ClientId=''; TenantId=''; CertPath=''; Sites=@{} }
-if (Test-Path $settingsFile) {
-    try { $SharePointToolsSettings = Import-PowerShellDataFile $settingsFile } catch {}
-}
+$SharePointToolsSettings = Get-STConfig -Path $settingsFile
+if (-not $SharePointToolsSettings) { $SharePointToolsSettings = @{} }
+if (-not $SharePointToolsSettings.ContainsKey('ClientId')) { $SharePointToolsSettings.ClientId = '' }
+if (-not $SharePointToolsSettings.ContainsKey('TenantId')) { $SharePointToolsSettings.TenantId = '' }
+if (-not $SharePointToolsSettings.ContainsKey('CertPath')) { $SharePointToolsSettings.CertPath = '' }
+if (-not $SharePointToolsSettings.ContainsKey('Sites')) { $SharePointToolsSettings.Sites = @{} }
 
 $loggingModule = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath 'Logging/Logging.psd1'
 Import-Module $loggingModule -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- add `Get-STConfig` to STCore
- use new function in SharePointTools, Logging and configuration script

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration @{ Run = @{ Exit=$true }}"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e60df170832c845b5e4ebb061543