### PR TITLE
Add Start-HealthMonitor command

### DIFF
--- a/docs/MonitoringTools.md
+++ b/docs/MonitoringTools.md
@@ -1,0 +1,20 @@
+# MonitoringTools Module
+
+Provides commands for collecting system metrics and health information.
+Import the module using its manifest:
+
+```powershell
+Import-Module ./src/MonitoringTools/MonitoringTools.psd1
+```
+
+## Available Commands
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `Get-CPUUsage` | Returns the current CPU utilisation. | `Get-CPUUsage` |
+| `Get-DiskSpaceInfo` | Lists disk free space. | `Get-DiskSpaceInfo` |
+| `Get-EventLogSummary` | Counts recent error and warning events. | `Get-EventLogSummary -LogName System` |
+| `Get-SystemHealth` | Summarises CPU, disk and event log data. | `Get-SystemHealth` |
+| `Start-HealthMonitor` | Periodically log system health metrics. | `Start-HealthMonitor -IntervalSeconds 60` |
+
+See [MonitoringTools/Start-HealthMonitor.md](MonitoringTools/Start-HealthMonitor.md) for full command help.

--- a/docs/MonitoringTools/Start-HealthMonitor.md
+++ b/docs/MonitoringTools/Start-HealthMonitor.md
@@ -1,0 +1,43 @@
+---
+external help file: MonitoringTools-help.xml
+Module Name: MonitoringTools
+online version:
+schema: 2.0.0
+---
+
+# Start-HealthMonitor
+
+## SYNOPSIS
+Periodically log system health metrics.
+
+## SYNTAX
+```powershell
+Start-HealthMonitor [[-IntervalSeconds] <Int32>] [[-Count] <Int32>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+`Start-HealthMonitor` calls `Get-SystemHealth` on a recurring interval and writes each result using `Write-STRichLog`. Set `Count` to limit the number of samples; otherwise the command runs until cancelled.
+
+## EXAMPLES
+### Example 1
+```powershell
+PS C:\> Start-HealthMonitor -IntervalSeconds 30 -Count 5
+```
+Collects five health samples thirty seconds apart.
+
+## PARAMETERS
+### -IntervalSeconds
+Seconds between health checks. Default is 60.
+### -Count
+Number of samples to capture before exiting. Zero runs indefinitely.
+
+## INPUTS
+None. You cannot pipe objects to this command.
+
+## OUTPUTS
+None. This command writes structured log entries but does not return data.
+
+## NOTES
+
+## RELATED LINKS
+`Get-SystemHealth`

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ The key guides are:
 
 - [Quickstart](./Quickstart.md) – short steps to install the modules and run common commands.
 - [User Guide](./UserGuide.md) – detailed deployment information and security notes.
-- [SupportTools](./SupportTools.md), [SharePointTools](./SharePointTools.md), [ServiceDeskTools](./ServiceDeskTools.md), [ChaosTools](./ChaosTools.md) – high level summaries of each module and the commands they expose.
+ - [SupportTools](./SupportTools.md), [SharePointTools](./SharePointTools.md), [ServiceDeskTools](./ServiceDeskTools.md), [MonitoringTools](./MonitoringTools.md), [ChaosTools](./ChaosTools.md) – high level summaries of each module and the commands they expose.
 - [Credential Storage](./CredentialStorage.md) – recommended approach to store secrets securely.
 - [Module Style Guide](./ModuleStyleGuide.md) – how scripts display progress messages and log output.
 - [PerformanceTools](./PerformanceTools.md) – measure execution time and resource usage.

--- a/src/MonitoringTools/MonitoringTools.psd1
+++ b/src/MonitoringTools/MonitoringTools.psd1
@@ -6,5 +6,5 @@
     Description = 'Commands for collecting system monitoring data.'
     RequiredModules = @('Logging','Telemetry')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','Monitoring','Internal') } }
-    FunctionsToExport = @('Get-CPUUsage','Get-DiskSpaceInfo','Get-EventLogSummary','Get-SystemHealth')
+    FunctionsToExport = @('Get-CPUUsage','Get-DiskSpaceInfo','Get-EventLogSummary','Get-SystemHealth','Start-HealthMonitor')
 }

--- a/src/MonitoringTools/Public/Start-HealthMonitor.ps1
+++ b/src/MonitoringTools/Public/Start-HealthMonitor.ps1
@@ -1,0 +1,38 @@
+function Start-HealthMonitor {
+    <#
+    .SYNOPSIS
+        Periodically logs system health metrics.
+    .DESCRIPTION
+        Calls Get-SystemHealth in a loop. Each result is written to the structured
+        log using Write-STRichLog. Specify Count to limit the number of samples;
+        otherwise the command runs until cancelled.
+    .PARAMETER IntervalSeconds
+        Seconds between health checks. Defaults to 60.
+    .PARAMETER Count
+        Number of samples to collect before exiting. 0 runs indefinitely.
+    #>
+    [CmdletBinding()]
+    param(
+        [int]$IntervalSeconds = 60,
+        [int]$Count = 0
+    )
+
+    try {
+        $collected = 0
+        while ($true) {
+            $start = Get-Date
+            $health = Get-SystemHealth
+            $json = $health | ConvertTo-Json -Compress
+            Write-STRichLog -Tool 'HealthMonitor' -Status 'sample' -Details $json
+
+            $collected++
+            if ($Count -gt 0 -and $collected -ge $Count) { break }
+
+            $elapsed = (Get-Date) - $start
+            $sleep = $IntervalSeconds - [int][math]::Floor($elapsed.TotalSeconds)
+            if ($sleep -gt 0) { Start-Sleep -Seconds $sleep }
+        }
+    } catch {
+        return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
+    }
+}

--- a/tests/MonitoringTools.Tests.ps1
+++ b/tests/MonitoringTools.Tests.ps1
@@ -13,6 +13,10 @@ Describe 'MonitoringTools Module' {
         (Get-Command -Module MonitoringTools).Name | Should -Contain 'Get-SystemHealth'
     }
 
+    It 'exports Start-HealthMonitor' {
+        (Get-Command -Module MonitoringTools).Name | Should -Contain 'Start-HealthMonitor'
+    }
+
     It 'returns system health object' {
         Mock Get-CPUUsage { 10 } -ModuleName MonitoringTools
         Mock Get-DiskSpaceInfo { @() } -ModuleName MonitoringTools
@@ -20,5 +24,12 @@ Describe 'MonitoringTools Module' {
         $result = Get-SystemHealth
         $result.CpuPercent | Should -Be 10
         $result.DiskInfo   | Should -Be @()
+    }
+
+    It 'logs health samples on a loop' {
+        Mock Get-SystemHealth { @{ CpuPercent=1; DiskInfo=@(); EventLogSummary=@() } } -ModuleName MonitoringTools
+        Mock Write-STRichLog {} -ModuleName MonitoringTools
+        Start-HealthMonitor -IntervalSeconds 0 -Count 2
+        Assert-MockCalled Write-STRichLog -ModuleName MonitoringTools -Times 2
     }
 }


### PR DESCRIPTION
## Summary
- add `Start-HealthMonitor` command to MonitoringTools
- export the new command
- document health monitor usage
- reference MonitoringTools docs in the main README
- test health monitor logic

## Testing
- `pwsh -NoLogo -Command '$cfg = Import-PowerShellDataFile "./PesterConfiguration.psd1"; Invoke-Pester -Configuration $cfg'` *(fails: cannot call a method on a null-valued expression)*


------
https://chatgpt.com/codex/tasks/task_e_68461fd80a40832c8f2c1c86d3db8b89