### PR TITLE
Add transcript option to long-running commands

### DIFF
--- a/src/SupportTools/Public/Search-ReadMe.ps1
+++ b/src/SupportTools/Public/Search-ReadMe.ps1
@@ -7,10 +7,19 @@ function Search-ReadMe {
         the name and returns the file objects found.
     #>
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TranscriptPath
+    )
 
-    Write-STStatus 'Searching for readme files...' -Level INFO
-    $results = Get-ChildItem -Path C:\*readme*.txt -Recurse -File -ErrorAction SilentlyContinue
-    Write-STStatus "Found $($results.Count) file(s)." -Level SUCCESS
-    return $results
+    if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+    try {
+        Write-STStatus 'Searching for readme files...' -Level INFO
+        $results = Get-ChildItem -Path C:\*readme*.txt -Recurse -File -ErrorAction SilentlyContinue
+        Write-STStatus "Found $($results.Count) file(s)." -Level SUCCESS
+        return $results
+    } finally {
+        if ($TranscriptPath) { Stop-Transcript | Out-Null }
+    }
 }

--- a/src/SupportTools/Public/Sync-SupportTools.ps1
+++ b/src/SupportTools/Public/Sync-SupportTools.ps1
@@ -19,6 +19,9 @@ function Sync-SupportTools {
         [ValidateNotNullOrEmpty()]
         [string]$InstallPath = $(if ($env:USERPROFILE) { Join-Path $env:USERPROFILE 'SupportTools' } else { Join-Path $env:HOME 'SupportTools' }),
         [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TranscriptPath,
+        [Parameter(Mandatory = $false)]
         [switch]$Explain,
         [Parameter(Mandatory = $false)]
         [object]$Logger,
@@ -48,6 +51,8 @@ function Sync-SupportTools {
             return
         }
 
+        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+
         $sw = [System.Diagnostics.Stopwatch]::StartNew()
         $result = 'Success'
         if (Test-Path (Join-Path $InstallPath '.git')) {
@@ -70,6 +75,7 @@ function Sync-SupportTools {
         $result = 'Failure'
         return New-STErrorObject -Message $_.Exception.Message -Category 'General'
     } finally {
+        if ($TranscriptPath) { Stop-Transcript | Out-Null }
         $sw.Stop()
         Send-STMetric -MetricName 'Sync-SupportTools' -Category 'Deployment' -Value $sw.Elapsed.TotalSeconds -Details @{ Result = $result }
     }

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -57,6 +57,36 @@ Describe 'SupportTools Module' {
                 Assert-MockCalled git -ModuleName SupportTools -Times 1 -ParameterFilter { $args[0] -eq '-C' -and $args[2] -eq 'pull' }
             }
         }
+
+        It 'records transcript when path provided' {
+            InModuleScope SupportTools {
+                function git {}
+                function Import-Module {}
+                function Start-Transcript {}
+                function Stop-Transcript {}
+                Mock git {} -ModuleName SupportTools
+                Mock Import-Module {} -ModuleName SupportTools
+                Mock Start-Transcript {} -ModuleName SupportTools
+                Mock Stop-Transcript {} -ModuleName SupportTools
+                $path = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid())
+                Sync-SupportTools -RepositoryUrl 'url' -InstallPath $path -TranscriptPath 't.log'
+                Assert-MockCalled Start-Transcript -ModuleName SupportTools -Times 1 -ParameterFilter { $Path -eq 't.log' -and $Append }
+                Assert-MockCalled Stop-Transcript -ModuleName SupportTools -Times 1
+            }
+        }
     }
 
+    Context 'Search-ReadMe transcript' {
+        It 'starts and stops transcript when path is given' {
+            InModuleScope SupportTools {
+                function Start-Transcript {}
+                function Stop-Transcript {}
+                Mock Start-Transcript {} -ModuleName SupportTools
+                Mock Stop-Transcript {} -ModuleName SupportTools
+                Search-ReadMe -TranscriptPath 'log.txt' | Out-Null
+                Assert-MockCalled Start-Transcript -ModuleName SupportTools -Times 1 -ParameterFilter { $Path -eq 'log.txt' -and $Append }
+                Assert-MockCalled Stop-Transcript -ModuleName SupportTools -Times 1
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- allow passing `-TranscriptPath` to `Search-ReadMe`
- add transcript support to `Sync-SupportTools`
- test transcript behavior for both commands

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Configuration ./PesterConfiguration.psd1"` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845f04c07c4832cab94f24730a85fc1