### PR TITLE
Fix STCore config parsing

### DIFF
--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -85,12 +85,12 @@ function Get-STConfig {
     try {
         $ext = [IO.Path]::GetExtension($Path).ToLower()
         switch ($ext) {
-            '.json' { return Get-Content $Path | ConvertFrom-Json }
+            '.json' { return Get-Content $Path | ConvertFrom-Json -AsHashtable }
             '.psd1' { return Import-PowerShellDataFile $Path }
             default { throw "Unsupported config type: $ext" }
         }
     } catch {
-        Write-STDebug "Failed to read config $Path: $_"
+        Write-STDebug "Failed to read config ${Path}: $_"
         return @{}
     }
 }


### PR DESCRIPTION
## Summary
- ensure colon in error message is parsed correctly
- return hashtables from Get-STConfig for JSON files

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: numerous test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68461f55e0f4832ca6252da2b73b878e