### PR TITLE
Automate user disabling from termination tickets

### DIFF
--- a/scripts/Process-TerminationTickets.ps1
+++ b/scripts/Process-TerminationTickets.ps1
@@ -1,0 +1,52 @@
+<#+
+.SYNOPSIS
+    Disable users automatically for termination tickets.
+.DESCRIPTION
+    Searches Service Desk for open tickets containing the word "termination" and
+    disables the referenced user account using Disable-GraphUser. Processed
+    ticket IDs are stored in a JSON file to avoid duplicate actions.
+.PARAMETER PollMinutes
+    How often to poll for new tickets. Defaults to 5 minutes.
+.PARAMETER StatePath
+    Path to the JSON file tracking processed ticket IDs.
+.PARAMETER TenantId
+    Azure AD tenant ID used when disabling accounts.
+.PARAMETER ClientId
+    Application ID for Microsoft Graph authentication.
+.PARAMETER ClientSecret
+    Optional client secret for Graph authentication.
+#>
+param(
+    [int]$PollMinutes = 5,
+    [string]$StatePath = "$PSScriptRoot/../config/terminated.json",
+    [string]$TenantId = $env:GRAPH_TENANT_ID,
+    [string]$ClientId = $env:GRAPH_CLIENT_ID,
+    [string]$ClientSecret = $env:GRAPH_CLIENT_SECRET
+)
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/EntraIDTools/EntraIDTools.psd1') -ErrorAction SilentlyContinue
+
+if (Test-Path $StatePath) { $processed = Get-Content $StatePath | ConvertFrom-Json } else { $processed = @() }
+
+while ($true) {
+    Write-STStatus 'Searching for termination tickets...' -Level INFO -Log
+    $tickets = Search-SDTicket -Query 'termination'
+    foreach ($t in $tickets) {
+        if ($processed -contains $t.Id) { continue }
+        $upn = $null
+        $pattern = '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+'
+        if ($t.Title -match $pattern) { $upn = $Matches[0] }
+        elseif ($t.RawJson -match $pattern) { $upn = $Matches[0] }
+        if ($upn) {
+            Write-STStatus "Disabling user $upn (ticket $($t.Id))" -Level INFO -Log
+            Disable-GraphUser -UserPrincipalName $upn -TenantId $TenantId -ClientId $ClientId -ClientSecret $ClientSecret
+            $processed += $t.Id
+        } else {
+            Write-STStatus "Ticket $($t.Id) missing user info" -Level WARN -Log
+        }
+    }
+    $processed | ConvertTo-Json | Out-File -FilePath $StatePath -Encoding utf8
+    Start-Sleep -Seconds ($PollMinutes * 60)
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,3 +34,4 @@ The following table provides a brief description of each script.
 | **Get-FunctionDependencyGraph.ps1** | Generates a Graphviz or Mermaid map of function calls inside a script. |
 
 | **Invoke-DailyAuditWorkflow.ps1** | Audits SharePoint permissions, logs results and opens a Service Desk ticket. |
+| **Process-TerminationTickets.ps1** | Disables users referenced in new termination tickets using Microsoft Graph. |

--- a/src/EntraIDTools/EntraIDTools.psd1
+++ b/src/EntraIDTools/EntraIDTools.psd1
@@ -11,5 +11,5 @@
             ReleaseNotes = 'Initial stable release of EntraIDTools.'
         }
     }
-    FunctionsToExport = @('Get-GraphUserDetails','Get-GraphGroupDetails','Get-UserInfoHybrid')
+    FunctionsToExport = @('Get-GraphUserDetails','Get-GraphGroupDetails','Get-UserInfoHybrid','Disable-GraphUser')
 }

--- a/src/EntraIDTools/EntraIDTools.psm1
+++ b/src/EntraIDTools/EntraIDTools.psm1
@@ -8,7 +8,7 @@ Import-Module $telemetryModule -ErrorAction SilentlyContinue
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Get-GraphUserDetails','Get-GraphGroupDetails','Get-UserInfoHybrid'
+Export-ModuleMember -Function 'Get-GraphUserDetails','Get-GraphGroupDetails','Get-UserInfoHybrid','Disable-GraphUser'
 
 function Show-EntraIDToolsBanner {
     <#

--- a/src/EntraIDTools/Public/Disable-GraphUser.ps1
+++ b/src/EntraIDTools/Public/Disable-GraphUser.ps1
@@ -1,0 +1,65 @@
+function Disable-GraphUser {
+    <#
+    .SYNOPSIS
+        Disables a user account via Microsoft Graph or Active Directory.
+    .DESCRIPTION
+        Sets accountEnabled to false using Microsoft Graph or disables the AD account when Cloud is AD.
+    .PARAMETER UserPrincipalName
+        UPN of the user to disable.
+    .PARAMETER TenantId
+        Azure AD tenant ID for Graph authentication.
+    .PARAMETER ClientId
+        Application (client) ID for Graph authentication.
+    .PARAMETER ClientSecret
+        Optional client secret for the application.
+    .PARAMETER Cloud
+        Target environment: Entra (default) or AD.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UserPrincipalName,
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TenantId,
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ClientId,
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$ClientSecret,
+        [Parameter()]
+        [ValidateSet('Entra','AD')]
+        [string]$Cloud = 'Entra'
+    )
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    Write-STLog -Message "Disable-GraphUser $UserPrincipalName" -Structured -Metadata @{ user = $UserPrincipalName }
+    $result = 'Success'
+    try {
+        if ($Cloud -eq 'Entra') {
+            $token = Get-GraphAccessToken -TenantId $TenantId -ClientId $ClientId -ClientSecret $ClientSecret
+            $headers = @{ Authorization = "Bearer $token" }
+            $url = "https://graph.microsoft.com/v1.0/users/$UserPrincipalName"
+            $body = @{ accountEnabled = $false } | ConvertTo-Json
+            if ($PSCmdlet.ShouldProcess($UserPrincipalName, 'Disable user')) {
+                Invoke-RestMethod -Uri $url -Headers $headers -Method Patch -Body $body -ContentType 'application/json'
+            }
+        } else {
+            Import-Module ActiveDirectory -ErrorAction Stop
+            if ($PSCmdlet.ShouldProcess($UserPrincipalName, 'Disable user')) {
+                Set-ADUser -Identity $UserPrincipalName -Enabled:$false -ErrorAction Stop
+            }
+        }
+        Write-STStatus "Disabled user $UserPrincipalName" -Level SUCCESS -Log
+    } catch {
+        $result = 'Failure'
+        Write-STStatus "Failed to disable $UserPrincipalName: $_" -Level ERROR -Log
+        Write-STLog -Message "Disable-GraphUser failed: $_" -Level ERROR
+        throw
+    } finally {
+        $sw.Stop()
+        Write-STTelemetryEvent -ScriptName 'Disable-GraphUser' -Result $result -Duration $sw.Elapsed
+    }
+}


### PR DESCRIPTION
## Summary
- add `Disable-GraphUser` to EntraIDTools
- export new function in EntraIDTools module
- watch Service Desk for termination tickets via new script
- document the new automation script

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(failed: Cannot convert value to PesterConfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68461d2184a8832c9016f6f0c10d4e88