### PR TITLE
Fix completers function

### DIFF
--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -1244,6 +1244,8 @@ function Register-SPToolsCompleters {
     .EXAMPLE
         Register-SPToolsCompleters
     #>
+    [CmdletBinding()]
+    param()
     $siteCmds = 'Get-SPToolsSiteUrl','Get-SPToolsLibraryReport','Get-SPToolsRecycleBinReport','Clear-SPToolsRecycleBin','Get-SPToolsPreservationHoldReport','Get-SPToolsAllLibraryReports','Get-SPToolsAllRecycleBinReports','Get-SPToolsFileReport','Select-SPToolsFolder'
     Register-ArgumentCompleter -CommandName $siteCmds -ParameterName SiteName -ScriptBlock {
         param($commandName,$parameterName,$wordToComplete)


### PR DESCRIPTION
## Summary
- make `Register-SPToolsCompleters` an advanced function

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)` *(fails: required modules not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6846002eea68832cbe3b4c2b93326c3c