### PR TITLE
Add Get-ServiceDeskStats command

### DIFF
--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -13,6 +13,7 @@ Commands for interacting with the Service Desk ticketing API. **ServiceDeskTools
 | `Add-SDTicketComment` | Add a comment to an incident | `Add-SDTicketComment -Id 42 -Comment 'Investigating'` |
 | `Search-SDTicket` | Search incidents by keyword | `Search-SDTicket -Query 'printer'` |
 | `Get-ServiceDeskAsset` | Retrieve an asset by ID | `Get-ServiceDeskAsset -Id 99` |
+| `Get-ServiceDeskStats` | Summarize incidents by status | `Get-ServiceDeskStats -StartDate (Get-Date).AddDays(-1) -EndDate (Get-Date)` |
 | `Set-SDTicketBulk` | Apply updates to multiple incidents | `Set-SDTicketBulk -Id 1,2,3 -Fields @{ status='Closed' }` |
 | `Link-SDTicketToSPTask` | Add a related SharePoint task link | `Link-SDTicketToSPTask -TicketId 42 -TaskUrl 'https://contoso.sharepoint.com/tasks/1'` |
 | `Submit-Ticket` | Create a Service Desk incident with minimal parameters | `Submit-Ticket -Subject 'Alert' -Description 'Issue detected' -RequesterEmail 'ops@example.com'` |

--- a/docs/ServiceDeskTools/Get-ServiceDeskStats.md
+++ b/docs/ServiceDeskTools/Get-ServiceDeskStats.md
@@ -1,0 +1,43 @@
+---
+external help file: ServiceDeskTools-help.xml
+Module Name: ServiceDeskTools
+online version:
+schema: 2.0.0
+---
+
+# Get-ServiceDeskStats
+
+## SYNOPSIS
+Returns counts of Service Desk incidents grouped by status.
+
+## SYNTAX
+```powershell
+Get-ServiceDeskStats [-StartDate] <DateTime> [-EndDate] <DateTime> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Queries the Service Desk API for incidents created between the specified start and end dates. The resulting incidents are grouped by their status field and returned as an object where each property is a status name with the count of incidents.
+
+## PARAMETERS
+### -StartDate
+Beginning of the date range (inclusive).
+
+### -EndDate
+End of the date range (inclusive).
+
+### -ProgressAction
+Specifies how progress is displayed.
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### PSObject
+An object with properties representing incident status names and their counts.
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/ServiceDeskTools/ReleaseNotes.md
+++ b/docs/ServiceDeskTools/ReleaseNotes.md
@@ -10,3 +10,6 @@
 
 ## 1.3.0 - 2025-06-09
 - Added `Add-SDTicketComment` to post comments on incidents.
+
+## 1.4.0 - 2025-06-10
+- Added `Get-ServiceDeskStats` to summarize incidents by status and record telemetry.

--- a/src/ServiceDeskTools/Public/Get-ServiceDeskStats.ps1
+++ b/src/ServiceDeskTools/Public/Get-ServiceDeskStats.ps1
@@ -1,0 +1,60 @@
+function Get-ServiceDeskStats {
+    <#
+    .SYNOPSIS
+        Retrieves incident counts grouped by status over a date range.
+    .DESCRIPTION
+        Queries the Service Desk API for incidents created within the supplied
+        start and end dates. The results are grouped by incident status and
+        returned as a simple object with properties for each status name.
+    .PARAMETER StartDate
+        Beginning of the date range to query.
+    .PARAMETER EndDate
+        End of the date range to query.
+    .PARAMETER ChaosMode
+        Enables random delays and failures for chaos testing.
+    .PARAMETER Explain
+        Shows the full help content.
+    .EXAMPLE
+        Get-ServiceDeskStats -StartDate (Get-Date).AddDays(-7) -EndDate (Get-Date)
+
+        Returns counts of incidents created in the last seven days grouped by status.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [Parameter(Mandatory)]
+        [datetime]$StartDate,
+        [Parameter(Mandatory)]
+        [datetime]$EndDate,
+        [switch]$ChaosMode,
+        [switch]$Explain
+    )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $result = 'Success'
+    Write-STLog -Message "Get-ServiceDeskStats" -Structured:$($env:ST_LOG_STRUCTURED -eq '1') -Metadata @{ start=$StartDate; end=$EndDate }
+    try {
+        $after  = [uri]::EscapeDataString($StartDate.ToString('yyyy-MM-dd'))
+        $before = [uri]::EscapeDataString($EndDate.ToString('yyyy-MM-dd'))
+        $path = "/incidents.json?created_after=$after&created_before=$before"
+        if ($PSCmdlet.ShouldProcess('incidents', 'Get stats')) {
+            $incidents = Invoke-SDRequest -Method 'GET' -Path $path -ChaosMode:$ChaosMode
+            $counts = @{}
+            foreach ($g in ($incidents | Group-Object -Property state)) { $counts[$g.Name] = $g.Count }
+            return [pscustomobject]$counts
+        }
+    }
+    catch {
+        $result = 'Failure'
+        Write-STLog -Message "Get-ServiceDeskStats failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        throw
+    }
+    finally {
+        $sw.Stop()
+        Write-STTelemetryEvent -ScriptName 'Get-ServiceDeskStats' -Result $result -Duration $sw.Elapsed -Category 'ServiceDeskTools'
+    }
+}

--- a/src/ServiceDeskTools/ServiceDeskTools.psd1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psd1
@@ -1,10 +1,10 @@
 @{
     RootModule = 'ServiceDeskTools.psm1'
-    ModuleVersion = '1.3.0'
+    ModuleVersion = '1.4.0'
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000003'
     Author = 'Contoso'
     Description = 'Commands for interacting with the Service Desk ticketing system.'
-    RequiredModules = @('Logging')
+    RequiredModules = @('Logging','Telemetry')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','ServiceDesk','Internal') } }
     FunctionsToExport = '*'
 }

--- a/src/ServiceDeskTools/ServiceDeskTools.psm1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psm1
@@ -3,8 +3,10 @@ $PublicDir = Join-Path $PSScriptRoot 'Public'
 $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
+$telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
 Import-Module $coreModule -ErrorAction SilentlyContinue
 Import-Module $loggingModule -ErrorAction SilentlyContinue
+Import-Module $telemetryModule -ErrorAction SilentlyContinue
 
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue |
     ForEach-Object { . $_.FullName }

--- a/tests/ServiceDeskTools/Get-ServiceDeskStats.Tests.ps1
+++ b/tests/ServiceDeskTools/Get-ServiceDeskStats.Tests.ps1
@@ -1,0 +1,31 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Get-ServiceDeskStats' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
+    }
+
+    It 'groups incidents by status' {
+        InModuleScope ServiceDeskTools {
+            $data = @(
+                @{ state = 'Open' },
+                @{ state = 'Resolved' },
+                @{ state = 'Open' }
+            )
+            Mock Invoke-SDRequest { $data }
+            $stats = Get-ServiceDeskStats -StartDate (Get-Date).AddDays(-1) -EndDate (Get-Date)
+            Assert-MockCalled Invoke-SDRequest -Times 1 -ParameterFilter { $Method -eq 'GET' -and $Path -match '/incidents.json' }
+            $stats.Open | Should -Be 2
+            $stats.Resolved | Should -Be 1
+        }
+    }
+
+    It 'throws when Invoke-SDRequest fails' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { throw 'bad' }
+            { Get-ServiceDeskStats -StartDate (Get-Date) -EndDate (Get-Date) } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Get-ServiceDeskStats` to query incidents and group by status
- load Telemetry module in ServiceDeskTools
- document the new command and update module version
- note command in docs and release notes
- add unit tests

## Testing
- `pwsh -NoLogo -Command '$cfg=Import-PowerShellDataFile ./PesterConfiguration.psd1; Invoke-Pester -Configuration $cfg'` *(fails: cannot call a method on a null-valued expression)*

------
https://chatgpt.com/codex/tasks/task_e_6846274caad4832c881528428a01e593