### PR TITLE
Implement ServiceDesk asset base URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ ServiceDeskTools reads the following variables for API access:
 ```text
 SD_API_TOKEN
 SD_BASE_URI
+SD_ASSET_BASE_URI
 ```
 
 When set, these variables override values stored in `config/SharePointToolsSettings.psd1`.

--- a/docs/CredentialStorage.md
+++ b/docs/CredentialStorage.md
@@ -24,6 +24,7 @@ Set-Secret -Name SPTOOLS_TENANT_ID  -Secret '<tenant-id>'
 Set-Secret -Name SPTOOLS_CERT_PATH  -Secret '<path-to-pfx>'
 Set-Secret -Name SD_API_TOKEN       -Secret '<service-desk-token>'
 Set-Secret -Name SD_BASE_URI        -Secret 'https://helpdesk.contoso.com'
+Set-Secret -Name SD_ASSET_BASE_URI  -Secret 'https://assets.contoso.com'
 ```
 
 ## Load environment variables
@@ -36,6 +37,7 @@ $env:SPTOOLS_TENANT_ID = Get-Secret SPTOOLS_TENANT_ID -AsPlainText
 $env:SPTOOLS_CERT_PATH = Get-Secret SPTOOLS_CERT_PATH -AsPlainText
 $env:SD_API_TOKEN      = Get-Secret SD_API_TOKEN -AsPlainText
 $env:SD_BASE_URI       = Get-Secret SD_BASE_URI -AsPlainText
+$env:SD_ASSET_BASE_URI = Get-Secret SD_ASSET_BASE_URI -AsPlainText
 ```
 
 With the variables set, you can import the modules and run the commands normally.

--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -16,7 +16,7 @@ Commands for interacting with the Service Desk ticketing API. **ServiceDeskTools
 | `Link-SDTicketToSPTask` | Add a related SharePoint task link | `Link-SDTicketToSPTask -TicketId 42 -TaskUrl 'https://contoso.sharepoint.com/tasks/1'` |
 | `Submit-Ticket` | Create a Service Desk incident with minimal parameters | `Submit-Ticket -Subject 'Alert' -Description 'Issue detected' -RequesterEmail 'ops@example.com'` |
 
-`SD_API_TOKEN` must be set in the environment. Optionally set `SD_BASE_URI` if your Service Desk API uses a custom URL.
+`SD_API_TOKEN` must be set in the environment. Optionally set `SD_BASE_URI` if your Service Desk API uses a custom URL. Use `SD_ASSET_BASE_URI` when assets are hosted on a separate endpoint.
 For guidance on storing the token securely see [CredentialStorage.md](./CredentialStorage.md).
 
 ### Chaos Mode

--- a/docs/ServiceDeskTools/Get-ServiceDeskAsset.md
+++ b/docs/ServiceDeskTools/Get-ServiceDeskAsset.md
@@ -38,5 +38,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 Asset returned from the Service Desk API.
 
 ## NOTES
-
+`SD_ASSET_BASE_URI` can be set to override the default Service Desk base URL for asset requests.
 ## RELATED LINKS

--- a/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
+++ b/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
@@ -4,12 +4,13 @@ function Invoke-SDRequest {
         [Parameter(Mandatory)][string]$Method,
         [Parameter(Mandatory)][string]$Path,
         [hashtable]$Body,
-        [switch]$ChaosMode
+        [switch]$ChaosMode,
+        [string]$BaseUri
     )
     Assert-ParameterNotNull $Method 'Method'
     Assert-ParameterNotNull $Path 'Path'
 
-    $baseUri = $env:SD_BASE_URI
+    $baseUri = if ($BaseUri) { $BaseUri } else { $env:SD_BASE_URI }
     if (-not $baseUri) { $baseUri = 'https://api.samanage.com' }
     $token = $env:SD_API_TOKEN
     if (-not $token) { throw 'SD_API_TOKEN environment variable must be set.' }

--- a/src/ServiceDeskTools/Public/Get-ServiceDeskAsset.ps1
+++ b/src/ServiceDeskTools/Public/Get-ServiceDeskAsset.ps1
@@ -23,6 +23,8 @@ function Get-ServiceDeskAsset {
 
     Write-STLog -Message "Get-ServiceDeskAsset $Id"
     if ($PSCmdlet.ShouldProcess("asset $Id", 'Get')) {
-        return Invoke-SDRequest -Method 'GET' -Path "/assets/$Id.json" -ChaosMode:$ChaosMode
+        $params = @{ Method = 'GET'; Path = "/assets/$Id.json"; ChaosMode = $ChaosMode }
+        if ($env:SD_ASSET_BASE_URI) { $params.BaseUri = $env:SD_ASSET_BASE_URI }
+        return Invoke-SDRequest @params
     }
 }

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -162,6 +162,31 @@ Describe 'ServiceDeskTools Module' {
                 Remove-Item env:SD_BASE_URI
             }
         }
+        It 'uses SD_BASE_URI for assets when SD_ASSET_BASE_URI not set' {
+            InModuleScope ServiceDeskTools {
+                $env:SD_API_TOKEN = 't'
+                $env:SD_BASE_URI = 'https://custom.example.com/api/'
+                Remove-Item env:SD_ASSET_BASE_URI -ErrorAction SilentlyContinue
+                Mock Write-STLog {} -ModuleName ServiceDeskTools
+                Mock Invoke-RestMethod {} -ModuleName ServiceDeskTools
+                Get-ServiceDeskAsset -Id 3
+                Assert-MockCalled Invoke-RestMethod -ModuleName ServiceDeskTools -ParameterFilter { $Uri -eq 'https://custom.example.com/api/assets/3.json' } -Times 1
+                Remove-Item env:SD_API_TOKEN
+                Remove-Item env:SD_BASE_URI
+            }
+        }
+        It 'uses SD_ASSET_BASE_URI when set' {
+            InModuleScope ServiceDeskTools {
+                $env:SD_API_TOKEN = 't'
+                $env:SD_ASSET_BASE_URI = 'https://assets.example.com/api/'
+                Mock Write-STLog {} -ModuleName ServiceDeskTools
+                Mock Invoke-RestMethod {} -ModuleName ServiceDeskTools
+                Get-ServiceDeskAsset -Id 4
+                Assert-MockCalled Invoke-RestMethod -ModuleName ServiceDeskTools -ParameterFilter { $Uri -eq 'https://assets.example.com/api/assets/4.json' } -Times 1
+                Remove-Item env:SD_API_TOKEN
+                Remove-Item env:SD_ASSET_BASE_URI
+            }
+        }
         It 'converts body to JSON' {
             InModuleScope ServiceDeskTools {
                 $env:SD_API_TOKEN = 't'


### PR DESCRIPTION
## Summary
- enable optional `BaseUri` parameter for `Invoke-SDRequest`
- support `SD_ASSET_BASE_URI` environment variable in `Get-ServiceDeskAsset`
- document new variable in docs and README
- cover asset base URI logic with Pester tests

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)` *(fails: Runtime errors during tests)*

------
https://chatgpt.com/codex/tasks/task_e_684625d45998832caec4ba6085bbaa29