### PR TITLE
Align TenantId parameter naming

### DIFF
--- a/docs/EntraIDTools/Get-GraphGroupDetails.md
+++ b/docs/EntraIDTools/Get-GraphGroupDetails.md
@@ -35,6 +35,7 @@ Identifier of the group to retrieve.
 
 ### -TenantId
 GUID identifier for the Azure AD tenant containing the group.
+Alias: `TenantID`, `tenantId`
 
 ### -ClientId
 Application (client) ID used for Microsoft Graph authentication.

--- a/docs/EntraIDTools/Get-GraphUserDetails.md
+++ b/docs/EntraIDTools/Get-GraphUserDetails.md
@@ -39,6 +39,7 @@ User principal name (UPN) of the account to retrieve.
 
 ### -TenantId
 GUID identifier for the Azure AD tenant containing the user.
+Alias: `TenantID`, `tenantId`
 
 ### -ClientId
 Application (client) ID used for Microsoft Graph authentication.

--- a/docs/SharePointTools/Clean-SPVersionHistory.md
+++ b/docs/SharePointTools/Clean-SPVersionHistory.md
@@ -124,6 +124,7 @@ Accept wildcard characters: False
 
 ### -TenantId
 Tenant ID used for authentication.
+Alias: `TenantID`, `tenantId`
 
 ```yaml
 Type: String

--- a/docs/SharePointTools/Get-SPPermissionsReport.md
+++ b/docs/SharePointTools/Get-SPPermissionsReport.md
@@ -93,6 +93,7 @@ Accept wildcard characters: False
 
 ### -TenantId
 Tenant ID used for authentication.
+Alias: `TenantID`, `tenantId`
 
 ```yaml
 Type: String

--- a/docs/SharePointTools/Invoke-ArchiveCleanup.md
+++ b/docs/SharePointTools/Invoke-ArchiveCleanup.md
@@ -94,6 +94,7 @@ Accept wildcard characters: False
 
 ### -TenantId
 Tenant ID used for authentication.
+Alias: `TenantID`, `tenantId`
 
 ```yaml
 Type: String

--- a/src/EntraIDTools/Private/Get-GraphAccessToken.ps1
+++ b/src/EntraIDTools/Private/Get-GraphAccessToken.ps1
@@ -6,6 +6,7 @@ function Get-GraphAccessToken {
     [CmdletBinding()]
     param(
         [ValidateNotNullOrEmpty()]
+        [Alias('TenantID','tenantId')]
         [string]$TenantId,
         [ValidateNotNullOrEmpty()]
         [string]$ClientId,

--- a/src/EntraIDTools/Public/Get-GraphGroupDetails.ps1
+++ b/src/EntraIDTools/Public/Get-GraphGroupDetails.ps1
@@ -12,6 +12,7 @@ function Get-GraphGroupDetails {
         [string]$GroupId,
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias('TenantID','tenantId')]
         [string]$TenantId,
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]

--- a/src/EntraIDTools/Public/Get-GraphUserDetails.ps1
+++ b/src/EntraIDTools/Public/Get-GraphUserDetails.ps1
@@ -50,6 +50,7 @@ function Get-GraphUserDetails {
         [string]$UserPrincipalName,
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias('TenantID','tenantId')]
         [string]$TenantId,
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]

--- a/src/EntraIDTools/Public/Get-UserInfoHybrid.ps1
+++ b/src/EntraIDTools/Public/Get-UserInfoHybrid.ps1
@@ -26,6 +26,7 @@ function Get-UserInfoHybrid {
         [string]$UserPrincipalName,
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias('TenantID','tenantId')]
         [string]$TenantId,
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -102,6 +102,7 @@ function Connect-SPToolsOnline {
         [string]$ClientId,
         [Parameter(Mandatory, ParameterSetName='Certificate')]
         [Parameter(Mandatory, ParameterSetName='Secret')]
+        [Alias('TenantID','tenantId')]
         [string]$TenantId,
         [Parameter(Mandatory, ParameterSetName='Certificate')]
         [string]$CertPath,
@@ -406,6 +407,11 @@ function Invoke-ArchiveCleanup {
         [ValidateNotNullOrEmpty()]
         [string]$LibraryName = 'Shared Documents',
         [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [Alias('TenantID','tenantId')]
+        [Alias('TenantID','tenantId')]
+        [Alias('TenantID','tenantId')]
+        [Alias('TenantID','tenantId')]
+        [Alias('TenantID','tenantId')]
         [string]$TenantId = $SharePointToolsSettings.TenantId,
         [string]$CertPath = $SharePointToolsSettings.CertPath,
         [string]$TranscriptPath
@@ -543,6 +549,7 @@ function Invoke-FileVersionCleanup {
         [ValidateNotNullOrEmpty()]
         [string]$LibraryName = 'Shared Documents',
         [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [Alias('TenantID','tenantId')]
         [string]$TenantId = $SharePointToolsSettings.TenantId,
         [string]$CertPath = $SharePointToolsSettings.CertPath,
         [string]$ReportPath = 'exportedReport.csv'
@@ -599,6 +606,7 @@ function Invoke-SharingLinkCleanup {
         [string]$LibraryName = 'Shared Documents',
         [string]$FolderName,
         [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [Alias('TenantID','tenantId')]
         [string]$TenantId = $SharePointToolsSettings.TenantId,
         [string]$CertPath = $SharePointToolsSettings.CertPath,
         [string]$TranscriptPath
@@ -720,6 +728,7 @@ function Get-SPToolsLibraryReport {
         [ValidateScript({ $_ -match '^https?://' })]
         [string]$SiteUrl,
         [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [Alias('TenantID','tenantId')]
         [string]$TenantId = $SharePointToolsSettings.TenantId,
         [string]$CertPath = $SharePointToolsSettings.CertPath
     )
@@ -790,6 +799,7 @@ function Get-SPToolsRecycleBinReport {
         [ValidateScript({ $_ -match '^https?://' })]
         [string]$SiteUrl,
         [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [Alias('TenantID','tenantId')]
         [string]$TenantId = $SharePointToolsSettings.TenantId,
         [string]$CertPath = $SharePointToolsSettings.CertPath
     )
@@ -830,6 +840,7 @@ function Clear-SPToolsRecycleBin {
         [string]$SiteUrl,
         [switch]$SecondStage,
         [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [Alias('TenantID','tenantId')]
         [string]$TenantId = $SharePointToolsSettings.TenantId,
         [string]$CertPath = $SharePointToolsSettings.CertPath
     )
@@ -888,6 +899,7 @@ function Get-SPToolsPreservationHoldReport {
         [ValidateScript({ $_ -match '^https?://' })]
         [string]$SiteUrl,
         [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [Alias('TenantID','tenantId')]
         [string]$TenantId = $SharePointToolsSettings.TenantId,
         [string]$CertPath = $SharePointToolsSettings.CertPath
     )
@@ -944,6 +956,7 @@ function Get-SPPermissionsReport {
         [string]$SiteUrl,
         [string]$FolderUrl,
         [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [Alias('TenantID','tenantId')]
         [string]$TenantId = $SharePointToolsSettings.TenantId,
         [string]$CertPath = $SharePointToolsSettings.CertPath
     )
@@ -990,6 +1003,7 @@ function Clean-SPVersionHistory {
         [ValidateRange(1, [int]::MaxValue)]
         [int]$KeepVersions = 5,
         [string]$ClientId = $SharePointToolsSettings.ClientId,
+        [Alias('TenantID','tenantId')]
         [string]$TenantId = $SharePointToolsSettings.TenantId,
         [string]$CertPath = $SharePointToolsSettings.CertPath
     )


### PR DESCRIPTION
## Summary
- add `TenantID` and `tenantId` aliases for all `TenantId` parameters
- document the new aliases in EntraIDTools and SharePointTools help files

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(failed: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461fe78220832c8ee367f7927ca213