### PR TITLE
Implement MaintenancePlan module

### DIFF
--- a/SupportTools.nuspec
+++ b/SupportTools.nuspec
@@ -30,6 +30,7 @@
     <file src="src\PerformanceTools\**\*" target="tools\PerformanceTools" />
     <file src="src\IncidentResponseTools\**\*" target="tools\IncidentResponseTools" />
     <file src="src\ConfigManagementTools\**\*" target="tools\ConfigManagementTools" />
+    <file src="src\MaintenancePlan\**\*" target="tools\MaintenancePlan" />
     <file src="tests\**\*" target="tests" />
   </files>
 </package>

--- a/docs/MaintenancePlan.md
+++ b/docs/MaintenancePlan.md
@@ -1,0 +1,16 @@
+# MaintenancePlan Module
+
+Import the module using its manifest:
+
+```powershell
+Import-Module ./src/MaintenancePlan/MaintenancePlan.psd1
+```
+
+## Available Commands
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `New-MaintenancePlan` | Create a maintenance plan object. | `New-MaintenancePlan -Name Weekly -Steps @('Cleanup.ps1','Backup-DB')` |
+| `Export-MaintenancePlan` | Save a plan to a JSON file. | `$plan | Export-MaintenancePlan -Path plan.json` |
+| `Import-MaintenancePlan` | Load a plan from JSON. | `Import-MaintenancePlan -Path plan.json` |
+| `Invoke-MaintenancePlan` | Execute plan steps. | `Invoke-MaintenancePlan -Plan $plan` |

--- a/src/MaintenancePlan/MaintenancePlan.psd1
+++ b/src/MaintenancePlan/MaintenancePlan.psd1
@@ -1,0 +1,10 @@
+@{
+    RootModule = 'MaintenancePlan.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000015'
+    Author = 'Contoso'
+    Description = 'Create and manage maintenance plans.'
+    RequiredModules = @('Logging')
+    PrivateData = @{ PSData = @{ Tags = @('PowerShell','Maintenance','Internal') } }
+    FunctionsToExport = @('New-MaintenancePlan','Export-MaintenancePlan','Import-MaintenancePlan','Invoke-MaintenancePlan')
+}

--- a/src/MaintenancePlan/MaintenancePlan.psm1
+++ b/src/MaintenancePlan/MaintenancePlan.psm1
@@ -1,0 +1,16 @@
+$PublicDir = Join-Path $PSScriptRoot 'Public'
+$coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
+$loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+Import-Module $coreModule -ErrorAction SilentlyContinue
+Import-Module $loggingModule -ErrorAction SilentlyContinue
+Get-ChildItem -Path "$PublicDir" -Filter *.ps1 -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
+
+Export-ModuleMember -Function (Get-ChildItem "$PublicDir/*.ps1" -ErrorAction SilentlyContinue).BaseName
+
+function Show-MaintenancePlanBanner {
+    Write-STDivider 'MAINTENANCEPLAN MODULE LOADED' -Style heavy
+    Write-STStatus "Run 'Get-Command -Module MaintenancePlan' to view available tools." -Level SUB
+    Write-STLog -Message 'MaintenancePlan module loaded'
+}
+
+Show-MaintenancePlanBanner

--- a/src/MaintenancePlan/Public/Export-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/Export-MaintenancePlan.ps1
@@ -1,0 +1,20 @@
+function Export-MaintenancePlan {
+    <#
+    .SYNOPSIS
+        Export a maintenance plan to JSON.
+    .PARAMETER Plan
+        Plan object created by New-MaintenancePlan.
+    .PARAMETER Path
+        Destination path for the JSON file.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,ValueFromPipeline)]
+        [object]$Plan,
+        [Parameter(Mandatory)][string]$Path
+    )
+    process {
+        $Plan | ConvertTo-Json -Depth 5 | Set-Content -Path $Path
+        Write-STStatus "Plan exported to $Path" -Level SUCCESS -Log
+    }
+}

--- a/src/MaintenancePlan/Public/Import-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/Import-MaintenancePlan.ps1
@@ -1,0 +1,15 @@
+function Import-MaintenancePlan {
+    <#
+    .SYNOPSIS
+        Import a maintenance plan from JSON.
+    .PARAMETER Path
+        Path to the JSON file.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+    Assert-ParameterNotNull $Path 'Path'
+    if (-not (Test-Path $Path)) { throw "File not found: $Path" }
+    Get-Content $Path -Raw | ConvertFrom-Json
+}

--- a/src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1
@@ -1,0 +1,26 @@
+function Invoke-MaintenancePlan {
+    <#
+    .SYNOPSIS
+        Execute all steps in a maintenance plan.
+    .PARAMETER Plan
+        Plan object created by New-MaintenancePlan or Import-MaintenancePlan.
+    .PARAMETER WhatIf
+        Display commands without executing.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Plan,
+        [switch]$WhatIf
+    )
+    Assert-ParameterNotNull $Plan 'Plan'
+    foreach ($step in $Plan.Steps) {
+        Write-STStatus "Running $step" -Level INFO -Log
+        if (-not $WhatIf) {
+            if (Test-Path $step) {
+                & $step
+            } else {
+                Invoke-Expression $step
+            }
+        }
+    }
+}

--- a/src/MaintenancePlan/Public/New-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/New-MaintenancePlan.ps1
@@ -1,0 +1,27 @@
+function New-MaintenancePlan {
+    <#
+    .SYNOPSIS
+        Create a new maintenance plan object.
+    .DESCRIPTION
+        Returns an object describing the plan which can be exported to JSON.
+    .PARAMETER Name
+        Name of the maintenance plan.
+    .PARAMETER Steps
+        Array of function calls or script paths to execute.
+    .PARAMETER Schedule
+        Optional description of the schedule.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][object[]]$Steps,
+        [string]$Schedule
+    )
+    Assert-ParameterNotNull $Name 'Name'
+    Assert-ParameterNotNull $Steps 'Steps'
+    [pscustomobject]@{
+        Name = $Name
+        Steps = $Steps
+        Schedule = $Schedule
+    }
+}

--- a/tests/MaintenancePlan.Tests.ps1
+++ b/tests/MaintenancePlan.Tests.ps1
@@ -1,0 +1,36 @@
+Describe 'MaintenancePlan Module' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../src/MaintenancePlan/MaintenancePlan.psd1 -Force
+    }
+
+    It 'exports New-MaintenancePlan' {
+        (Get-Command -Module MaintenancePlan).Name | Should -Contain 'New-MaintenancePlan'
+    }
+
+    It 'creates and persists a plan' {
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            $plan = New-MaintenancePlan -Name Test -Steps @('Write-Host "hi"')
+            $plan | Export-MaintenancePlan -Path $temp
+            $imported = Import-MaintenancePlan -Path $temp
+            $imported.Name | Should -Be 'Test'
+            $imported.Steps[0] | Should -Be 'Write-Host "hi"'
+        } finally {
+            Remove-Item $temp -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'executes script steps' {
+        $scriptPath = Join-Path ([IO.Path]::GetTempPath()) 'step.ps1'
+        Set-Content $scriptPath '$script:ran = $true'
+        try {
+            $plan = New-MaintenancePlan -Name Demo -Steps @($scriptPath)
+            $script:ran = $false
+            Invoke-MaintenancePlan -Plan $plan
+            $script:ran | Should -Be $true
+        } finally {
+            Remove-Item $scriptPath -ErrorAction SilentlyContinue
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new MaintenancePlan module for creating and executing plans
- document usage of the module
- include new tests
- package module in nuspec

## Testing
- `./pwsh/pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration ./PesterConfiguration.psd1"` *(fails: Cannot process argument transformation on parameter 'Configuration')*

------
https://chatgpt.com/codex/tasks/task_e_6845f5f41fac832c9455d757fad345f1