### PR TITLE
Improve logging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ module see [docs/CredentialStorage.md](docs/CredentialStorage.md).
 
 ## Centralized Logging 📝
 
-Commands automatically record their activity to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default.
+Commands automatically record their activity to `%USERPROFILE%\SupportToolsLogs\supporttools.log` if `$env:ST_LOG_PATH` is not defined.
 Set the `ST_LOG_PATH` environment variable or use the `-Path` parameter of `Write-STLog` to write logs to a custom location.
 Use `-Structured` to emit JSON lines that include the current user and script name for ingestion into tools like Azure Log Analytics.
-Set `ST_LOG_STRUCTURED=1` to enable structured output without adding the switch each time.
+Set `ST_LOG_STRUCTURED=1` to enable structured output without adding the switch each time. The rich JSON format is described in [RichLogFormat.md](docs/Logging/RichLogFormat.md).
 Set `ST_LOG_MAX_BYTES` to control when logs rotate. Files over the limit (default 1 MB) are renamed with a `.1` suffix.
 Use `-Metric` and `-Value` with `Write-STLog` to capture performance data like durations.
 Review the resulting log file with `Get-Content` when troubleshooting.

--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -20,7 +20,10 @@ Write-STLog [-Message] <String> [[-Level] <String>] [[-Path] <String>] [-Progres
 ```
 
 ## DESCRIPTION
-Used by scripts and modules to record log messages in a consistent format.
+Used by scripts and modules to record log messages in a consistent format. Entries are written
+to `%USERPROFILE%\SupportToolsLogs\supporttools.log` unless `$env:ST_LOG_PATH` is set.
+Setting `ST_LOG_STRUCTURED=1` makes `Write-STLog` emit JSON lines by default. The
+[RichLogFormat](RichLogFormat.md) document shows an example of the structured output.
 
 ## EXAMPLES
 

--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -27,6 +27,11 @@ if ($result -is [System.Management.Automation.ErrorRecord]) {
 }
 ```
 
+### Logging
+
+All functions write logs to `%USERPROFILE%\SupportToolsLogs\supporttools.log` unless `$env:ST_LOG_PATH` is set.
+Set `ST_LOG_STRUCTURED=1` to automatically emit structured entries. See [RichLogFormat.md](Logging/RichLogFormat.md) for the JSON schema example.
+
 ## Available Commands
 
 The table below lists each command and the script it invokes. Arguments not listed are forwarded to the underlying script unchanged.


### PR DESCRIPTION
## Summary
- document the default log paths
- describe `ST_LOG_STRUCTURED` and link to the rich JSON example
- mention logging in SupportTools documentation

## Testing
- `pwsh -NoLogo -Command Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846248d6574832c89c6876e46d26152