### PR TITLE
Add Exchange error tests

### DIFF
--- a/tests/ConfigManagementTools/PublicFunctions.Tests.ps1
+++ b/tests/ConfigManagementTools/PublicFunctions.Tests.ps1
@@ -76,6 +76,20 @@ Describe 'ConfigManagementTools public functions' {
                 $res.Category | Should -Be 'Exchange'
             }
         }
+        It 'returns error object when connection fails without web login' {
+            InModuleScope ConfigManagementTools {
+                Mock Write-STStatus {}
+                Mock Write-STLog {}
+                Mock Send-STMetric {}
+                Mock Get-InstalledModule { @{ Version = [version]'1.0' } }
+                Mock Find-Module { $null }
+                Mock Import-Module {}
+                Mock Connect-ExchangeOnline { throw 'fail' }
+                Mock Disconnect-ExchangeOnline {}
+                $res = Set-SharedMailboxAutoReply @commonParams
+                $res.Category | Should -Be 'Exchange'
+            }
+        }
     }
 
     Context 'Invoke-ExchangeCalendarManager' {
@@ -98,6 +112,21 @@ Describe 'ConfigManagementTools public functions' {
                 Mock Disconnect-ExchangeOnline {}
                 Mock Read-Host { 'Q' }
                 $res = Invoke-ExchangeCalendarManager -Action Get -DisplayName 'n' -Type Building
+                $res.Category | Should -Be 'Exchange'
+            }
+        }
+        It 'returns error object when connect fails without parameters' {
+            InModuleScope ConfigManagementTools {
+                Mock Write-STStatus {}
+                Mock Write-STLog {}
+                Mock Send-STMetric {}
+                Mock Get-InstalledModule { @{ Version = [version]'1.0' } }
+                Mock Find-Module { $null }
+                Mock Import-Module {}
+                Mock Connect-ExchangeOnline { throw 'fail' }
+                Mock Disconnect-ExchangeOnline {}
+                Mock Read-Host { 'Q' }
+                $res = Invoke-ExchangeCalendarManager
                 $res.Category | Should -Be 'Exchange'
             }
         }


### PR DESCRIPTION
## Summary
- add failing connection cases for Set-SharedMailboxAutoReply
- add failing connection cases for Invoke-ExchangeCalendarManager

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461fefc87c832c86819c34c874b31b