### PR TITLE
Add STDashboard command

### DIFF
--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -46,3 +46,4 @@ The table below lists each command and the script it invokes. Arguments not list
 | `Sync-SupportTools` | *git* | `[RepositoryUrl]`, `[InstallPath]` | `Sync-SupportTools` |
 | `New-SPUsageReport` | `Generate-SPUsageReport.ps1` | `[ItemThreshold]`, `[RequesterEmail]`, `[CsvPath]`, `[TranscriptPath]` | `New-SPUsageReport -RequesterEmail 'user@contoso.com'` |
 | `Invoke-NewHireUserAutomation` | `Create-NewHireUser.ps1` | `[PollMinutes]`, `[-Once]` | `Invoke-NewHireUserAutomation -Once` |
+| `New-STDashboard` | *built-in* | `[LogPath]`, `[TelemetryLogPath]`, `[OutputPath]` | `New-STDashboard` |

--- a/src/SupportTools/Public/New-STDashboard.ps1
+++ b/src/SupportTools/Public/New-STDashboard.ps1
@@ -1,0 +1,71 @@
+function New-STDashboard {
+    <#
+    .SYNOPSIS
+        Generates an HTML dashboard summarizing logs and telemetry metrics.
+    .DESCRIPTION
+        Reads SupportTools log files and telemetry events then creates a simple
+        HTML page showing the latest log lines and aggregated metrics.
+    .PARAMETER LogPath
+        Optional path to the structured log file. Defaults to $env:ST_LOG_PATH or
+        ~/SupportToolsLogs/supporttools.log.
+    .PARAMETER TelemetryLogPath
+        Optional path to the telemetry log file. Defaults to $env:ST_TELEMETRY_PATH
+        or ~/SupportToolsTelemetry/telemetry.jsonl.
+    .PARAMETER OutputPath
+        Optional path for the resulting HTML file. A timestamped file is created
+        in the current directory when omitted.
+    .EXAMPLE
+        New-STDashboard -LogPath log.txt -TelemetryLogPath telemetry.jsonl
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$LogPath,
+        [string]$TelemetryLogPath,
+        [string]$OutputPath
+    )
+    try {
+        if (-not $OutputPath) {
+            $OutputPath = Join-Path (Get-Location) "STDashboard_$((Get-Date).ToString('yyyyMMdd_HHmmss')).html"
+        }
+        if (-not $LogPath) {
+            if ($env:ST_LOG_PATH) { $LogPath = $env:ST_LOG_PATH }
+            else { $LogPath = Join-Path $HOME 'SupportToolsLogs/supporttools.log' }
+        }
+        if (-not $TelemetryLogPath) {
+            if ($env:ST_TELEMETRY_PATH) { $TelemetryLogPath = $env:ST_TELEMETRY_PATH }
+            else { $TelemetryLogPath = Join-Path $HOME 'SupportToolsTelemetry/telemetry.jsonl' }
+        }
+
+        $logLines = if (Test-Path $LogPath) { Get-Content $LogPath -Tail 20 } else { @() }
+        $metrics  = if (Test-Path $TelemetryLogPath) { Get-STTelemetryMetrics -LogPath $TelemetryLogPath } else { @() }
+
+        $html = @()
+        $html += '<html><head><title>Support Tools Dashboard</title></head><body>'
+        $html += '<h1>Support Tools Dashboard</h1>'
+        $html += '<h2>Recent Log Entries</h2>'
+        if ($logLines.Count -gt 0) {
+            $html += '<pre>'
+            $html += ($logLines | ForEach-Object { $_ -replace '<','&lt;' -replace '>','&gt;' }) -join "`n"
+            $html += '</pre>'
+        } else {
+            $html += '<p>No log entries found.</p>'
+        }
+        $html += '<h2>Telemetry Metrics</h2>'
+        if ($metrics.Count -gt 0) {
+            $html += '<table border="1"><tr><th>Script</th><th>Executions</th><th>Successes</th><th>Failures</th><th>AverageSeconds</th><th>LastRun</th></tr>'
+            foreach ($m in $metrics) {
+                $html += "<tr><td>$($m.Script)</td><td>$($m.Executions)</td><td>$($m.Successes)</td><td>$($m.Failures)</td><td>$($m.AverageSeconds)</td><td>$($m.LastRun)</td></tr>"
+            }
+            $html += '</table>'
+        } else {
+            $html += '<p>No telemetry metrics found.</p>'
+        }
+        $html += '</body></html>'
+
+        $html -join "`n" | Out-File -FilePath $OutputPath -Encoding utf8
+        Write-STStatus "Dashboard saved to $OutputPath" -Level SUCCESS
+        return $OutputPath
+    } catch {
+        return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
+    }
+}

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -33,6 +33,7 @@
         'Search-ReadMe',
         'Start-Countdown',
         'Export-ITReport',
+        'New-STDashboard',
         'Sync-SupportTools',
         'Invoke-NewHireUserAutomation'
     )

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -34,6 +34,7 @@ Export-ModuleMember -Function @(
     'Search-ReadMe',
     'Start-Countdown',
     'Export-ITReport',
+    'New-STDashboard',
     'Sync-SupportTools',
     'Invoke-NewHireUserAutomation'
 )

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -19,6 +19,7 @@ Describe 'SupportTools Module' {
             'Start-Countdown',
             'Export-ITReport',
             'New-SPUsageReport',
+            'New-STDashboard',
             'Invoke-NewHireUserAutomation'
             'Sync-SupportTools',
             'Invoke-JobBundle',

--- a/tests/SupportTools/New-STDashboard.Tests.ps1
+++ b/tests/SupportTools/New-STDashboard.Tests.ps1
@@ -1,0 +1,25 @@
+Describe 'New-STDashboard function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force
+    }
+
+    It 'creates an HTML dashboard with metrics' {
+        $log = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString() + '.log')
+        $tlog = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString() + '.jsonl')
+        $out = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString() + '.html')
+        try {
+            'sample log' | Set-Content -Path $log
+            @{Timestamp='2024-01-01T00:00:00Z'; Script='test.ps1'; Result='Success'; Duration=1} |
+                ConvertTo-Json -Compress | Set-Content -Path $tlog
+            New-STDashboard -LogPath $log -TelemetryLogPath $tlog -OutputPath $out | Out-Null
+            Test-Path $out | Should -Be $true
+            $content = Get-Content $out -Raw
+            $content | Should -Match '<html>'
+            $content | Should -Match '<table'
+        } finally {
+            Remove-Item $log,$tlog,$out -ErrorAction SilentlyContinue
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `New-STDashboard` command to output HTML with log and telemetry metrics
- document the new command in SupportTools docs
- export `New-STDashboard` from module
- test exported command list
- add basic Pester test for dashboard HTML

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile './PesterConfiguration.psd1')` *(fails: required modules not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_68461fd62b50832cba3f96250c6e609a