### PR TITLE
Add CI checks for tests and lint

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -26,6 +26,10 @@ jobs:
         run: |
           $cfg = Import-PowerShellDataFile ./PesterConfiguration.psd1
           Invoke-Pester -Configuration $cfg
+      - name: Ensure all functions have tests
+        shell: pwsh
+        run: |
+          ./scripts/Ensure-TestCoverage.ps1
       - uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -24,8 +24,12 @@ jobs:
         run: |
           Import-Module PSScriptAnalyzer
           Import-Module ConvertToSARIF
-          Invoke-ScriptAnalyzer -Path . -Recurse -Severity Warning,Error |
-            ConvertTo-SARIF -FilePath PSScriptAnalyzerResults.sarif
+          $results = Invoke-ScriptAnalyzer -Path . -Recurse -Severity Warning,Error
+          $results | ConvertTo-SARIF -FilePath PSScriptAnalyzerResults.sarif
+          if ($results.Count -gt 0) {
+            Write-Error 'PSScriptAnalyzer found issues.'
+            exit 1
+          }
       - name: Upload lint results
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/Ensure-TestCoverage.ps1
+++ b/scripts/Ensure-TestCoverage.ps1
@@ -1,0 +1,17 @@
+# Ensure every public function has a corresponding Pester test reference
+
+$publicDir = Join-Path $PSScriptRoot '..' 'src/SupportTools/Public'
+$testDir = Join-Path $PSScriptRoot '..' 'tests'
+$publicFunctions = Get-ChildItem -Path $publicDir -Filter '*.ps1' | ForEach-Object { $_.BaseName }
+$missing = @()
+foreach ($func in $publicFunctions) {
+    $pattern = "\b$func\b"
+    $found = Select-String -Path (Join-Path $testDir '*.ps1') -Pattern $pattern -SimpleMatch -CaseSensitive -Quiet
+    if (-not $found) {
+        Write-Error "No tests found referencing function '$func'"
+        $missing += $func
+    }
+}
+if ($missing.Count -gt 0) {
+    exit 1
+}


### PR DESCRIPTION
## Summary
- fail Pester workflow if functions have no tests
- fail lint workflow on PSScriptAnalyzer issues
- add helper script `Ensure-TestCoverage.ps1`

## Testing
- `pwsh Ensure-TestCoverage.ps1` *(fails: No tests found referencing functions)*
- `Invoke-ScriptAnalyzer` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f7c07020832c856936b88ca98119