### PR TITLE
Add MonitoringTools module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+powershell-*.tar.gz
+TestResults.xml
+coverage.xml

--- a/src/MonitoringTools/MonitoringTools.psd1
+++ b/src/MonitoringTools/MonitoringTools.psd1
@@ -1,0 +1,10 @@
+@{
+    RootModule = 'MonitoringTools.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000110'
+    Author = 'Contoso'
+    Description = 'Commands for collecting system monitoring data.'
+    RequiredModules = @('Logging','Telemetry')
+    PrivateData = @{ PSData = @{ Tags = @('PowerShell','Monitoring','Internal') } }
+    FunctionsToExport = @('Get-CPUUsage','Get-DiskSpaceInfo','Get-EventLogSummary','Get-SystemHealth')
+}

--- a/src/MonitoringTools/MonitoringTools.psm1
+++ b/src/MonitoringTools/MonitoringTools.psm1
@@ -1,0 +1,23 @@
+$PublicDir = Join-Path $PSScriptRoot 'Public'
+$loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+$telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
+Import-Module $loggingModule -ErrorAction SilentlyContinue
+Import-Module $telemetryModule -ErrorAction SilentlyContinue
+
+Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
+
+Export-ModuleMember -Function 'Get-CPUUsage','Get-DiskSpaceInfo','Get-EventLogSummary','Get-SystemHealth'
+
+function Show-MonitoringToolsBanner {
+    <#
+    .SYNOPSIS
+        Displays the MonitoringTools module banner.
+    #>
+    [CmdletBinding()]
+    param()
+    Write-STDivider 'MONITORINGTOOLS MODULE LOADED' -Style heavy
+    Write-STStatus "Run 'Get-Command -Module MonitoringTools' to view available tools." -Level SUB
+    Write-STLog -Message 'MonitoringTools module loaded'
+}
+
+Show-MonitoringToolsBanner

--- a/src/MonitoringTools/Public/Get-CPUUsage.ps1
+++ b/src/MonitoringTools/Public/Get-CPUUsage.ps1
@@ -1,0 +1,18 @@
+function Get-CPUUsage {
+    <#
+    .SYNOPSIS
+        Gets the current CPU utilisation percentage.
+    .DESCRIPTION
+        Uses Get-Counter when available to calculate average CPU usage.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if (Get-Command Get-Counter -ErrorAction SilentlyContinue) {
+        $samples = Get-Counter '\\Processor(_Total)\\% Processor Time' -SampleInterval 1 -MaxSamples 3
+        return [math]::Round(($samples.CounterSamples | Measure-Object -Property CookedValue -Average).Average,2)
+    } else {
+        Write-Warning 'Get-Counter not available.'
+        return $null
+    }
+}

--- a/src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1
+++ b/src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1
@@ -1,0 +1,31 @@
+function Get-DiskSpaceInfo {
+    <#
+    .SYNOPSIS
+        Retrieves disk usage information.
+    .DESCRIPTION
+        Returns drive size and free space for fixed disks.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if ($IsWindows) {
+        $disks = Get-CimInstance -ClassName Win32_LogicalDisk -Filter "DriveType = 3"
+        foreach ($d in $disks) {
+            [pscustomobject]@{
+                Drive       = $d.DeviceID
+                SizeGB      = [math]::Round($d.Size / 1GB,2)
+                FreeGB      = [math]::Round($d.FreeSpace / 1GB,2)
+                FreePercent = if ($d.Size -gt 0) { [math]::Round(($d.FreeSpace/$d.Size)*100,2) } else { 0 }
+            }
+        }
+    } else {
+        Get-PSDrive -PSProvider FileSystem | Where-Object { $_.Free -ne $null } | ForEach-Object {
+            [pscustomobject]@{
+                Drive       = $_.Root
+                SizeGB      = [math]::Round($_.Used/1GB + $_.Free/1GB,2)
+                FreeGB      = [math]::Round($_.Free/1GB,2)
+                FreePercent = if ($_.Used + $_.Free -gt 0) { [math]::Round(($_.Free/($_.Used+$_.Free))*100,2) } else { 0 }
+            }
+        }
+    }
+}

--- a/src/MonitoringTools/Public/Get-EventLogSummary.ps1
+++ b/src/MonitoringTools/Public/Get-EventLogSummary.ps1
@@ -1,0 +1,30 @@
+function Get-EventLogSummary {
+    <#
+    .SYNOPSIS
+        Summarises recent event log activity.
+    .DESCRIPTION
+        Returns counts of Error and Warning events from the specified log within the last N hours.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$LogName = 'System',
+        [int]$LastHours = 24
+    )
+
+    if (Get-Command Get-WinEvent -ErrorAction SilentlyContinue) {
+        $events = Get-WinEvent -FilterHashtable @{ LogName = $LogName; StartTime = (Get-Date).AddHours(-$LastHours) }
+        $events |
+            Where-Object { $_.LevelDisplayName -in @('Error','Warning') } |
+            Group-Object LevelDisplayName |
+            Select-Object Name, Count
+    } elseif (Get-Command Get-EventLog -ErrorAction SilentlyContinue) {
+        $events = Get-EventLog -LogName $LogName -After (Get-Date).AddHours(-$LastHours)
+        $events |
+            Where-Object { $_.EntryType -in 'Error','Warning' } |
+            Group-Object EntryType |
+            Select-Object Name, Count
+    } else {
+        Write-Warning 'Event log cmdlets are not available.'
+        @()
+    }
+}

--- a/src/MonitoringTools/Public/Get-SystemHealth.ps1
+++ b/src/MonitoringTools/Public/Get-SystemHealth.ps1
@@ -1,0 +1,20 @@
+function Get-SystemHealth {
+    <#
+    .SYNOPSIS
+        Provides an overview of system health.
+    .DESCRIPTION
+        Returns CPU usage, disk free space and recent event log summary.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $cpu = Get-CPUUsage
+    $disks = Get-DiskSpaceInfo
+    $events = Get-EventLogSummary
+
+    [pscustomobject]@{
+        CpuPercent      = $cpu
+        DiskInfo        = $disks
+        EventLogSummary = $events
+    }
+}

--- a/tests/MonitoringTools.Tests.ps1
+++ b/tests/MonitoringTools.Tests.ps1
@@ -1,0 +1,24 @@
+Describe 'MonitoringTools Module' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../src/MonitoringTools/MonitoringTools.psd1 -Force
+    }
+
+    It 'exports Get-CPUUsage' {
+        (Get-Command -Module MonitoringTools).Name | Should -Contain 'Get-CPUUsage'
+    }
+
+    It 'exports Get-SystemHealth' {
+        (Get-Command -Module MonitoringTools).Name | Should -Contain 'Get-SystemHealth'
+    }
+
+    It 'returns system health object' {
+        Mock Get-CPUUsage { 10 } -ModuleName MonitoringTools
+        Mock Get-DiskSpaceInfo { @() } -ModuleName MonitoringTools
+        Mock Get-EventLogSummary { @() } -ModuleName MonitoringTools
+        $result = Get-SystemHealth
+        $result.CpuPercent | Should -Be 10
+        $result.DiskInfo   | Should -Be @()
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a new MonitoringTools module
- add functions for disk, CPU, event logs and system health
- export these functions via MonitoringTools.psd1/psm1
- cover new module with basic Pester tests
- ignore PowerShell tarball and generated test artifacts

## Testing
- `Invoke-Pester -Configuration PesterConfiguration.psd1` *(fails: required module 'Logging' is not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6845f0a08144832c81c136fb2ae937e4