### PR TITLE
Add Get-SDTicketHistory command

### DIFF
--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -7,6 +7,7 @@ Commands for interacting with the Service Desk ticketing API. **ServiceDeskTools
 | Command | Description | Example |
 |---------|-------------|---------|
 | `Get-SDTicket` | Retrieve an incident by ID | `Get-SDTicket -Id 42` |
+| `Get-SDTicketHistory` | Retrieve audit history for an incident | `Get-SDTicketHistory -Id 42` |
 | `New-SDTicket` | Create a new incident | `New-SDTicket -Subject "Printer issue" -Description "Cannot print" -RequesterEmail 'jane.doe@example.com'` |
 | `Set-SDTicket` | Update an existing incident | `Set-SDTicket -Id 42 -Fields @{ status = 'Resolved' }` |
 | `Search-SDTicket` | Search incidents by keyword | `Search-SDTicket -Query 'printer'` |

--- a/src/ServiceDeskTools/Public/Get-SDTicketHistory.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDTicketHistory.ps1
@@ -1,0 +1,29 @@
+function Get-SDTicketHistory {
+    <#
+    .SYNOPSIS
+        Retrieves audit history entries for a Service Desk incident.
+    .PARAMETER Id
+        Incident ID to retrieve history for.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [int]$Id,
+        [Parameter(Mandatory=$false)]
+        [switch]$ChaosMode,
+        [Parameter(Mandatory=$false)]
+        [switch]$Explain
+    )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
+
+    Write-STLog -Message "Get-SDTicketHistory $Id"
+    if ($PSCmdlet.ShouldProcess("ticket $Id", 'Get history')) {
+        $result = Invoke-SDRequest -Method 'GET' -Path "/incidents/$Id/audits.json" -ChaosMode:$ChaosMode
+        return $result
+    }
+}

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -6,7 +6,7 @@ Describe 'ServiceDeskTools Module' {
 
     Context 'Exported commands' {
         $expected = @(
-            'Get-SDTicket','New-SDTicket','Set-SDTicket',
+            'Get-SDTicket','Get-SDTicketHistory','New-SDTicket','Set-SDTicket',
             'Search-SDTicket','Set-SDTicketBulk','Link-SDTicketToSPTask'
         )
         $exported = (Get-Command -Module ServiceDeskTools).Name
@@ -22,6 +22,11 @@ Describe 'ServiceDeskTools Module' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Get-SDTicket -Id 1
             Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter { $Method -eq 'GET' -and $Path -eq '/incidents/1.json' } -Times 1
+        }
+        It 'Get-SDTicketHistory calls Invoke-SDRequest' {
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
+            Get-SDTicketHistory -Id 1
+            Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter { $Method -eq 'GET' -and $Path -eq '/incidents/1/audits.json' } -Times 1
         }
         It 'New-SDTicket calls Invoke-SDRequest' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools


### PR DESCRIPTION
## Summary
- add `Get-SDTicketHistory` for fetching audit history
- document new command
- test the export and request routing

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461fd1f6b0832c88337e7b3c7733de