### PR TITLE
Add automation for new hire tickets

### DIFF
--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -45,3 +45,4 @@ The table below lists each command and the script it invokes. Arguments not list
 | `Start-Countdown` | `SimpleCountdown.ps1` | *passthrough* | `Start-Countdown -Seconds 30` |
 | `Sync-SupportTools` | *git* | `[RepositoryUrl]`, `[InstallPath]` | `Sync-SupportTools` |
 | `New-SPUsageReport` | `Generate-SPUsageReport.ps1` | `[ItemThreshold]`, `[RequesterEmail]`, `[CsvPath]`, `[TranscriptPath]` | `New-SPUsageReport -RequesterEmail 'user@contoso.com'` |
+| `Invoke-NewHireUserAutomation` | `Create-NewHireUser.ps1` | `[PollMinutes]`, `[-Once]` | `Invoke-NewHireUserAutomation -Once` |

--- a/docs/SupportTools/Invoke-NewHireUserAutomation.md
+++ b/docs/SupportTools/Invoke-NewHireUserAutomation.md
@@ -1,0 +1,43 @@
+---
+external help file: SupportTools-help.xml
+Module Name: SupportTools
+online version:
+schema: 2.0.0
+---
+
+# Invoke-NewHireUserAutomation
+
+## SYNOPSIS
+Creates Entra ID users from new hire Service Desk tickets.
+
+## SYNTAX
+```powershell
+Invoke-NewHireUserAutomation [[-PollMinutes] <Int32>] [-Once] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Wraps the `Create-NewHireUser.ps1` script. The command searches the Service Desk for tickets containing the phrase "new hire" and creates accounts using the details stored in each ticket's custom fields.
+
+## EXAMPLES
+### Example 1
+```powershell
+PS C:\> Invoke-NewHireUserAutomation -Once
+```
+Processes new hire tickets a single time and exits.
+
+## PARAMETERS
+### -PollMinutes
+Interval between ticket checks in minutes. Default is `5`.
+
+### -Once
+Run only a single polling cycle then exit.
+
+### -TranscriptPath
+Optional path to save a transcript log.
+
+## INPUTS
+None
+
+## OUTPUTS
+None
+

--- a/scripts/Create-NewHireUser.ps1
+++ b/scripts/Create-NewHireUser.ps1
@@ -1,0 +1,89 @@
+<#+
+.SYNOPSIS
+    Creates Entra ID users when new hire Service Desk tickets are detected.
+.DESCRIPTION
+    Polls the Service Desk for tickets containing the phrase "new hire".
+    When a ticket includes required user fields, a new account is created
+    with Microsoft Graph and the ticket is marked resolved.
+.PARAMETER PollMinutes
+    How often to poll for new tickets in minutes. Defaults to 5.
+.PARAMETER Once
+    Run the check only a single time then exit.
+.PARAMETER TranscriptPath
+    Optional path to a transcript log file.
+#>
+[CmdletBinding()]
+param(
+    [int]$PollMinutes = 5,
+    [switch]$Once,
+    [string]$TranscriptPath
+)
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction SilentlyContinue
+
+if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+
+function Get-NewHireTickets {
+    Write-STStatus 'Searching Service Desk for new hire tickets...' -Level INFO -Log
+    Search-SDTicket -Query 'new hire'
+}
+
+function Get-UserDetailsFromTicket {
+    param([object]$Ticket)
+    $json = $Ticket.RawJson | ConvertFrom-Json
+    [pscustomobject]@{
+        FirstName        = $json.custom_fields.firstName
+        LastName         = $json.custom_fields.lastName
+        UserPrincipalName = $json.custom_fields.userPrincipalName
+    }
+}
+
+function Create-EntraUser {
+    param([object]$Details)
+    if (-not (Get-Module -ListAvailable -Name Microsoft.Graph.Users)) {
+        Install-Module Microsoft.Graph.Users -Scope CurrentUser -Force | Out-Null
+    }
+    Import-Module Microsoft.Graph.Users -ErrorAction Stop
+    Connect-MgGraph -Scopes 'User.ReadWrite.All' -NoWelcome
+    $params = @{ 
+        DisplayName     = "$($Details.FirstName) $($Details.LastName)" 
+        MailNickname    = $Details.FirstName
+        UserPrincipalName = $Details.UserPrincipalName
+        AccountEnabled  = $true
+        PasswordProfile = @{ ForceChangePasswordNextSignIn = $true; Password = [guid]::NewGuid().ToString() }
+    }
+    New-MgUser @params | Out-Null
+    Disconnect-MgGraph | Out-Null
+    Write-STStatus "Created user $($Details.UserPrincipalName)" -Level SUCCESS -Log
+}
+
+function Start-Main {
+    param([int]$PollMinutes,[switch]$Once)
+    while ($true) {
+        $tickets = Get-NewHireTickets
+        foreach ($t in $tickets) {
+            try {
+                $info = Get-UserDetailsFromTicket -Ticket $t
+                if (-not $info.FirstName -or -not $info.LastName -or -not $info.UserPrincipalName) {
+                    Write-STStatus "Ticket $($t.Id) missing user fields" -Level WARN -Log
+                    continue
+                }
+                Create-EntraUser -Details $info
+                Set-SDTicket -Id $t.Id -Fields @{ state = 'Resolved' } | Out-Null
+                Write-STStatus "Resolved ticket $($t.Id)" -Level SUCCESS -Log
+            } catch {
+                Write-STStatus "Failed processing ticket $($t.Id): $_" -Level ERROR -Log
+            }
+        }
+        if ($Once) { break }
+        Start-Sleep -Seconds ($PollMinutes * 60)
+    }
+}
+
+try {
+    Start-Main -PollMinutes $PollMinutes -Once:$Once
+} finally {
+    if ($TranscriptPath) { Stop-Transcript | Out-Null }
+}
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,3 +34,4 @@ The following table provides a brief description of each script.
 | **Get-FunctionDependencyGraph.ps1** | Generates a Graphviz or Mermaid map of function calls inside a script. |
 
 | **Invoke-DailyAuditWorkflow.ps1** | Audits SharePoint permissions, logs results and opens a Service Desk ticket. |
+| **Create-NewHireUser.ps1** | Creates Entra ID users based on new hire Service Desk tickets. |

--- a/src/SupportTools/Public/Invoke-NewHireUserAutomation.ps1
+++ b/src/SupportTools/Public/Invoke-NewHireUserAutomation.ps1
@@ -1,0 +1,37 @@
+function Invoke-NewHireUserAutomation {
+    <#
+    .SYNOPSIS
+        Creates Entra ID users based on new hire Service Desk tickets.
+    .DESCRIPTION
+        Wraps the Create-NewHireUser.ps1 script in the scripts folder with the provided parameters.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [Parameter(Mandatory=$false)]
+        [int]$PollMinutes = 5,
+        [Parameter(Mandatory=$false)]
+        [switch]$Once,
+        [Parameter(Mandatory=$false)]
+        [string]$TranscriptPath,
+        [Parameter(Mandatory=$false)]
+        [switch]$Simulate,
+        [Parameter(Mandatory=$false)]
+        [switch]$Explain,
+        [Parameter(Mandatory=$false)]
+        [object]$Logger,
+        [Parameter(Mandatory=$false)]
+        [object]$TelemetryClient,
+        [Parameter(Mandatory=$false)]
+        [object]$Config
+    )
+    process {
+        try {
+            $args = @('-PollMinutes', $PollMinutes)
+            if ($Once) { $args += '-Once' }
+            if ($PSBoundParameters.ContainsKey('TranscriptPath')) { $args += '-TranscriptPath'; $args += $TranscriptPath }
+            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Create-NewHireUser.ps1' -Args $args -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        } catch {
+            return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
+        }
+    }
+}

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -33,6 +33,7 @@
         'Search-ReadMe',
         'Start-Countdown',
         'Export-ITReport',
-        'Sync-SupportTools'
+        'Sync-SupportTools',
+        'Invoke-NewHireUserAutomation'
     )
 }

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -34,7 +34,8 @@ Export-ModuleMember -Function @(
     'Search-ReadMe',
     'Start-Countdown',
     'Export-ITReport',
-    'Sync-SupportTools'
+    'Sync-SupportTools',
+    'Invoke-NewHireUserAutomation'
 )
 
 

--- a/tests/Create-NewHireUser.Tests.ps1
+++ b/tests/Create-NewHireUser.Tests.ps1
@@ -1,0 +1,27 @@
+Describe 'Create-NewHireUser script' {
+    BeforeAll {
+        function Search-SDTicket {}
+        function Set-SDTicket {}
+        function Install-Module {}
+        function Import-Module {}
+        function Connect-MgGraph {}
+        function Disconnect-MgGraph {}
+        function New-MgUser {}
+        . $PSScriptRoot/../scripts/Create-NewHireUser.ps1
+    }
+    BeforeEach {
+        Mock Search-SDTicket { @([pscustomobject]@{ Id=1; RawJson='{"custom_fields":{"firstName":"John","lastName":"Doe","userPrincipalName":"john.doe@contoso.com"}}' }) }
+        Mock Set-SDTicket {}
+        Mock Install-Module {}
+        Mock Import-Module {}
+        Mock Connect-MgGraph {}
+        Mock Disconnect-MgGraph {}
+        Mock New-MgUser {}
+    }
+    It 'creates a user and resolves the ticket' {
+        Start-Main -PollMinutes 1 -Once | Out-Null
+        Assert-MockCalled Search-SDTicket -Times 1
+        Assert-MockCalled New-MgUser -Times 1
+        Assert-MockCalled Set-SDTicket -Times 1 -ParameterFilter { $Id -eq 1 }
+    }
+}

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -18,7 +18,8 @@ Describe 'SupportTools Module' {
             'Search-ReadMe',
             'Start-Countdown',
             'Export-ITReport',
-            'New-SPUsageReport'
+            'New-SPUsageReport',
+            'Invoke-NewHireUserAutomation'
             'Sync-SupportTools',
             'Invoke-JobBundle',
             'Invoke-PerformanceAudit'

--- a/tests/SupportTools/NewHireUserAutomation.Tests.ps1
+++ b/tests/SupportTools/NewHireUserAutomation.Tests.ps1
@@ -1,0 +1,16 @@
+Describe 'Invoke-NewHireUserAutomation function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force
+    }
+
+    It 'passes parameters to Invoke-ScriptFile' {
+        InModuleScope SupportTools {
+            Mock Invoke-ScriptFile {} -ModuleName SupportTools
+            Invoke-NewHireUserAutomation -PollMinutes 1 -Once -TranscriptPath 't.log'
+            Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -Times 1 -ParameterFilter {
+                $Name -eq 'Create-NewHireUser.ps1' -and $Args -contains '-Once'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Create-NewHireUser.ps1` script to poll Service Desk for "new hire" tickets and create accounts
- expose new wrapper function `Invoke-NewHireUserAutomation`
- document command and script usage
- test script and module exports

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461c31e554832ca754346323c9db6b