### PR TITLE
Add Pester tests for wrapper modules

### DIFF
--- a/tests/ConfigManagementTools/PublicFunctions.Tests.ps1
+++ b/tests/ConfigManagementTools/PublicFunctions.Tests.ps1
@@ -1,0 +1,105 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'ConfigManagementTools public functions' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/ConfigManagementTools/ConfigManagementTools.psd1 -Force
+    }
+
+    $wrappers = @{
+        'Install-Font' = 'Install-Fonts.ps1'
+        'Install-MaintenanceTasks' = 'Setup-ScheduledMaintenance.ps1'
+        'Invoke-DeploymentTemplate' = 'SS_DEPLOYMENT_TEMPLATE.ps1'
+        'Invoke-PostInstall' = 'PostInstallScript.ps1'
+        'Set-ComputerIPAddress' = 'Set-ComputerIPAddress.ps1'
+        'Set-NetAdapterMetering' = 'Set-NetAdapterMetering.ps1'
+        'Set-TimeZoneEasternStandardTime' = 'Set-TimeZoneEasternStandardTime.ps1'
+    }
+
+    Safe-It 'calls Invoke-ScriptFile' -ForEach $wrappers.GetEnumerator() {
+        param($case)
+        InModuleScope ConfigManagementTools {
+            Mock Invoke-ScriptFile {} -ModuleName ConfigManagementTools
+            if ($case.Key -eq 'Install-MaintenanceTasks') {
+                & $case.Key -Register
+            } else {
+                & $case.Key
+            }
+            Assert-MockCalled Invoke-ScriptFile -ModuleName ConfigManagementTools -Times 1 -ParameterFilter { $Name -eq $case.Value }
+        }
+    }
+
+    Safe-It 'throws when Invoke-ScriptFile fails' -ForEach $wrappers.GetEnumerator() {
+        param($case)
+        InModuleScope ConfigManagementTools {
+            Mock Invoke-ScriptFile { throw 'bad' } -ModuleName ConfigManagementTools
+            { if ($case.Key -eq 'Install-MaintenanceTasks') { & $case.Key -Register } else { & $case.Key } } | Should -Throw
+        }
+    }
+
+    Context 'Invoke-GroupMembershipCleanup' {
+        It 'calls cleanup script' {
+            InModuleScope ConfigManagementTools {
+                Mock Invoke-ScriptFile {} -ModuleName ConfigManagementTools
+                Invoke-GroupMembershipCleanup -CsvPath 'c.csv' -GroupName 'g1'
+                Assert-MockCalled Invoke-ScriptFile -ModuleName ConfigManagementTools -Times 1 -ParameterFilter { $Name -eq 'CleanupGroupMembership.ps1' }
+            }
+        }
+        It 'throws on failure' {
+            InModuleScope ConfigManagementTools {
+                Mock Invoke-ScriptFile { throw 'oops' } -ModuleName ConfigManagementTools
+                { Invoke-GroupMembershipCleanup -CsvPath 'c.csv' -GroupName 'g1' } | Should -Throw
+            }
+        }
+    }
+
+    Context 'Set-SharedMailboxAutoReply' {
+        $commonParams = @{ MailboxIdentity='mb'; StartTime=(Get-Date); EndTime=(Get-Date).AddHours(1); InternalMessage='msg'; AdminUser='admin' }
+        It 'returns simulation object' {
+            InModuleScope ConfigManagementTools {
+                Mock Write-STStatus {}
+                $res = Set-SharedMailboxAutoReply @commonParams -Simulate
+                $res.Simulated | Should -BeTrue
+            }
+        }
+        It 'returns error object when connection fails' {
+            InModuleScope ConfigManagementTools {
+                Mock Write-STStatus {}
+                Mock Write-STLog {}
+                Mock Send-STMetric {}
+                Mock Get-InstalledModule { @{ Version = [version]'1.0' } }
+                Mock Find-Module { $null }
+                Mock Import-Module {}
+                Mock Connect-ExchangeOnline { throw 'fail' }
+                Mock Disconnect-ExchangeOnline {}
+                $res = Set-SharedMailboxAutoReply @commonParams -UseWebLogin
+                $res.Category | Should -Be 'Exchange'
+            }
+        }
+    }
+
+    Context 'Invoke-ExchangeCalendarManager' {
+        It 'returns simulation object' {
+            InModuleScope ConfigManagementTools {
+                Mock Write-STStatus {}
+                $res = Invoke-ExchangeCalendarManager -Simulate
+                $res.Simulated | Should -BeTrue
+            }
+        }
+        It 'returns error object when connect fails' {
+            InModuleScope ConfigManagementTools {
+                Mock Write-STStatus {}
+                Mock Write-STLog {}
+                Mock Send-STMetric {}
+                Mock Get-InstalledModule { @{ Version = [version]'1.0' } }
+                Mock Find-Module { $null }
+                Mock Import-Module {}
+                Mock Connect-ExchangeOnline { throw 'fail' }
+                Mock Disconnect-ExchangeOnline {}
+                Mock Read-Host { 'Q' }
+                $res = Invoke-ExchangeCalendarManager -Action Get -DisplayName 'n' -Type Building
+                $res.Category | Should -Be 'Exchange'
+            }
+        }
+    }
+}

--- a/tests/IncidentResponseTools/PublicFunctions.Tests.ps1
+++ b/tests/IncidentResponseTools/PublicFunctions.Tests.ps1
@@ -1,0 +1,116 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'IncidentResponseTools public functions' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/IncidentResponseTools/IncidentResponseTools.psd1 -Force
+    }
+
+    $wrappers = @{
+        'Get-FailedLogin'       = 'Get-FailedLogins.ps1'
+        'Get-NetworkShare'      = 'Get-NetworkShares.ps1'
+        'Invoke-IncidentResponse' = 'Invoke-IncidentResponse.ps1'
+        'Search-Indicators'     = 'Search-Indicators.ps1'
+        'Submit-SystemInfoTicket' = 'Submit-SystemInfoTicket.ps1'
+        'Update-Sysmon'         = 'Update-Sysmon.ps1'
+    }
+
+    Safe-It 'calls Invoke-ScriptFile' -ForEach $wrappers.GetEnumerator() {
+        param($case)
+        InModuleScope IncidentResponseTools {
+            Mock Invoke-ScriptFile {} -ModuleName IncidentResponseTools
+            switch ($case.Key) {
+                'Submit-SystemInfoTicket' { & $case.Key -SiteName 'A' -RequesterEmail 'r@c.com' }
+                default { & $case.Key }
+            }
+            Assert-MockCalled Invoke-ScriptFile -ModuleName IncidentResponseTools -Times 1 -ParameterFilter { $Name -eq $case.Value }
+        }
+    }
+
+    Safe-It 'throws when Invoke-ScriptFile fails' -ForEach $wrappers.GetEnumerator() {
+        param($case)
+        InModuleScope IncidentResponseTools {
+            Mock Invoke-ScriptFile { throw 'fail' } -ModuleName IncidentResponseTools
+            switch ($case.Key) {
+                'Submit-SystemInfoTicket' { { & $case.Key -SiteName 'A' -RequesterEmail 'r@c.com' } | Should -Throw }
+                default { { & $case.Key } | Should -Throw }
+            }
+        }
+    }
+
+    Context 'Get-CommonSystemInfo' {
+        It 'returns system info when CIM available' {
+            InModuleScope IncidentResponseTools {
+                Mock Get-Command { @{ Name='Get-CimInstance' } } -ParameterFilter { $Name -eq 'Get-CimInstance' }
+                Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Get-WmiObject' }
+                Mock Get-CimInstance {
+                    switch ($ClassName) {
+                        'Win32_OperatingSystem' { [pscustomobject]@{ CSName='PC'; Caption='OS'; BuildNumber='1'; TotalVisibleMemorySize=2048 } }
+                        'Win32_Processor'       { [pscustomobject]@{ Name='CPU' } }
+                        'Win32_LogicalDisk'     { @([pscustomobject]@{ DeviceID='C:'; Size=100GB; FreeSpace=50GB }) }
+                        default { @() }
+                    }
+                }
+                Mock Write-STStatus {}
+                Mock Send-STMetric {}
+                $res = Get-CommonSystemInfo
+                $res.ComputerName | Should -Be 'PC'
+                Assert-MockCalled Send-STMetric -ParameterFilter { $MetricName -eq 'Get-CommonSystemInfo' } -Times 1
+            }
+        }
+        It 'returns error object on failure' {
+            InModuleScope IncidentResponseTools {
+                Mock Get-Command { @{ Name='Get-CimInstance' } } -ParameterFilter { $Name -eq 'Get-CimInstance' }
+                Mock Get-CimInstance { throw 'bad' }
+                Mock Write-STStatus {}
+                Mock Write-STLog {}
+                Mock Send-STMetric {}
+                $res = Get-CommonSystemInfo
+                $res.Category | Should -Be 'WMI'
+            }
+        }
+    }
+
+    Context 'Invoke-RemoteAudit' {
+        It 'collects info from computers' {
+            InModuleScope IncidentResponseTools {
+                Mock Invoke-Command { [pscustomobject]@{ ComputerName=$ComputerName; Info='i' } }
+                $r = Invoke-RemoteAudit -ComputerName 'PC1'
+                $r.Success | Should -BeTrue
+                $r.Info | Should -Be 'i'
+            }
+        }
+        It 'captures errors from Invoke-Command' {
+            InModuleScope IncidentResponseTools {
+                Mock Invoke-Command { throw 'fail' }
+                $r = Invoke-RemoteAudit -ComputerName 'PC1'
+                $r.Success | Should -BeFalse
+                $r.Error | Should -Match 'fail'
+            }
+        }
+    }
+
+    Context 'Invoke-FullSystemAudit' {
+        It 'aggregates step output' {
+            InModuleScope IncidentResponseTools {
+                Mock Get-CommonSystemInfo { 'info' }
+                Mock Get-FailedLogin { 'fails' }
+                Mock Invoke-ScriptFile { 'sp' } -ParameterFilter { $Name -eq 'Generate-SPUsageReport.ps1' }
+                Mock Invoke-ScriptFile { 'perf' } -ParameterFilter { $Name -eq 'Invoke-PerformanceAudit.ps1' }
+                $s = Invoke-FullSystemAudit -OutputPath (Join-Path $env:TEMP 'o.json')
+                $s.CommonSystemInfo | Should -Be 'info'
+                $s.Errors.Count | Should -Be 0
+            }
+        }
+        It 'records errors when steps fail' {
+            InModuleScope IncidentResponseTools {
+                Mock Get-CommonSystemInfo { throw 'boom' }
+                Mock Get-FailedLogin { 'fails' }
+                Mock Invoke-ScriptFile { 'sp' } -ParameterFilter { $Name -eq 'Generate-SPUsageReport.ps1' }
+                Mock Invoke-ScriptFile { 'perf' } -ParameterFilter { $Name -eq 'Invoke-PerformanceAudit.ps1' }
+                $s = Invoke-FullSystemAudit -OutputPath (Join-Path $env:TEMP 'o.json')
+                $s.Errors.Count | Should -Be 1
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for ConfigManagementTools functions
- add tests for IncidentResponseTools functions

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: required modules not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6845f7ac8000832c841bd041c86181f8