### PR TITLE
Add Get-ServiceDeskAsset cmdlet

### DIFF
--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -7,6 +7,7 @@ Commands for interacting with the Service Desk ticketing API. **ServiceDeskTools
 | Command | Description | Example |
 |---------|-------------|---------|
 | `Get-SDTicket` | Retrieve an incident by ID | `Get-SDTicket -Id 42` |
+| `Get-ServiceDeskAsset` | Retrieve an asset by ID | `Get-ServiceDeskAsset -Id 99` |
 | `New-SDTicket` | Create a new incident | `New-SDTicket -Subject "Printer issue" -Description "Cannot print" -RequesterEmail 'jane.doe@example.com'` |
 | `Set-SDTicket` | Update an existing incident | `Set-SDTicket -Id 42 -Fields @{ status = 'Resolved' }` |
 | `Search-SDTicket` | Search incidents by keyword | `Search-SDTicket -Query 'printer'` |

--- a/docs/ServiceDeskTools/Get-ServiceDeskAsset.md
+++ b/docs/ServiceDeskTools/Get-ServiceDeskAsset.md
@@ -1,0 +1,44 @@
+---
+external help file: ServiceDeskTools-help.xml
+Module Name: ServiceDeskTools
+online version:
+schema: 2.0.0
+---
+
+# Get-ServiceDeskAsset
+
+## SYNOPSIS
+Retrieves details for a Service Desk asset.
+
+## SYNTAX
+
+```
+Get-ServiceDeskAsset [-Id] <Int32> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Queries the Service Desk API for an asset by numeric identifier.
+The command requires the asset ID and uses the `SD_API_TOKEN`
+environment variable for authentication.
+
+## PARAMETERS
+
+### -Id
+Unique numeric identifier of the asset to retrieve.
+
+### -ProgressAction
+Specifies how progress is displayed.
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### PSObject
+The asset returned by the Service Desk API.
+
+## NOTES
+
+## RELATED LINKS

--- a/src/ServiceDeskTools/Public/Get-ServiceDeskAsset.ps1
+++ b/src/ServiceDeskTools/Public/Get-ServiceDeskAsset.ps1
@@ -1,0 +1,30 @@
+function Get-ServiceDeskAsset {
+    <#
+    .SYNOPSIS
+        Retrieves details for a Service Desk asset.
+    .PARAMETER Id
+        Asset ID to retrieve.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    [OutputType([psobject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [int]$Id,
+        [Parameter(Mandatory = $false)]
+        [switch]$ChaosMode,
+        [Parameter(Mandatory = $false)]
+        [switch]$Explain
+    )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
+
+    Write-STLog -Message "Get-ServiceDeskAsset $Id"
+    if ($PSCmdlet.ShouldProcess("asset $Id", 'Get')) {
+        $result = Invoke-SDRequest -Method 'GET' -Path "/assets/$Id.json" -ChaosMode:$ChaosMode
+        return $result
+    }
+}

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -6,7 +6,7 @@ Describe 'ServiceDeskTools Module' {
 
     Context 'Exported commands' {
         $expected = @(
-            'Get-SDTicket','New-SDTicket','Set-SDTicket',
+            'Get-SDTicket','Get-ServiceDeskAsset','New-SDTicket','Set-SDTicket',
             'Search-SDTicket','Set-SDTicketBulk','Link-SDTicketToSPTask'
         )
         $exported = (Get-Command -Module ServiceDeskTools).Name
@@ -22,6 +22,11 @@ Describe 'ServiceDeskTools Module' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Get-SDTicket -Id 1
             Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter { $Method -eq 'GET' -and $Path -eq '/incidents/1.json' } -Times 1
+        }
+        It 'Get-ServiceDeskAsset calls Invoke-SDRequest' {
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
+            Get-ServiceDeskAsset -Id 4
+            Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter { $Method -eq 'GET' -and $Path -eq '/assets/4.json' } -Times 1
         }
         It 'New-SDTicket calls Invoke-SDRequest' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
@@ -71,6 +76,12 @@ Describe 'ServiceDeskTools Module' {
             Mock Write-STLog {} -ModuleName ServiceDeskTools
             Get-SDTicket -Id 5
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Get-SDTicket 5' } -Times 1
+        }
+        It 'Get-ServiceDeskAsset logs the request' {
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
+            Mock Write-STLog {} -ModuleName ServiceDeskTools
+            Get-ServiceDeskAsset -Id 6
+            Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Get-ServiceDeskAsset 6' } -Times 1
         }
         It 'New-SDTicket logs the request' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
@@ -169,6 +180,11 @@ Describe 'ServiceDeskTools Module' {
         It 'Set-SDTicket does not invoke request when -WhatIf used' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Set-SDTicket -Id 1 -Fields @{status='Open'} -WhatIf
+            Assert-MockCalled Invoke-SDRequest -Times 0 -ModuleName ServiceDeskTools
+        }
+        It 'Get-ServiceDeskAsset does not invoke request when -WhatIf used' {
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
+            Get-ServiceDeskAsset -Id 2 -WhatIf
             Assert-MockCalled Invoke-SDRequest -Times 0 -ModuleName ServiceDeskTools
         }
     }


### PR DESCRIPTION
## Summary
- add `Get-ServiceDeskAsset` cmdlet for retrieving an asset by ID
- document new command in ServiceDeskTools docs
- create help page for `Get-ServiceDeskAsset`
- extend tests for new command

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461fdd9b50832c9c30b37738bf069f