### PR TITLE
Add Search-Indicators cmdlet

### DIFF
--- a/docs/IncidentResponseTools.md
+++ b/docs/IncidentResponseTools.md
@@ -18,3 +18,4 @@ Import-Module ./src/IncidentResponseTools/IncidentResponseTools.psd1
 | `Invoke-FullSystemAudit` | Execute common audit scripts and summarize. | `Invoke-FullSystemAudit` |
 | `Submit-SystemInfoTicket` | Upload system info and create a ticket. | `Submit-SystemInfoTicket -SiteName IT -RequesterEmail user@contoso.com` |
 | `Update-Sysmon` | Update the Sysmon installation. | `Update-Sysmon -SourcePath D:\Tools` |
+| `Search-Indicators` | Find indicators in logs, registry and files. | `Search-Indicators -IndicatorList .\indicators.csv` |

--- a/docs/IncidentResponseTools/Search-Indicators.md
+++ b/docs/IncidentResponseTools/Search-Indicators.md
@@ -1,0 +1,85 @@
+---
+external help file: SupportTools-help.xml
+Module Name: IncidentResponseTools
+online version:
+schema: 2.0.0
+---
+
+# Search-Indicators
+
+## SYNOPSIS
+Search event logs, registry and file system for suspicious indicators.
+
+## SYNTAX
+```
+Search-Indicators -IndicatorList <String> [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Calls the `Search-Indicators.ps1` script with the supplied indicator list. The CSV file should contain an `Indicator` column listing values to search for such as IP addresses, domains or file hashes.
+
+## EXAMPLES
+### Example 1
+```powershell
+PS C:\> Search-Indicators -IndicatorList .\indicators.csv
+```
+
+Search multiple sources for indicators listed in `indicators.csv`.
+
+## PARAMETERS
+### -IndicatorList
+Path to a CSV file with an `Indicator` column.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TranscriptPath
+File path used to capture a transcript of this command's output and actions.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+Specifies how progress is displayed.
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+## OUTPUTS
+### System.Object
+Custom objects summarizing match counts for each indicator.
+
+## NOTES
+## RELATED LINKS

--- a/scripts/Search-Indicators.ps1
+++ b/scripts/Search-Indicators.ps1
@@ -1,0 +1,44 @@
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$IndicatorList
+)
+
+function Search-Indicators {
+    <#
+    .SYNOPSIS
+        Search event logs, registry and file system for suspicious indicators.
+    .DESCRIPTION
+        Reads a CSV file containing indicators and scans common forensic sources
+        for occurrences. The CSV must contain an 'Indicator' column listing
+        strings such as IPs, domains or hashes.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)][string]$IndicatorList
+    )
+
+    if (-not (Test-Path $IndicatorList)) { throw "Indicator list '$IndicatorList' not found." }
+    Write-STStatus "Loading indicators from $IndicatorList" -Level INFO
+    $indicators = Import-Csv -Path $IndicatorList | Select-Object -ExpandProperty Indicator
+    $results = foreach ($ind in $indicators) {
+        Write-STStatus "Searching for '$ind'" -Level SUB
+        $eventHits = Get-WinEvent -LogName Security,Application,System -ErrorAction SilentlyContinue |
+            Where-Object { $_.Message -match [regex]::Escape($ind) }
+        $regHits = Get-ChildItem -Path HKLM:\,HKCU:\ -Recurse -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match [regex]::Escape($ind) }
+        $fileHits = Get-ChildItem -Path C:\ -Recurse -ErrorAction SilentlyContinue -Force |
+            Where-Object { $_.FullName -match [regex]::Escape($ind) }
+        [pscustomobject]@{
+            Indicator      = $ind
+            EventMatches   = $eventHits.Count
+            RegistryMatches= $regHits.Count
+            FileMatches    = $fileHits.Count
+        }
+    }
+    Write-STStatus 'Search complete.' -Level SUCCESS
+    return $results
+}
+
+Search-Indicators -IndicatorList $IndicatorList

--- a/src/IncidentResponseTools/IncidentResponseTools.psd1
+++ b/src/IncidentResponseTools/IncidentResponseTools.psd1
@@ -14,6 +14,7 @@
         'Invoke-RemoteAudit',
         'Invoke-FullSystemAudit',
         'Submit-SystemInfoTicket',
-        'Update-Sysmon'
+        'Update-Sysmon',
+        'Search-Indicators'
     )
 }

--- a/src/IncidentResponseTools/IncidentResponseTools.psm1
+++ b/src/IncidentResponseTools/IncidentResponseTools.psm1
@@ -10,7 +10,7 @@ Import-Module $telemetryModule -ErrorAction SilentlyContinue
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Invoke-IncidentResponse','Invoke-RemoteAudit','Invoke-FullSystemAudit','Submit-SystemInfoTicket','Update-Sysmon'
+Export-ModuleMember -Function 'Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Invoke-IncidentResponse','Invoke-RemoteAudit','Invoke-FullSystemAudit','Submit-SystemInfoTicket','Update-Sysmon','Search-Indicators'
 
 function Show-IncidentResponseToolsBanner {
     Write-STDivider 'INCIDENTRESPONSETOOLS MODULE LOADED' -Style heavy

--- a/src/IncidentResponseTools/Public/Search-Indicators.ps1
+++ b/src/IncidentResponseTools/Public/Search-Indicators.ps1
@@ -1,0 +1,31 @@
+function Search-Indicators {
+    <#
+    .SYNOPSIS
+        Search event logs, registry and file system for suspicious indicators.
+    .DESCRIPTION
+        Calls the Search-Indicators.ps1 script with the supplied indicator list.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$IndicatorList,
+        [Parameter(Mandatory=$false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TranscriptPath,
+        [Parameter(Mandatory=$false)]
+        [switch]$Simulate,
+        [Parameter(Mandatory=$false)]
+        [switch]$Explain,
+        [Parameter(Mandatory=$false)]
+        [object]$Logger,
+        [Parameter(Mandatory=$false)]
+        [object]$TelemetryClient,
+        [Parameter(Mandatory=$false)]
+        [object]$Config
+    )
+    process {
+        $arguments = @('-IndicatorList', $IndicatorList)
+        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Search-Indicators.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+    }
+}

--- a/tests/IncidentResponseTools.Tests.ps1
+++ b/tests/IncidentResponseTools.Tests.ps1
@@ -12,4 +12,8 @@ Describe 'IncidentResponseTools Module' {
     It 'exports Invoke-RemoteAudit' {
         (Get-Command -Module IncidentResponseTools).Name | Should -Contain 'Invoke-RemoteAudit'
     }
+
+    It 'exports Search-Indicators' {
+        (Get-Command -Module IncidentResponseTools).Name | Should -Contain 'Search-Indicators'
+    }
 }


### PR DESCRIPTION
## Summary
- search for suspicious indicators in events, registry, and file names
- expose Search-Indicators in IncidentResponseTools module
- document the new cmdlet
- update tests

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile './PesterConfiguration.psd1')` *(fails: required modules not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6845f330ef58832cbda685ac2c34b3cb