### PR TITLE
Refactor logging paths

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -27,7 +27,7 @@ jobs:
           if ($outdated) {
             $outdated | Format-Table Name, Version, LatestVersion
           } else {
-            Write-Host 'All modules are up to date.'
+            Write-Information 'All modules are up to date.'
           }
 
       - name: Lint with PSScriptAnalyzer

--- a/SupportToolsLoader.ps1
+++ b/SupportToolsLoader.ps1
@@ -21,7 +21,7 @@ if (-not $script:SupportToolsLoaderLoaded) {
         if (Get-Command Write-STStatus -ErrorAction SilentlyContinue) {
             Write-STStatus -Message $Message -Level SUB -Log
         } else {
-            Write-Host $Message
+            Write-STLog -Message $Message -Level INFO
         }
     }
 

--- a/build.ps1
+++ b/build.ps1
@@ -3,6 +3,7 @@ Param(
 )
 $ErrorActionPreference = 'Stop'
 $root = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $root 'SupportToolsLoader.ps1')
 if (-not $Version) {
     $Version = (Import-PowerShellDataFile (Join-Path $root 'src/SupportTools/SupportTools.psd1')).ModuleVersion
 }
@@ -20,5 +21,5 @@ if (-not $nuget) {
     }
 }
 & $nuget pack (Join-Path $root 'SupportTools.nuspec') -Version $Version -OutputDirectory $packageDir
-Write-Host "Package created in $packageDir"
+Write-STLog -Message "Package created in $packageDir" -Level INFO
 

--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -38,7 +38,7 @@ function Write-STDebug {
         [string]$Message
     )
     if ($env:ST_DEBUG -eq '1') {
-        Write-Host "[DEBUG] $Message" -ForegroundColor DarkGray
+        Write-STStatus "[DEBUG] $Message" -Level SUB
     }
 }
 
@@ -57,7 +57,7 @@ function Test-IsElevated {
 Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','Write-STDebug','Test-IsElevated'
 
 function Show-STCoreBanner {
-    Write-Host 'STCore module loaded' -ForegroundColor DarkGray
+    Write-STStatus 'STCore module loaded' -Level SUB
 }
 
 Show-STCoreBanner


### PR DESCRIPTION
## Summary
- ensure modules load SupportTools logging for builds
- route STCore messages through Write-STStatus
- pipe SupportToolsLoader messages to Write-STLog when logging not loaded
- record maint task results via Write-Information
- include module info in Write-STLog entries

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)` *(fails: Logging module not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6845e60173fc832c99bca00910421503