### PR TITLE
Introduce OutTools module

### DIFF
--- a/SupportToolsLoader.ps1
+++ b/SupportToolsLoader.ps1
@@ -15,10 +15,12 @@
 if (-not $script:SupportToolsLoaderLoaded) {
     $script:SupportToolsLoaderLoaded = $true
 
+    Import-Module (Join-Path $PSScriptRoot 'src/OutTools/OutTools.psd1') -ErrorAction SilentlyContinue
+
     function Write-LoaderLog {
         param([string]$Message)
-        if (Get-Command Write-STStatus -ErrorAction SilentlyContinue) {
-            Write-STStatus -Message $Message -Level SUB -Log
+        if (Get-Command Out-STStatus -ErrorAction SilentlyContinue) {
+            Out-STStatus -Message $Message -Level SUB -Log
         }
     }
 
@@ -41,6 +43,10 @@ if (-not $script:SupportToolsLoaderLoaded) {
                 Import-Module $moduleFile.FullName -Force -ErrorAction Stop
                 $loadedModules += $name
                 Write-LoaderLog "Loaded module $name"
+                $bannerFunc = "Show-$name`Banner"
+                if (Get-Command $bannerFunc -ErrorAction SilentlyContinue) {
+                    & $bannerFunc | Out-STBanner
+                }
             }
         } catch {
             Write-Warning "Failed to import module from $($moduleFile.FullName): $($_.Exception.Message)"

--- a/docs/SharePointTools.md
+++ b/docs/SharePointTools.md
@@ -66,7 +66,8 @@ The following walkthroughs demonstrate how the commands can be combined.
 Add-SPToolsSite -Name HR -Url https://contoso.sharepoint.com/sites/hr
 
 # Run a library usage report
-Get-SPToolsLibraryReport -SiteName HR -Verbose
+$report = Get-SPToolsLibraryReport -SiteName 'HR'
+$report | Out-SPToolsLibraryReport
 ```
 
 ### 2. Clean up archived folders

--- a/src/ChaosTools/ChaosTools.psm1
+++ b/src/ChaosTools/ChaosTools.psm1
@@ -11,13 +11,13 @@ Export-ModuleMember -Function 'Invoke-ChaosTest'
 function Show-ChaosToolsBanner {
     <#
     .SYNOPSIS
-        Displays the ChaosTools module banner.
+        Returns ChaosTools module metadata for banner display.
     #>
     [CmdletBinding()]
     param()
-    Write-STDivider 'CHAOSTOOLS MODULE LOADED' -Style heavy
-    Write-STStatus "Run 'Get-Command -Module ChaosTools' to view available tools." -Level SUB
-    Write-STLog -Message 'ChaosTools module loaded'
+    $manifestPath = Join-Path $PSScriptRoot 'ChaosTools.psd1'
+    [pscustomobject]@{
+        Module  = 'ChaosTools'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
-
-Show-ChaosToolsBanner

--- a/src/ConfigManagementTools/ConfigManagementTools.psm1
+++ b/src/ConfigManagementTools/ConfigManagementTools.psm1
@@ -13,9 +13,11 @@ Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-O
 Export-ModuleMember -Function 'Add-UserToGroup','Invoke-GroupMembershipCleanup','Install-Font','Install-MaintenanceTasks','Invoke-CompanyPlaceManagement','Invoke-DeploymentTemplate','Invoke-ExchangeCalendarManager','Invoke-PostInstall','Set-ComputerIPAddress','Set-NetAdapterMetering','Set-SharedMailboxAutoReply','Set-TimeZoneEasternStandardTime','Test-Drift'
 
 function Show-ConfigManagementToolsBanner {
-    Write-STDivider 'CONFIGMANAGEMENTTOOLS MODULE LOADED' -Style heavy
-    Write-STStatus "Run 'Get-Command -Module ConfigManagementTools' to view available tools." -Level SUB
-    Write-STLog -Message 'ConfigManagementTools module loaded'
+    [CmdletBinding()]
+    param()
+    $manifestPath = Join-Path $PSScriptRoot 'ConfigManagementTools.psd1'
+    [pscustomobject]@{
+        Module  = 'ConfigManagementTools'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
-
-Show-ConfigManagementToolsBanner

--- a/src/EntraIDTools/EntraIDTools.psm1
+++ b/src/EntraIDTools/EntraIDTools.psm1
@@ -13,13 +13,13 @@ Export-ModuleMember -Function 'Get-GraphUserDetails','Get-GraphGroupDetails','Ge
 function Show-EntraIDToolsBanner {
     <#
     .SYNOPSIS
-        Displays the EntraIDTools module banner.
+        Returns EntraIDTools module metadata for banner display.
     #>
     [CmdletBinding()]
     param()
-    Write-STDivider 'ENTRAIDTOOLS MODULE LOADED' -Style heavy
-    Write-STStatus "Run 'Get-Command -Module EntraIDTools' to view available tools." -Level SUB
-    Write-STLog -Message 'EntraIDTools module loaded'
+    $manifestPath = Join-Path $PSScriptRoot 'EntraIDTools.psd1'
+    [pscustomobject]@{
+        Module  = 'EntraIDTools'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
-
-Show-EntraIDToolsBanner

--- a/src/IncidentResponseTools/IncidentResponseTools.psm1
+++ b/src/IncidentResponseTools/IncidentResponseTools.psm1
@@ -13,9 +13,11 @@ Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-O
 Export-ModuleMember -Function 'Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Invoke-IncidentResponse','Invoke-RemoteAudit','Invoke-FullSystemAudit','Submit-SystemInfoTicket','Update-Sysmon','Search-Indicators'
 
 function Show-IncidentResponseToolsBanner {
-    Write-STDivider 'INCIDENTRESPONSETOOLS MODULE LOADED' -Style heavy
-    Write-STStatus "Run 'Get-Command -Module IncidentResponseTools' to view available tools." -Level SUB
-    Write-STLog -Message 'IncidentResponseTools module loaded'
+    [CmdletBinding()]
+    param()
+    $manifestPath = Join-Path $PSScriptRoot 'IncidentResponseTools.psd1'
+    [pscustomobject]@{
+        Module  = 'IncidentResponseTools'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
-
-Show-IncidentResponseToolsBanner

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -226,13 +226,13 @@ Export-ModuleMember -Function 'Write-STLog','Write-STRichLog','Write-STStatus','
 function Show-LoggingBanner {
     <#
     .SYNOPSIS
-        Displays the Logging module banner.
+        Returns Logging module metadata for banner display.
     #>
     [CmdletBinding()]
     param()
-    Write-STDivider 'LOGGING MODULE LOADED' -Style heavy
-    Write-STStatus "Run 'Get-Command -Module Logging' to view available tools." -Level SUB
-    Write-STLog -Message 'Logging module loaded'
+    $manifestPath = Join-Path $PSScriptRoot 'Logging.psd1'
+    [pscustomobject]@{
+        Module  = 'Logging'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
-
-Show-LoggingBanner

--- a/src/MaintenancePlan/MaintenancePlan.psm1
+++ b/src/MaintenancePlan/MaintenancePlan.psm1
@@ -8,9 +8,11 @@ Get-ChildItem -Path "$PublicDir" -Filter *.ps1 -ErrorAction SilentlyContinue | F
 Export-ModuleMember -Function (Get-ChildItem "$PublicDir/*.ps1" -ErrorAction SilentlyContinue).BaseName
 
 function Show-MaintenancePlanBanner {
-    Write-STDivider 'MAINTENANCEPLAN MODULE LOADED' -Style heavy
-    Write-STStatus "Run 'Get-Command -Module MaintenancePlan' to view available tools." -Level SUB
-    Write-STLog -Message 'MaintenancePlan module loaded'
+    [CmdletBinding()]
+    param()
+    $manifestPath = Join-Path $PSScriptRoot 'MaintenancePlan.psd1'
+    [pscustomobject]@{
+        Module  = 'MaintenancePlan'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
-
-Show-MaintenancePlanBanner

--- a/src/MonitoringTools/MonitoringTools.psm1
+++ b/src/MonitoringTools/MonitoringTools.psm1
@@ -11,13 +11,13 @@ Export-ModuleMember -Function 'Get-CPUUsage','Get-DiskSpaceInfo','Get-EventLogSu
 function Show-MonitoringToolsBanner {
     <#
     .SYNOPSIS
-        Displays the MonitoringTools module banner.
+        Returns MonitoringTools module metadata for banner display.
     #>
     [CmdletBinding()]
     param()
-    Write-STDivider 'MONITORINGTOOLS MODULE LOADED' -Style heavy
-    Write-STStatus "Run 'Get-Command -Module MonitoringTools' to view available tools." -Level SUB
-    Write-STLog -Message 'MonitoringTools module loaded'
+    $manifestPath = Join-Path $PSScriptRoot 'MonitoringTools.psd1'
+    [pscustomobject]@{
+        Module  = 'MonitoringTools'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
-
-Show-MonitoringToolsBanner

--- a/src/OutTools/OutTools.psd1
+++ b/src/OutTools/OutTools.psd1
@@ -1,0 +1,8 @@
+@{
+    RootModule = 'OutTools.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = '00000000-0000-0000-0000-000000000999'
+    Author = 'Contoso'
+    Description = 'Output helper functions.'
+    FunctionsToExport = @('Out-STStatus','Out-STBanner')
+}

--- a/src/OutTools/OutTools.psm1
+++ b/src/OutTools/OutTools.psm1
@@ -1,0 +1,23 @@
+function Out-STStatus {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Message,
+        [Parameter()][ValidateSet('INFO','SUCCESS','ERROR','WARN','SUB','FINAL','FATAL')][string]$Level = 'INFO',
+        [switch]$Log
+    )
+    Write-STStatus -Message $Message -Level $Level -Log:$Log
+}
+
+function Out-STBanner {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Info
+    )
+    if (-not $Info.Module) { throw 'Module property required' }
+    $title = "$($Info.Module.ToUpper()) MODULE LOADED"
+    Write-STDivider $title -Style heavy
+    Write-STStatus "Run 'Get-Command -Module $($Info.Module)' to view available tools." -Level SUB
+    Write-STLog -Message "$($Info.Module) module loaded"
+}
+
+Export-ModuleMember -Function 'Out-STStatus','Out-STBanner'

--- a/src/PerformanceTools/PerformanceTools.psm1
+++ b/src/PerformanceTools/PerformanceTools.psm1
@@ -89,13 +89,13 @@ Export-ModuleMember -Function 'Measure-STCommand','Invoke-PerformanceAudit'
 function Show-PerformanceToolsBanner {
     <#
     .SYNOPSIS
-        Displays the PerformanceTools module banner.
+        Returns PerformanceTools module metadata for banner display.
     #>
     [CmdletBinding()]
     param()
-    Write-STDivider 'PERFORMANCETOOLS MODULE LOADED' -Style heavy
-    Write-STStatus "Run 'Get-Command -Module PerformanceTools' to view available tools." -Level SUB
-    Write-STLog -Message 'PerformanceTools module loaded'
+    $manifestPath = Join-Path $PSScriptRoot 'PerformanceTools.psd1'
+    [pscustomobject]@{
+        Module  = 'PerformanceTools'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
-
-Show-PerformanceToolsBanner

--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -81,11 +81,13 @@ Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','Wri
 function Show-STCoreBanner {
     <#
     .SYNOPSIS
-        Displays the STCore module banner.
+        Returns STCore module metadata for banner display.
     #>
     [CmdletBinding()]
     param()
-    Write-STStatus 'STCore module loaded' -Level SUB -Log
+    $manifestPath = Join-Path $PSScriptRoot 'STCore.psd1'
+    [pscustomobject]@{
+        Module  = 'STCore'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
-
-Show-STCoreBanner

--- a/src/ServiceDeskTools/ServiceDeskTools.psm1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psm1
@@ -18,13 +18,13 @@ Export-ModuleMember -Function (
 function Show-ServiceDeskToolsBanner {
     <#
     .SYNOPSIS
-        Displays the ServiceDeskTools module banner.
+        Returns ServiceDeskTools module metadata for banner display.
     #>
     [CmdletBinding()]
     param()
-    Write-STDivider 'SERVICEDESKTOOLS MODULE LOADED' -Style heavy
-    Write-STStatus "Run 'Get-Command -Module ServiceDeskTools' to view available tools." -Level SUB
-    Write-STLog -Message 'ServiceDeskTools module loaded'
+    $manifestPath = Join-Path $PSScriptRoot 'ServiceDeskTools.psd1'
+    [pscustomobject]@{
+        Module  = 'ServiceDeskTools'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
-
-Show-ServiceDeskToolsBanner

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -762,6 +762,17 @@ function Get-SPToolsAllLibraryReports {
     Write-SPToolsHacker 'Reports complete'
 }
 
+function Out-SPToolsLibraryReport {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline)]
+        [pscustomobject]$InputObject
+    )
+    process {
+        $InputObject | Format-Table SiteName,LibraryName,ItemCount,LastModified
+    }
+}
+
 function Get-SPToolsRecycleBinReport {
     <#
     .SYNOPSIS
@@ -1224,7 +1235,7 @@ function List-OneDriveUsage {
     Write-SPToolsHacker 'Report complete'
     $report
 }
-Export-ModuleMember -Function 'Invoke-YFArchiveCleanup','Invoke-IBCCentralFilesArchiveCleanup','Invoke-MexCentralFilesArchiveCleanup','Invoke-ArchiveCleanup','Invoke-YFFileVersionCleanup','Invoke-IBCCentralFilesFileVersionCleanup','Invoke-MexCentralFilesFileVersionCleanup','Invoke-FileVersionCleanup','Invoke-SharingLinkCleanup','Invoke-YFSharingLinkCleanup','Invoke-IBCCentralFilesSharingLinkCleanup','Invoke-MexCentralFilesSharingLinkCleanup','Get-SPToolsSettings','Get-SPToolsSiteUrl','Add-SPToolsSite','Set-SPToolsSite','Remove-SPToolsSite','Get-SPToolsLibraryReport','Get-SPToolsAllLibraryReports','Get-SPToolsRecycleBinReport','Clear-SPToolsRecycleBin','Get-SPToolsAllRecycleBinReports','Get-SPToolsFileReport','Get-SPToolsPreservationHoldReport','Get-SPToolsAllPreservationHoldReports','Get-SPPermissionsReport','Clean-SPVersionHistory','Find-OrphanedSPFiles','Select-SPToolsFolder','List-OneDriveUsage','Test-SPToolsPrereqs' -Variable 'SharePointToolsSettings'
+Export-ModuleMember -Function 'Invoke-YFArchiveCleanup','Invoke-IBCCentralFilesArchiveCleanup','Invoke-MexCentralFilesArchiveCleanup','Invoke-ArchiveCleanup','Invoke-YFFileVersionCleanup','Invoke-IBCCentralFilesFileVersionCleanup','Invoke-MexCentralFilesFileVersionCleanup','Invoke-FileVersionCleanup','Invoke-SharingLinkCleanup','Invoke-YFSharingLinkCleanup','Invoke-IBCCentralFilesSharingLinkCleanup','Invoke-MexCentralFilesSharingLinkCleanup','Get-SPToolsSettings','Get-SPToolsSiteUrl','Add-SPToolsSite','Set-SPToolsSite','Remove-SPToolsSite','Get-SPToolsLibraryReport','Get-SPToolsAllLibraryReports','Out-SPToolsLibraryReport','Get-SPToolsRecycleBinReport','Clear-SPToolsRecycleBin','Get-SPToolsAllRecycleBinReports','Get-SPToolsFileReport','Get-SPToolsPreservationHoldReport','Get-SPToolsAllPreservationHoldReports','Get-SPPermissionsReport','Clean-SPVersionHistory','Find-OrphanedSPFiles','Select-SPToolsFolder','List-OneDriveUsage','Test-SPToolsPrereqs' -Variable 'SharePointToolsSettings'
 
 function Register-SPToolsCompleters {
     <#
@@ -1250,16 +1261,17 @@ function Register-SPToolsCompleters {
 function Show-SharePointToolsBanner {
     <#
     .SYNOPSIS
-        Displays a module loaded message.
+        Returns SharePointTools module metadata for banner display.
     .EXAMPLE
         Show-SharePointToolsBanner
     #>
     [CmdletBinding()]
     param()
-    Write-STDivider 'SHAREPOINTTOOLS MODULE LOADED' -Style heavy
-    Write-STStatus "Run 'Get-Command -Module SharePointTools' to view available tools." -Level SUB
-    Write-STLog -Message 'SharePointTools module loaded'
+    $manifestPath = Join-Path $PSScriptRoot 'SharePointTools.psd1'
+    [pscustomobject]@{
+        Module  = 'SharePointTools'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
 
 Register-SPToolsCompleters
-Show-SharePointToolsBanner

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -40,13 +40,13 @@ Export-ModuleMember -Function @(
 function Show-SupportToolsBanner {
     <#
     .SYNOPSIS
-        Displays the SupportTools module banner.
+        Returns SupportTools module metadata for banner display.
     #>
     [CmdletBinding()]
     param()
-    Write-STDivider 'SUPPORTTOOLS MODULE LOADED' -Style heavy
-    Write-STStatus "Run 'Get-Command -Module SupportTools' to view available tools." -Level SUB
-    Write-STLog -Message 'SupportTools module loaded'
+    $manifestPath = Join-Path $PSScriptRoot 'SupportTools.psd1'
+    [pscustomobject]@{
+        Module  = 'SupportTools'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
-
-Show-SupportToolsBanner

--- a/src/Telemetry/Telemetry.psm1
+++ b/src/Telemetry/Telemetry.psm1
@@ -138,13 +138,13 @@ Export-ModuleMember -Function 'Write-STTelemetryEvent','Get-STTelemetryMetrics',
 function Show-TelemetryBanner {
     <#
     .SYNOPSIS
-        Displays the Telemetry module banner.
+        Returns Telemetry module metadata for banner display.
     #>
     [CmdletBinding()]
     param()
-    Write-STDivider 'TELEMETRY MODULE LOADED' -Style heavy
-    Write-STStatus "Run 'Get-Command -Module Telemetry' to view available tools." -Level SUB
-    Write-STLog -Message 'Telemetry module loaded'
+    $manifestPath = Join-Path $PSScriptRoot 'Telemetry.psd1'
+    [pscustomobject]@{
+        Module  = 'Telemetry'
+        Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    }
 }
-
-Show-TelemetryBanner

--- a/tests/OutTools.Tests.ps1
+++ b/tests/OutTools.Tests.ps1
@@ -1,0 +1,11 @@
+Describe 'OutTools Module' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../src/OutTools/OutTools.psd1 -Force
+    }
+
+    It 'formats banner objects' {
+        $obj = [pscustomobject]@{ Module='TestMod'; Version='1.0' }
+        { $obj | Out-STBanner } | Should -Not -Throw
+    }
+}


### PR DESCRIPTION
## Summary
- add new `OutTools` module with `Out-STBanner` and `Out-STStatus`
- refactor all banner functions to return metadata objects
- update loader to call `Out-STBanner`
- add `Out-SPToolsLibraryReport` and mention in docs
- add basic tests for `OutTools`

## Testing
- `pwsh run_pester.ps1` *(fails: module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845fa03148c832c86183a21e089d3b4