### PR TITLE
Add Get-SystemHealth Pester test

### DIFF
--- a/tests/MonitoringTools/Get-SystemHealth.Tests.ps1
+++ b/tests/MonitoringTools/Get-SystemHealth.Tests.ps1
@@ -1,0 +1,20 @@
+Describe 'Get-SystemHealth function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/MonitoringTools/MonitoringTools.psd1 -Force
+    }
+
+    It 'returns expected health object' {
+        Mock Get-CPUUsage { 42 } -ModuleName MonitoringTools
+        $disk = @([pscustomobject]@{ Drive='C:'; SizeGB=100; FreeGB=50 })
+        Mock Get-DiskSpaceInfo { $disk } -ModuleName MonitoringTools
+        $events = @([pscustomobject]@{ Name='Error'; Count=1 })
+        Mock Get-EventLogSummary { $events } -ModuleName MonitoringTools
+
+        $result = Get-SystemHealth
+        $result.CpuPercent | Should -Be 42
+        $result.DiskInfo | Should -Be $disk
+        $result.EventLogSummary | Should -Be $events
+    }
+}


### PR DESCRIPTION
## Summary
- add new MonitoringTools tests folder
- test Get-SystemHealth with mocked dependencies

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461fecd7e8832cb42c46582a47f51b