### PR TITLE
Update logging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ module see [docs/CredentialStorage.md](docs/CredentialStorage.md).
 
 ## Centralized Logging 📝
 
-Commands automatically record their activity to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default.
-Set the `ST_LOG_PATH` environment variable or use the `-Path` parameter of `Write-STLog` to write logs to a custom location.
-Use `-Structured` to emit JSON lines that include the current user and script name for ingestion into tools like Azure Log Analytics.
-Set `ST_LOG_STRUCTURED=1` to enable structured output without adding the switch each time.
+Commands automatically record their activity to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default or to `$env:ST_LOG_PATH` when set.
+Use the `-Path` parameter of `Write-STLog` to log elsewhere as needed.
+Use `-Structured` or set `ST_LOG_STRUCTURED=1` to emit rich JSON events that include user and script metadata.
+For the schema of these structured entries see [docs/Logging/RichLogFormat.md](docs/Logging/RichLogFormat.md).
 Use `-MaxSizeMB` and `-MaxFiles` with `Write-STLog` to control log rotation. Logs over the size limit (default 1 MB) are renamed with incrementing numeric suffixes.
 Use `-Metric` and `-Value` with `Write-STLog` to capture performance data like durations.
 Review the resulting log file with `Get-Content` when troubleshooting.

--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -20,7 +20,8 @@ Write-STLog [-Message] <String> [[-Level] <String>] [[-Path] <String>] [-Progres
 ```
 
 ## DESCRIPTION
-Used by scripts and modules to record log messages in a consistent format.
+Records log messages in a consistent format. Logs are written to `%USERPROFILE%\SupportToolsLogs\supporttools.log` or `$env:ST_LOG_PATH` if set.
+Set `ST_LOG_STRUCTURED=1` or use `-Structured` to output JSON lines. The structure is described in [RichLogFormat.md](./RichLogFormat.md).
 
 ## EXAMPLES
 
@@ -197,3 +198,4 @@ Older files are preserved up to `-MaxFiles` with incrementing numeric
 extensions.
 
 ## RELATED LINKS
+[RichLogFormat.md](./RichLogFormat.md)

--- a/docs/ModuleStyleGuide.md
+++ b/docs/ModuleStyleGuide.md
@@ -21,6 +21,7 @@ Write-STBlock @{ 'User'='svc-backend'; 'Domain'='corp.local'; 'IP'='10.10.10.5' 
 Write-STClosing
 ```
 
-All messages can also be logged to `%USERPROFILE%\SupportToolsLogs\supporttools.log` using the `-Log` switch or by setting `ST_LOG_PATH`.
-Use the `-Structured` parameter of `Write-STLog` to output JSON lines with extra metadata for ingestion into a centralized dashboard.
-Set the `ST_LOG_STRUCTURED` environment variable to `1` to enable structured output automatically.
+All messages can also be logged to `%USERPROFILE%\SupportToolsLogs\supporttools.log` or `$env:ST_LOG_PATH`.
+Use the `-Log` switch or `-Path` parameter of `Write-STLog` to override the location.
+Use the `-Structured` parameter or set `ST_LOG_STRUCTURED=1` to output JSON lines with extra metadata.
+See [Logging/RichLogFormat.md](./Logging/RichLogFormat.md) for an example of the structured log schema.

--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -27,6 +27,11 @@ if ($result -is [System.Management.Automation.ErrorRecord]) {
 }
 ```
 
+### Logging
+
+Commands record their activity to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default or to `$env:ST_LOG_PATH` if set.
+Use `-Structured` or set `ST_LOG_STRUCTURED=1` to output JSON events. See [../Logging/RichLogFormat.md](../Logging/RichLogFormat.md) for an example of the structure.
+
 ## Available Commands
 
 The table below lists each command and the script it invokes. Arguments not listed are forwarded to the underlying script unchanged.


### PR DESCRIPTION
## Summary
- document default `%USERPROFILE%\SupportToolsLogs` and `$env:ST_LOG_PATH`
- describe `ST_LOG_STRUCTURED` and link to the rich log format
- add logging details to SupportTools docs

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846260373b8832c99b6beb86709acfc