### PR TITLE
Add Get-ServiceDeskAsset cmdlet

### DIFF
--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -11,6 +11,7 @@ Commands for interacting with the Service Desk ticketing API. **ServiceDeskTools
 | `New-SDTicket` | Create a new incident | `New-SDTicket -Subject "Printer issue" -Description "Cannot print" -RequesterEmail 'jane.doe@example.com'` |
 | `Set-SDTicket` | Update an existing incident | `Set-SDTicket -Id 42 -Fields @{ status = 'Resolved' }` |
 | `Search-SDTicket` | Search incidents by keyword | `Search-SDTicket -Query 'printer'` |
+| `Get-ServiceDeskAsset` | Retrieve an asset by ID | `Get-ServiceDeskAsset -Id 99` |
 | `Set-SDTicketBulk` | Apply updates to multiple incidents | `Set-SDTicketBulk -Id 1,2,3 -Fields @{ status='Closed' }` |
 | `Link-SDTicketToSPTask` | Add a related SharePoint task link | `Link-SDTicketToSPTask -TicketId 42 -TaskUrl 'https://contoso.sharepoint.com/tasks/1'` |
 | `Submit-Ticket` | Create a Service Desk incident with minimal parameters | `Submit-Ticket -Subject 'Alert' -Description 'Issue detected' -RequesterEmail 'ops@example.com'` |

--- a/docs/ServiceDeskTools/Get-ServiceDeskAsset.md
+++ b/docs/ServiceDeskTools/Get-ServiceDeskAsset.md
@@ -1,0 +1,42 @@
+---
+external help file: ServiceDeskTools-help.xml
+Module Name: ServiceDeskTools
+online version:
+schema: 2.0.0
+---
+
+# Get-ServiceDeskAsset
+
+## SYNOPSIS
+Retrieves details for a Service Desk asset.
+
+## SYNTAX
+
+```
+Get-ServiceDeskAsset [-Id] <Int32> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Queries the Service Desk API for a single asset and returns the full asset object.
+
+## PARAMETERS
+
+### -Id
+Unique numeric identifier of the asset to retrieve.
+
+### -ProgressAction
+Specifies how progress is displayed.
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### PSObject
+Asset returned from the Service Desk API.
+
+## NOTES
+
+## RELATED LINKS

--- a/src/ServiceDeskTools/Public/Get-ServiceDeskAsset.ps1
+++ b/src/ServiceDeskTools/Public/Get-ServiceDeskAsset.ps1
@@ -1,0 +1,28 @@
+function Get-ServiceDeskAsset {
+    <#
+    .SYNOPSIS
+        Retrieves asset details from the Service Desk.
+    .PARAMETER Id
+        Asset ID to retrieve.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [int]$Id,
+        [Parameter(Mandatory=$false)]
+        [switch]$ChaosMode,
+        [Parameter(Mandatory=$false)]
+        [switch]$Explain
+    )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
+
+    Write-STLog -Message "Get-ServiceDeskAsset $Id"
+    if ($PSCmdlet.ShouldProcess("asset $Id", 'Get')) {
+        return Invoke-SDRequest -Method 'GET' -Path "/assets/$Id.json" -ChaosMode:$ChaosMode
+    }
+}

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -7,7 +7,7 @@ Describe 'ServiceDeskTools Module' {
     Context 'Exported commands' {
         $expected = @(
             'Get-SDTicket','Get-SDTicketHistory','New-SDTicket','Set-SDTicket',
-            'Search-SDTicket','Set-SDTicketBulk','Link-SDTicketToSPTask'
+            'Search-SDTicket','Get-ServiceDeskAsset','Set-SDTicketBulk','Link-SDTicketToSPTask'
         )
         $exported = (Get-Command -Module ServiceDeskTools).Name
         foreach ($cmd in $expected) {
@@ -55,6 +55,13 @@ Describe 'ServiceDeskTools Module' {
                 $Method -eq 'GET' -and $Path -eq '/incidents.json?search=error'
             } -Times 1
         }
+        It 'Get-ServiceDeskAsset calls Invoke-SDRequest' {
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
+            Get-ServiceDeskAsset -Id 4
+            Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter {
+                $Method -eq 'GET' -and $Path -eq '/assets/4.json'
+            } -Times 1
+        }
         It 'Set-SDTicketBulk calls Set-SDTicket for each id' {
             Mock Set-SDTicket {} -ModuleName ServiceDeskTools
             Set-SDTicketBulk -Id 10,11 -Fields @{status='Closed'}
@@ -94,6 +101,12 @@ Describe 'ServiceDeskTools Module' {
             Mock Write-STLog {} -ModuleName ServiceDeskTools
             Search-SDTicket -Query 'fail'
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Search-SDTicket fail' } -Times 1
+        }
+        It 'Get-ServiceDeskAsset logs the request' {
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
+            Mock Write-STLog {} -ModuleName ServiceDeskTools
+            Get-ServiceDeskAsset -Id 6
+            Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Get-ServiceDeskAsset 6' } -Times 1
         }
         It 'Set-SDTicketBulk logs each id' {
             Mock Set-SDTicket {} -ModuleName ServiceDeskTools


### PR DESCRIPTION
## Summary
- add new Get-ServiceDeskAsset function
- document Get-ServiceDeskAsset usage
- mention new command in ServiceDeskTools overview
- test exports, routing and logging for Get-ServiceDeskAsset

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846217a3db4832c82bd624573578afc