### PR TITLE
Add cross-cloud support for identity functions

### DIFF
--- a/scripts/CleanupGroupMembership.ps1
+++ b/scripts/CleanupGroupMembership.ps1
@@ -13,26 +13,46 @@ Import-SupportToolsLogging
 
 param(
     [Parameter(Mandatory)][string]$CsvPath,
-    [Parameter(Mandatory)][string]$GroupName
+    [Parameter(Mandatory)][string]$GroupName,
+    [ValidateSet('Entra','AD')][string]$Cloud = 'Entra'
 )
 
-Write-STStatus 'Connecting to Microsoft Graph...' -Level INFO
-Connect-MgGraph -Scopes "User.Read.All","Group.ReadWrite.All" -NoWelcome
+if ($Cloud -eq 'Entra') {
+    Write-STStatus 'Connecting to Microsoft Graph...' -Level INFO
+    Connect-MgGraph -Scopes "User.Read.All","Group.ReadWrite.All" -NoWelcome
 
-$group = Get-MgGroup -Filter "displayName eq '$GroupName'" | Select-Object -First 1
-if (-not $group) { throw "Group '$GroupName' not found." }
+    $group = Get-MgGroup -Filter "displayName eq '$GroupName'" | Select-Object -First 1
+    if (-not $group) { throw "Group '$GroupName' not found." }
 
-$users = Import-Csv $CsvPath
-foreach ($user in $users.UPN) {
-    $obj = Get-MgUser -UserId $user -ErrorAction SilentlyContinue
-    if (-not $obj) { Write-STStatus "User not found: $user" -Level WARN; continue }
-    try {
-        Remove-MgGroupMemberByRef -GroupId $group.Id -DirectoryObjectId $obj.Id -ErrorAction Stop
-        Write-STStatus "Removed $($obj.UserPrincipalName)" -Level SUCCESS
-    } catch {
-        Write-STStatus "Failed to remove $user: $_" -Level ERROR
+    $users = Import-Csv $CsvPath
+    foreach ($user in $users.UPN) {
+        $obj = Get-MgUser -UserId $user -ErrorAction SilentlyContinue
+        if (-not $obj) { Write-STStatus "User not found: $user" -Level WARN; continue }
+        try {
+            Remove-MgGroupMemberByRef -GroupId $group.Id -DirectoryObjectId $obj.Id -ErrorAction Stop
+            Write-STStatus "Removed $($obj.UserPrincipalName)" -Level SUCCESS
+        } catch {
+            Write-STStatus "Failed to remove $user: $_" -Level ERROR
+        }
+    }
+
+    Disconnect-MgGraph | Out-Null
+} else {
+    Import-Module ActiveDirectory -ErrorAction Stop
+    $group = Get-ADGroup -Identity $GroupName -ErrorAction Stop
+
+    $users = Import-Csv $CsvPath
+    foreach ($user in $users.UPN) {
+        $obj = Get-ADUser -Filter "UserPrincipalName -eq '$user'" -ErrorAction SilentlyContinue
+        if (-not $obj) { $obj = Get-ADUser -Identity $user -ErrorAction SilentlyContinue }
+        if (-not $obj) { Write-STStatus "User not found: $user" -Level WARN; continue }
+        try {
+            Remove-ADGroupMember -Identity $group.DistinguishedName -Members $obj.SamAccountName -Confirm:$false -ErrorAction Stop
+            Write-STStatus "Removed $($obj.UserPrincipalName)" -Level SUCCESS
+        } catch {
+            Write-STStatus "Failed to remove $user: $_" -Level ERROR
+        }
     }
 }
 
-Disconnect-MgGraph | Out-Null
 Write-STStatus 'Group membership cleanup finished.' -Level SUCCESS

--- a/src/ConfigManagementTools/Public/Add-UserToGroup.ps1
+++ b/src/ConfigManagementTools/Public/Add-UserToGroup.ps1
@@ -30,6 +30,9 @@ function Add-UserToGroup {
         [Parameter(Mandatory = $false)]
         [object]$TelemetryClient,
         [Parameter(Mandatory = $false)]
+        [ValidateSet('Entra','AD')]
+        [string]$Cloud = 'Entra',
+        [Parameter(Mandatory = $false)]
         [object]$Config
     )
 
@@ -42,6 +45,10 @@ function Add-UserToGroup {
         if ($PSBoundParameters.ContainsKey('GroupName')) {
             $arguments += '-GroupName'
             $arguments += $GroupName
+        }
+        if ($PSBoundParameters.ContainsKey('Cloud')) {
+            $arguments += '-Cloud'
+            $arguments += $Cloud
         }
 
         Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain

--- a/src/ConfigManagementTools/Public/Invoke-GroupMembershipCleanup.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-GroupMembershipCleanup.ps1
@@ -27,12 +27,16 @@ function Invoke-GroupMembershipCleanup {
         [Parameter(Mandatory = $false)]
         [object]$TelemetryClient,
         [Parameter(Mandatory = $false)]
+        [ValidateSet('Entra','AD')]
+        [string]$Cloud = 'Entra',
+        [Parameter(Mandatory = $false)]
         [object]$Config
     )
     process {
         $arguments = @()
         if ($PSBoundParameters.ContainsKey('CsvPath')) { $arguments += '-CsvPath'; $arguments += $CsvPath }
         if ($PSBoundParameters.ContainsKey('GroupName')) { $arguments += '-GroupName'; $arguments += $GroupName }
+        if ($PSBoundParameters.ContainsKey('Cloud')) { $arguments += '-Cloud'; $arguments += $Cloud }
         Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'CleanupGroupMembership.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Explain:$Explain
     }
 }

--- a/tests/AddUsersToGroup.Tests.ps1
+++ b/tests/AddUsersToGroup.Tests.ps1
@@ -6,6 +6,10 @@ Describe 'AddUsersToGroup Script' {
         function Disconnect-MgGraph {}
         function Get-MgContext {}
         function New-MgGroupMember {}
+        function Add-ADGroupMember {}
+        function Get-ADGroup {}
+        function Get-ADGroupMember {}
+        function Get-ADUser {}
         function Get-Group { param([string]$GroupName) }
         function Get-GroupExistingMembers { param($Group) }
         function Get-CSVFilePath {}
@@ -27,6 +31,10 @@ Describe 'AddUsersToGroup Script' {
         Mock Import-Csv { @([pscustomobject]@{ UPN='user1@contoso.com' }, [pscustomobject]@{ UPN='existing@contoso.com' }) }
         Mock Get-UserID { param($UserPrincipalName) [pscustomobject]@{ UserPrincipalName=$UserPrincipalName; DisplayName='User'; Id='id' } }
         Mock New-MgGroupMember {}
+        Mock Add-ADGroupMember {}
+        Mock Get-ADGroup {}
+        Mock Get-ADGroupMember {}
+        Mock Get-ADUser {}
     }
     It 'connects and disconnects from Graph' {
         Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' | Out-Null
@@ -40,5 +48,11 @@ Describe 'AddUsersToGroup Script' {
     It 'adds only missing users' {
         Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' | Out-Null
         Assert-MockCalled New-MgGroupMember -Times 1
+    }
+
+    It 'uses AD cmdlets when Cloud is AD' {
+        Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' -Cloud 'AD' | Out-Null
+        Assert-MockCalled Add-ADGroupMember -Times 1
+        Assert-MockCalled Connect-MgGraph -Times 0
     }
 }

--- a/tests/ConfigManagementTools/Add-UserToGroup.Tests.ps1
+++ b/tests/ConfigManagementTools/Add-UserToGroup.Tests.ps1
@@ -33,4 +33,14 @@ Describe 'Add-UserToGroup function' {
             }
         }
     }
+
+    It 'passes Cloud parameter' {
+        InModuleScope ConfigManagementTools {
+            Mock Invoke-ScriptFile {} -ModuleName ConfigManagementTools
+            Add-UserToGroup -CsvPath 'users.csv' -GroupName 'G1' -Cloud 'AD'
+            Assert-MockCalled Invoke-ScriptFile -ModuleName ConfigManagementTools -Times 1 -ParameterFilter {
+                $Arguments -contains '-Cloud' -and $Arguments -contains 'AD'
+            }
+        }
+    }
 }

--- a/tests/EntraIDTools.Tests.ps1
+++ b/tests/EntraIDTools.Tests.ps1
@@ -43,6 +43,20 @@ Describe 'EntraIDTools Module' {
         }
     }
 
+    Context 'Cloud parameter' {
+        It 'uses AD for user details when Cloud is AD' {
+            Mock Get-ADUser { @{ UserPrincipalName='u'; Name='User'; MemberOf=@(); LastLogonDate=(Get-Date) } } -ModuleName EntraIDTools
+            $res = Get-GraphUserDetails -UserPrincipalName 'u' -TenantId 'tid' -ClientId 'cid' -Cloud 'AD'
+            Assert-MockCalled Get-ADUser -ModuleName EntraIDTools -Times 1
+        }
+        It 'uses AD for group details when Cloud is AD' {
+            Mock Get-ADGroup { @{ Name='G'; Description='D' } } -ModuleName EntraIDTools
+            Mock Get-ADGroupMember { @{Name='User'} } -ModuleName EntraIDTools
+            $res = Get-GraphGroupDetails -GroupId 'gid' -TenantId 'tid' -ClientId 'cid' -Cloud 'AD'
+            Assert-MockCalled Get-ADGroup -ModuleName EntraIDTools -Times 1
+        }
+    }
+
     Context 'Environment variables' {
         It 'uses GRAPH_* variables when parameters missing' {
             $env:GRAPH_TENANT_ID = 'tidEnv'


### PR DESCRIPTION
## Summary
- extend Add-UserToGroup and Invoke-GroupMembershipCleanup with a `-Cloud` parameter
- update AddUsersToGroup.ps1 and CleanupGroupMembership.ps1 for AD routing
- update EntraIDTools cmdlets with `-Cloud` support
- add unit tests for AD execution paths

## Testing
- `Invoke-Pester -Output Detailed` *(fails: Logging module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f3509fcc832c8e5e5ceb84813b76