### PR TITLE
Document logging defaults and structured mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ module see [docs/CredentialStorage.md](docs/CredentialStorage.md).
 Commands automatically record their activity to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default.
 Set the `ST_LOG_PATH` environment variable or use the `-Path` parameter of `Write-STLog` to write logs to a custom location.
 Use `-Structured` to emit JSON lines that include the current user and script name for ingestion into tools like Azure Log Analytics.
-Set `ST_LOG_STRUCTURED=1` to enable structured output without adding the switch each time.
+Set `ST_LOG_STRUCTURED=1` to enable structured output without adding the switch each time. The resulting format is shown in [docs/Logging/RichLogFormat.md](docs/Logging/RichLogFormat.md).
+For a full description of logging options see [docs/Logging/Write-STLog.md](docs/Logging/Write-STLog.md).
 Set `ST_LOG_MAX_BYTES` to control when logs rotate. Files over the limit (default 1 MB) are renamed with a `.1` suffix.
 Use `-Metric` and `-Value` with `Write-STLog` to capture performance data like durations.
 Review the resulting log file with `Get-Content` when troubleshooting.

--- a/docs/ChaosTools.md
+++ b/docs/ChaosTools.md
@@ -7,6 +7,8 @@ Import the module with its manifest:
 Import-Module ./src/ChaosTools/ChaosTools.psd1
 ```
 
+Chaos commands log to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default. Specify `$env:ST_LOG_PATH` to change the location. Structured JSON output is enabled with `ST_LOG_STRUCTURED=1` (see [Logging/RichLogFormat.md](Logging/RichLogFormat.md)).
+
 ## Available Commands
 
 | Command | Description | Example |

--- a/docs/ConfigManagementTools.md
+++ b/docs/ConfigManagementTools.md
@@ -6,6 +6,8 @@ Import the module using its manifest:
 Import-Module ./src/ConfigManagementTools/ConfigManagementTools.psd1
 ```
 
+Logs are written to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default. Override with `$env:ST_LOG_PATH`. Set `ST_LOG_STRUCTURED=1` for JSON output; see [Logging/RichLogFormat.md](Logging/RichLogFormat.md).
+
 ## Available Commands
 
 | Command | Description | Example |

--- a/docs/EntraIDTools.md
+++ b/docs/EntraIDTools.md
@@ -6,6 +6,8 @@ Commands that query Microsoft Graph for tenant data. Import the module:
 Import-Module ./src/EntraIDTools/EntraIDTools.psd1
 ```
 
+Logs are written to `%USERPROFILE%\SupportToolsLogs\supporttools.log` unless `$env:ST_LOG_PATH` is provided. Enable `ST_LOG_STRUCTURED=1` to produce JSON logs; see [Logging/RichLogFormat.md](Logging/RichLogFormat.md).
+
 This module depends on the **MSAL.PS** module which provides the `Get-MsalToken`
 command used for authentication. Install the dependency from the PowerShell
 Gallery first:

--- a/docs/IncidentResponseTools.md
+++ b/docs/IncidentResponseTools.md
@@ -6,6 +6,8 @@ Import the module using its manifest:
 Import-Module ./src/IncidentResponseTools/IncidentResponseTools.psd1
 ```
 
+All commands log to `%USERPROFILE%\SupportToolsLogs\supporttools.log` unless `$env:ST_LOG_PATH` is set. Use `ST_LOG_STRUCTURED=1` to capture structured JSON entries; see [Logging/RichLogFormat.md](Logging/RichLogFormat.md).
+
 ## Available Commands
 
 | Command | Description | Example |

--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -21,6 +21,8 @@ Write-STLog [-Message] <String> [[-Level] <String>] [[-Path] <String>] [-Progres
 
 ## DESCRIPTION
 Used by scripts and modules to record log messages in a consistent format.
+Logs default to `%USERPROFILE%\SupportToolsLogs\supporttools.log` unless
+`$env:ST_LOG_PATH` specifies another location.
 
 ## EXAMPLES
 
@@ -67,7 +69,8 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Custom path to the log file. Overrides the default location and the `ST_LOG_PATH`
+Custom path to the log file. Overrides the default log at
+`%USERPROFILE%\SupportToolsLogs\supporttools.log` and the `ST_LOG_PATH`
 environment variable.
 
 ```yaml
@@ -97,7 +100,7 @@ Accept wildcard characters: False
 ```
 
 ### -Structured
-Outputs the log entry as a JSON object. Set the `ST_LOG_STRUCTURED` environment variable to `1` to enable structured output by default.
+Outputs the log entry as a JSON object. Set the `ST_LOG_STRUCTURED` environment variable to `1` to enable structured output by default. The resulting schema is shown in [RichLogFormat](RichLogFormat.md).
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
@@ -169,3 +172,4 @@ Logs rotate automatically when their size exceeds `ST_LOG_MAX_BYTES` (default
 started.
 
 ## RELATED LINKS
+[RichLogFormat](RichLogFormat.md)

--- a/docs/ModuleStyleGuide.md
+++ b/docs/ModuleStyleGuide.md
@@ -21,6 +21,5 @@ Write-STBlock @{ 'User'='svc-backend'; 'Domain'='corp.local'; 'IP'='10.10.10.5' 
 Write-STClosing
 ```
 
-All messages can also be logged to `%USERPROFILE%\SupportToolsLogs\supporttools.log` using the `-Log` switch or by setting `ST_LOG_PATH`.
-Use the `-Structured` parameter of `Write-STLog` to output JSON lines with extra metadata for ingestion into a centralized dashboard.
-Set the `ST_LOG_STRUCTURED` environment variable to `1` to enable structured output automatically.
+Logs are written to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default. Override the path with `$env:ST_LOG_PATH` or the `-Log` switch.
+Use the `-Structured` parameter of `Write-STLog` or set `ST_LOG_STRUCTURED=1` to output JSON lines in the [RichLogFormat](Logging/RichLogFormat.md) for dashboards.

--- a/docs/MonitoringTools.md
+++ b/docs/MonitoringTools.md
@@ -7,6 +7,8 @@ Import the module using its manifest:
 Import-Module ./src/MonitoringTools/MonitoringTools.psd1
 ```
 
+Log entries are written to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default. Specify `$env:ST_LOG_PATH` for a custom path. Set `ST_LOG_STRUCTURED=1` to record JSON formatted events (see [Logging/RichLogFormat.md](Logging/RichLogFormat.md)).
+
 ## Available Commands
 
 | Command | Description | Example |

--- a/docs/PerformanceTools.md
+++ b/docs/PerformanceTools.md
@@ -6,6 +6,8 @@ Provides helper commands for measuring script performance. Import the module usi
 Import-Module ./src/PerformanceTools/PerformanceTools.psd1
 ```
 
+Performance logs are written to `%USERPROFILE%\SupportToolsLogs\supporttools.log` unless `$env:ST_LOG_PATH` is set. Enable `ST_LOG_STRUCTURED=1` for JSON output. See [Logging/RichLogFormat.md](Logging/RichLogFormat.md).
+
 ## Available Commands
 
 | Command | Description |

--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -2,6 +2,8 @@
 
 Commands for interacting with the Service Desk ticketing API. **ServiceDeskTools is now considered Stable** and is fully supported for production use.
 
+Logs are written to `%USERPROFILE%\SupportToolsLogs\supporttools.log` unless `$env:ST_LOG_PATH` is set. Set `ST_LOG_STRUCTURED=1` for JSON-formatted events; see [Logging/RichLogFormat.md](Logging/RichLogFormat.md).
+
 ## Available Commands
 
 | Command | Description | Example |

--- a/docs/SharePointTools.md
+++ b/docs/SharePointTools.md
@@ -6,6 +6,8 @@ This module provides SharePoint cleanup and reporting utilities. Import the modu
 Import-Module ./src/SharePointTools/SharePointTools.psd1
 ```
 
+Logs are written to `%USERPROFILE%\SupportToolsLogs\supporttools.log` unless `$env:ST_LOG_PATH` overrides the path. Enable `ST_LOG_STRUCTURED=1` to capture JSON events; see [Logging/RichLogFormat.md](Logging/RichLogFormat.md).
+
 Validate prerequisites using `Test-SPToolsPrereqs`:
 
 ```powershell

--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -8,6 +8,8 @@ Import-Module ./src/SupportTools/SupportTools.psd1
 
 For a guided experience, run `./scripts/SupportToolsMenu.ps1` with the optional `-UserRole` parameter to select common tasks from an interactive menu tailored for `Helpdesk` or `Site Admin` roles. To browse and execute any script in the repository, use `./scripts/ScriptLauncher.ps1` for a general menu of options.
 
+All commands log to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default. Set `$env:ST_LOG_PATH` to choose a different location. Set `ST_LOG_STRUCTURED=1` to record JSON entries; see [Logging/RichLogFormat.md](Logging/RichLogFormat.md).
+
 ### Simulation Mode
 
 All commands now accept a `-Simulate` switch. When used, the command logs each step and returns randomized mock data without making changes. This is useful for testing in lab environments.


### PR DESCRIPTION
## Summary
- document default log paths and ST_LOG_PATH
- explain ST_LOG_STRUCTURED and link to the JSON example
- add logging notes in module docs and README

## Testing
- `pwsh -NoLogo -Command Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684624385984832cb62be7a108842a65