### PR TITLE
Add transcript option to additional SupportTools functions

### DIFF
--- a/src/SupportTools/Public/Get-CommonSystemInfo.ps1
+++ b/src/SupportTools/Public/Get-CommonSystemInfo.ps1
@@ -13,10 +13,14 @@ function Get-CommonSystemInfo {
         [Parameter(Mandatory = $false)]
         [object]$TelemetryClient,
         [Parameter(Mandatory = $false)]
-        [object]$Config
+        [object]$Config,
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TranscriptPath
     )
 
     process {
+        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
         $sw = [System.Diagnostics.Stopwatch]::StartNew()
         $result = 'Success'
         try {
@@ -68,6 +72,7 @@ function Get-CommonSystemInfo {
             $result = 'Failure'
             return New-STErrorObject -Message $_.Exception.Message -Category 'WMI'
         } finally {
+            if ($TranscriptPath) { Stop-Transcript | Out-Null }
             $sw.Stop()
             Send-STMetric -MetricName 'Get-CommonSystemInfo' -Category 'Audit' -Value $sw.Elapsed.TotalSeconds -Details @{ Result = $result }
         }

--- a/src/SupportTools/Public/Invoke-RemoteAudit.ps1
+++ b/src/SupportTools/Public/Invoke-RemoteAudit.ps1
@@ -25,8 +25,14 @@ function Invoke-RemoteAudit {
         [Parameter()]
         [System.Management.Automation.PSCredential]$Credential,
         [switch]$UseSSL,
-        [int]$Port = 5985
+        [int]$Port = 5985,
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TranscriptPath
     )
+    begin {
+        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+    }
     process {
         foreach ($comp in $ComputerName) {
             $invokeParams = @{ ComputerName = $comp }
@@ -48,5 +54,8 @@ function Invoke-RemoteAudit {
                 }
             }
         }
+    }
+    end {
+        if ($TranscriptPath) { Stop-Transcript | Out-Null }
     }
 }

--- a/src/SupportTools/Public/Sync-SupportTools.ps1
+++ b/src/SupportTools/Public/Sync-SupportTools.ps1
@@ -25,7 +25,10 @@ function Sync-SupportTools {
         [Parameter(Mandatory = $false)]
         [object]$TelemetryClient,
         [Parameter(Mandatory = $false)]
-        [object]$Config
+        [object]$Config,
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TranscriptPath
     )
 
     try {
@@ -48,6 +51,7 @@ function Sync-SupportTools {
             return
         }
 
+        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
         $sw = [System.Diagnostics.Stopwatch]::StartNew()
         $result = 'Success'
         if (Test-Path (Join-Path $InstallPath '.git')) {
@@ -70,6 +74,7 @@ function Sync-SupportTools {
         $result = 'Failure'
         return New-STErrorObject -Message $_.Exception.Message -Category 'General'
     } finally {
+        if ($TranscriptPath) { Stop-Transcript | Out-Null }
         $sw.Stop()
         Send-STMetric -MetricName 'Sync-SupportTools' -Category 'Deployment' -Value $sw.Elapsed.TotalSeconds -Details @{ Result = $result }
     }


### PR DESCRIPTION
## Summary
- add `-TranscriptPath` parameter to `Get-CommonSystemInfo`
- add transcript begin/end handling in `Invoke-RemoteAudit`
- add transcript parameter to `Sync-SupportTools`

## Testing
- `Invoke-Pester -Configuration $cfg`

------
https://chatgpt.com/codex/tasks/task_e_6845e61affd4832cb375345d132ddd27