### PR TITLE
Add Export-ITReport command for generating reports

### DIFF
--- a/src/SupportTools/Public/Export-ITReport.ps1
+++ b/src/SupportTools/Public/Export-ITReport.ps1
@@ -1,0 +1,68 @@
+function Export-ITReport {
+    <#
+    .SYNOPSIS
+        Exports an arbitrary object as an IT report.
+    .DESCRIPTION
+        Takes any PowerShell object from the pipeline or -Data parameter
+        and writes it to a file in one of three formats: HTML, CSV or JSON.
+        Useful for saving log entries, audit summaries or configuration
+        drift results.
+    .PARAMETER Data
+        The object to export. Accepts pipeline input.
+    .PARAMETER Format
+        Desired output format. One of HTML, CSV or JSON.
+    .PARAMETER OutputPath
+        Optional path for the report file. If not provided, a file name
+        with a timestamp and appropriate extension is created in the
+        current directory.
+    .PARAMETER TranscriptPath
+        Optional path to a transcript log file.
+    .EXAMPLE
+        Get-FailedLogin | Export-ITReport -Format CSV -OutputPath report.csv
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [psobject]$Data,
+        [Parameter(Mandatory)]
+        [ValidateSet('HTML','CSV','JSON')]
+        [string]$Format,
+        [string]$OutputPath,
+        [string]$TranscriptPath
+    )
+    begin {
+        $items = @()
+        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+    }
+    process {
+        $items += $Data
+    }
+    end {
+        try {
+            Assert-ParameterNotNull $Format 'Format'
+            if (-not $OutputPath) {
+                $ext = switch ($Format) {
+                    'HTML' { 'html' }
+                    'CSV'  { 'csv' }
+                    'JSON' { 'json' }
+                }
+                $OutputPath = Join-Path (Get-Location) "ITReport_$((Get-Date).ToString('yyyyMMdd_HHmmss')).$ext"
+            }
+            switch ($Format) {
+                'HTML' {
+                    $items | ConvertTo-Html -PreContent '<h1>IT Report</h1>' | Out-File -FilePath $OutputPath -Encoding utf8
+                }
+                'CSV' {
+                    $items | Export-Csv -Path $OutputPath -NoTypeInformation -Encoding utf8
+                }
+                'JSON' {
+                    $items | ConvertTo-Json -Depth 10 | Out-File -FilePath $OutputPath -Encoding utf8
+                }
+            }
+            Write-STStatus "Report saved to $OutputPath" -Level SUCCESS
+            return $OutputPath
+        } finally {
+            if ($TranscriptPath) { Stop-Transcript | Out-Null }
+        }
+    }
+}

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -32,6 +32,7 @@
         'Restore-ArchiveFolder',
         'Search-ReadMe',
         'Start-Countdown',
+        'Export-ITReport',
         'Sync-SupportTools'
     )
 }

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -33,6 +33,7 @@ Export-ModuleMember -Function @(
     'Restore-ArchiveFolder',
     'Search-ReadMe',
     'Start-Countdown',
+    'Export-ITReport',
     'Sync-SupportTools'
 )
 

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -17,6 +17,7 @@ Describe 'SupportTools Module' {
             'Export-ProductKey',
             'Search-ReadMe',
             'Start-Countdown',
+            'Export-ITReport',
             'New-SPUsageReport'
             'Sync-SupportTools',
             'Invoke-JobBundle',

--- a/tests/SupportTools/Export-ITReport.Tests.ps1
+++ b/tests/SupportTools/Export-ITReport.Tests.ps1
@@ -1,0 +1,27 @@
+Describe 'Export-ITReport function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force
+    }
+
+    It 'creates a CSV report' {
+        $path = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString() + '.csv')
+        try {
+            @([pscustomobject]@{A=1;B=2}) | Export-ITReport -Format CSV -OutputPath $path
+            Test-Path $path | Should -Be $true
+            (Get-Content $path | Select-Object -First 1) | Should -Match 'A,B'
+        } finally {
+            Remove-Item $path -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'returns generated path when OutputPath not provided' {
+        $path = @([pscustomobject]@{A=1}) | Export-ITReport -Format JSON
+        try {
+            Test-Path $path | Should -Be $true
+            $path | Should -Match '\.json$'
+        } finally {
+            Remove-Item $path -ErrorAction SilentlyContinue
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `Export-ITReport` function in SupportTools
- export the command in SupportTools module
- update module tests to include the new command
- test `Export-ITReport` behavior

## Testing
- `Invoke-Pester` *(fails: The module to process 'STCore.psm1' was not processed)*

------
https://chatgpt.com/codex/tasks/task_e_6845f7e4fbc0832c8244e53dd24ff7a3