### PR TITLE
Add MaintenancePlan module

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository packages a collection of scripts into reusable modules.
 | PerformanceTools | Beta |
 | EntraIDTools | Stable |
 | ChaosTools | Beta |
+| MaintenancePlan | Beta |
 
 ## Requirements 📋
 
@@ -100,7 +101,7 @@ Get-GraphUserDetails -UserPrincipalName 'user@contoso.com' -TenantId <tenantId> 
 ```
 The command gathers basic profile information, assigned licenses, group membership and last sign-in time. Results can be exported to CSV or HTML for reporting.
 
-See [docs/SupportTools.md](docs/SupportTools.md), [docs/IncidentResponseTools.md](docs/IncidentResponseTools.md), [docs/ConfigManagementTools.md](docs/ConfigManagementTools.md), [docs/SharePointTools.md](docs/SharePointTools.md), [docs/ServiceDeskTools.md](docs/ServiceDeskTools.md), [docs/PerformanceTools.md](docs/PerformanceTools.md), [docs/EntraIDTools.md](docs/EntraIDTools.md) and [docs/ChaosTools.md](docs/ChaosTools.md) for a full list of commands. For a short introduction refer to [docs/Quickstart.md](docs/Quickstart.md). For detailed deployment guidance see [docs/UserGuide.md](docs/UserGuide.md).
+See [docs/SupportTools.md](docs/SupportTools.md), [docs/IncidentResponseTools.md](docs/IncidentResponseTools.md), [docs/ConfigManagementTools.md](docs/ConfigManagementTools.md), [docs/SharePointTools.md](docs/SharePointTools.md), [docs/ServiceDeskTools.md](docs/ServiceDeskTools.md), [docs/PerformanceTools.md](docs/PerformanceTools.md), [docs/EntraIDTools.md](docs/EntraIDTools.md), [docs/ChaosTools.md](docs/ChaosTools.md) and [docs/MaintenancePlan.md](docs/MaintenancePlan.md) for a full list of commands. For a short introduction refer to [docs/Quickstart.md](docs/Quickstart.md). For detailed deployment guidance see [docs/UserGuide.md](docs/UserGuide.md).
 
 The module also provides `Set-SharedMailboxAutoReply` for configuring automatic
 out-of-office replies on a shared mailbox.

--- a/docs/MaintenancePlan.md
+++ b/docs/MaintenancePlan.md
@@ -1,0 +1,18 @@
+# MaintenancePlan Module
+
+Import the module using its manifest:
+
+```powershell
+Import-Module ./src/MaintenancePlan/MaintenancePlan.psd1
+```
+
+## Available Commands
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `New-MaintenancePlan` | Create a maintenance plan object. | `New-MaintenancePlan -Name Weekly -Tasks 'Clear-TempFile' -Schedule '0 2 * * Sun'` |
+| `Export-MaintenancePlan` | Write a plan object to a JSON file. | `Export-MaintenancePlan -Plan $plan -Path plan.json` |
+| `Import-MaintenancePlan` | Load a plan from JSON. | `Import-MaintenancePlan -Path plan.json` |
+| `Invoke-MaintenancePlan` | Execute all tasks in a plan. | `Invoke-MaintenancePlan -Plan $plan` |
+
+Use maintenance plans to group recurring tasks and store them as JSON files for sharing.

--- a/src/MaintenancePlan/MaintenancePlan.psd1
+++ b/src/MaintenancePlan/MaintenancePlan.psd1
@@ -1,0 +1,8 @@
+@{
+    RootModule = 'MaintenancePlan.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000050'
+    Author = 'Contoso'
+    Description = 'Manage scheduled maintenance plans.'
+    FunctionsToExport = @('New-MaintenancePlan','Export-MaintenancePlan','Import-MaintenancePlan','Invoke-MaintenancePlan')
+}

--- a/src/MaintenancePlan/MaintenancePlan.psm1
+++ b/src/MaintenancePlan/MaintenancePlan.psm1
@@ -1,0 +1,76 @@
+$coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
+Import-Module $coreModule -ErrorAction SilentlyContinue
+$loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+Import-Module $loggingModule -ErrorAction SilentlyContinue
+
+function New-MaintenancePlan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string[]]$Tasks,
+        [string]$Schedule = '0 3 * * Sun'
+    )
+    Assert-ParameterNotNull $Name 'Name'
+    Assert-ParameterNotNull $Tasks 'Tasks'
+    [pscustomobject]@{
+        Name     = $Name
+        Tasks    = $Tasks
+        Schedule = $Schedule
+    }
+}
+
+function Export-MaintenancePlan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]$Plan,
+        [Parameter(Mandatory)][string]$Path
+    )
+    Assert-ParameterNotNull $Plan 'Plan'
+    Assert-ParameterNotNull $Path 'Path'
+    $json = $Plan | ConvertTo-Json -Depth 5
+    $dir = Split-Path -Path $Path -Parent
+    if ($dir -and -not (Test-Path $dir)) {
+        New-Item -Path $dir -ItemType Directory -Force | Out-Null
+    }
+    Set-Content -Path $Path -Value $json -Encoding UTF8
+}
+
+function Import-MaintenancePlan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+    Assert-ParameterNotNull $Path 'Path'
+    if (-not (Test-Path $Path)) { throw "Plan file not found: $Path" }
+    Get-Content -Path $Path -Raw | ConvertFrom-Json
+}
+
+function Invoke-MaintenancePlan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]$Plan
+    )
+    foreach ($task in $Plan.Tasks) {
+        if (Test-Path $task) {
+            Write-STStatus "Running script $task" -Level INFO -Log
+            & $task
+        } elseif (Get-Command $task -ErrorAction SilentlyContinue) {
+            Write-STStatus "Invoking command $task" -Level INFO -Log
+            & $task
+        } else {
+            Write-STStatus "Task $task not found" -Level ERROR -Log
+        }
+    }
+}
+
+Export-ModuleMember -Function 'New-MaintenancePlan','Export-MaintenancePlan','Import-MaintenancePlan','Invoke-MaintenancePlan'
+
+function Show-MaintenancePlanBanner {
+    [CmdletBinding()]
+    param()
+    Write-STDivider 'MAINTENANCEPLAN MODULE LOADED' -Style heavy
+    Write-STStatus "Run 'Get-Command -Module MaintenancePlan' to view available tools." -Level SUB
+    Write-STLog -Message 'MaintenancePlan module loaded'
+}
+
+Show-MaintenancePlanBanner

--- a/tests/MaintenancePlan.Tests.ps1
+++ b/tests/MaintenancePlan.Tests.ps1
@@ -1,0 +1,32 @@
+Describe 'MaintenancePlan Module' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../src/MaintenancePlan/MaintenancePlan.psd1 -Force
+    }
+
+    It 'exports New-MaintenancePlan' {
+        (Get-Command -Module MaintenancePlan).Name | Should -Contain 'New-MaintenancePlan'
+    }
+
+    It 'exports Export-MaintenancePlan' {
+        (Get-Command -Module MaintenancePlan).Name | Should -Contain 'Export-MaintenancePlan'
+    }
+
+    It 'exports Import-MaintenancePlan' {
+        (Get-Command -Module MaintenancePlan).Name | Should -Contain 'Import-MaintenancePlan'
+    }
+
+    It 'round trips a plan to JSON' {
+        $plan = New-MaintenancePlan -Name 'Test' -Tasks 'Write-Host' -Schedule 'Daily'
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            Export-MaintenancePlan -Plan $plan -Path $temp
+            $loaded = Import-MaintenancePlan -Path $temp
+            $loaded.Name | Should -Be 'Test'
+            $loaded.Tasks[0] | Should -Be 'Write-Host'
+            $loaded.Schedule | Should -Be 'Daily'
+        } finally {
+            Remove-Item $temp -ErrorAction SilentlyContinue
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement a MaintenancePlan module for creating and persisting plans
- document the module and reference it in the README
- add basic Pester tests for MaintenancePlan

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)` *(fails: The required module 'Logging' is not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6845f31f39f4832ca3da92df92086494