### PR TITLE
Add WhatIf support to AddUsersToGroup

### DIFF
--- a/src/ConfigManagementTools/Public/Add-UserToGroup.ps1
+++ b/src/ConfigManagementTools/Public/Add-UserToGroup.ps1
@@ -10,7 +10,7 @@ function Add-UserToGroup {
     .PARAMETER GroupName
         Name of the Microsoft 365 group to modify.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
@@ -50,6 +50,13 @@ function Add-UserToGroup {
             if ($PSBoundParameters.ContainsKey('Cloud')) {
                 $arguments += '-Cloud'
                 $arguments += $Cloud
+            }
+
+            if ($PSBoundParameters.ContainsKey('WhatIf')) {
+                $arguments += '-WhatIf'
+            }
+            if ($PSBoundParameters.ContainsKey('Confirm')) {
+                $arguments += '-Confirm'
             }
 
             Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain


### PR DESCRIPTION
## Summary
- support `-WhatIf` for AddUsersToGroup.ps1 by implementing `SupportsShouldProcess`
- forward `-WhatIf`/`-Confirm` from Add-UserToGroup wrapper

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile 'PesterConfiguration.psd1')` *(fails: Get-STConfig not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460069caa4832c80e7a2108ad76762