### PR TITLE
Add Add-SDTicketComment cmdlet

### DIFF
--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -10,6 +10,7 @@ Commands for interacting with the Service Desk ticketing API. **ServiceDeskTools
 | `Get-SDTicketHistory` | Retrieve audit history for an incident | `Get-SDTicketHistory -Id 42` |
 | `New-SDTicket` | Create a new incident | `New-SDTicket -Subject "Printer issue" -Description "Cannot print" -RequesterEmail 'jane.doe@example.com'` |
 | `Set-SDTicket` | Update an existing incident | `Set-SDTicket -Id 42 -Fields @{ status = 'Resolved' }` |
+| `Add-SDTicketComment` | Add a comment to an incident | `Add-SDTicketComment -Id 42 -Comment 'Investigating'` |
 | `Search-SDTicket` | Search incidents by keyword | `Search-SDTicket -Query 'printer'` |
 | `Get-ServiceDeskAsset` | Retrieve an asset by ID | `Get-ServiceDeskAsset -Id 99` |
 | `Set-SDTicketBulk` | Apply updates to multiple incidents | `Set-SDTicketBulk -Id 1,2,3 -Fields @{ status='Closed' }` |

--- a/docs/ServiceDeskTools/Add-SDTicketComment.md
+++ b/docs/ServiceDeskTools/Add-SDTicketComment.md
@@ -1,0 +1,42 @@
+---
+external help file: ServiceDeskTools-help.xml
+Module Name: ServiceDeskTools
+online version:
+schema: 2.0.0
+---
+
+# Add-SDTicketComment
+
+## SYNOPSIS
+Adds a comment to a Service Desk incident.
+
+## SYNTAX
+
+```
+Add-SDTicketComment [-Id] <Int32> [-Comment] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Sends a POST request to the Service Desk API to append a comment to an existing incident.
+
+## PARAMETERS
+
+### -Id
+Incident ID to update.
+
+### -Comment
+Text body of the comment.
+
+### -ProgressAction
+Specifies how progress is displayed.
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/ServiceDeskTools/ReleaseNotes.md
+++ b/docs/ServiceDeskTools/ReleaseNotes.md
@@ -7,3 +7,6 @@
 
 ## 1.2.0 - 2025-06-08
 - Improved `Invoke-SDRequest` with rate limiting, retry logic and verbose logging.
+
+## 1.3.0 - 2025-06-09
+- Added `Add-SDTicketComment` to post comments on incidents.

--- a/src/ServiceDeskTools/Public/Add-SDTicketComment.ps1
+++ b/src/ServiceDeskTools/Public/Add-SDTicketComment.ps1
@@ -1,0 +1,34 @@
+function Add-SDTicketComment {
+    <#
+    .SYNOPSIS
+        Adds a comment to a Service Desk incident.
+    .PARAMETER Id
+        Incident ID to update.
+    .PARAMETER Comment
+        Text body of the comment.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [int]$Id,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Comment,
+        [Parameter(Mandatory=$false)]
+        [switch]$ChaosMode,
+        [Parameter(Mandatory=$false)]
+        [switch]$Explain
+    )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
+
+    Write-STLog -Message "Add-SDTicketComment $Id"
+    $body = @{ comment = @{ body = $Comment } }
+    if ($PSCmdlet.ShouldProcess("ticket $Id", 'Add comment')) {
+        Invoke-SDRequest -Method 'POST' -Path "/incidents/$Id/comments.json" -Body $body -ChaosMode:$ChaosMode
+    }
+}

--- a/src/ServiceDeskTools/ServiceDeskTools.psd1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'ServiceDeskTools.psm1'
-    ModuleVersion = '1.1.0'
+    ModuleVersion = '1.3.0'
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000003'
     Author = 'Contoso'
     Description = 'Commands for interacting with the Service Desk ticketing system.'

--- a/tests/ServiceDeskTools/Add-SDTicketComment.Tests.ps1
+++ b/tests/ServiceDeskTools/Add-SDTicketComment.Tests.ps1
@@ -1,0 +1,28 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Add-SDTicketComment' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
+    }
+
+    It 'returns API response on success' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { @{ ok = $true } }
+            $res = Add-SDTicketComment -Id 1 -Comment 'done'
+            Assert-MockCalled Invoke-SDRequest -Times 1 -ParameterFilter {
+                $Method -eq 'POST' -and
+                $Path -eq '/incidents/1/comments.json' -and
+                $Body.comment.body -eq 'done'
+            }
+            $res.ok | Should -Be $true
+        }
+    }
+
+    It 'throws when Invoke-SDRequest fails' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { throw 'bad' }
+            { Add-SDTicketComment -Id 2 -Comment 'x' } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Add-SDTicketComment` command for posting ticket comments
- export new command and bump ServiceDeskTools version
- document the new command
- expand ServiceDeskTools tests
- cover success and failure for Add-SDTicketComment

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68462477d9e0832ca9a555495ce38acf