### PR TITLE
Fix some lint warnings

### DIFF
--- a/src/IncidentResponseTools/Public/Get-FailedLogin.ps1
+++ b/src/IncidentResponseTools/Public/Get-FailedLogin.ps1
@@ -25,6 +25,7 @@ function Get-FailedLogin {
         [object]$Config
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess('failed login data')) { return }
         Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Get-FailedLogins.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/IncidentResponseTools/Public/Search-Indicators.ps1
+++ b/src/IncidentResponseTools/Public/Search-Indicators.ps1
@@ -25,6 +25,7 @@ function Search-Indicators {
         [object]$Config
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess('indicator search')) { return }
         $arguments = @('-IndicatorList', $IndicatorList)
         Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Search-Indicators.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }

--- a/src/IncidentResponseTools/Public/Update-Sysmon.ps1
+++ b/src/IncidentResponseTools/Public/Update-Sysmon.ps1
@@ -24,6 +24,7 @@ function Update-Sysmon {
         [object]$Config
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess('Sysmon update')) { return }
         Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Update-Sysmon.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/MonitoringTools/Public/Get-CPUUsage.ps1
+++ b/src/MonitoringTools/Public/Get-CPUUsage.ps1
@@ -9,6 +9,8 @@ function Get-CPUUsage {
     [CmdletBinding(SupportsShouldProcess=$true)]
     param()
 
+    if (-not $PSCmdlet.ShouldProcess('CPU usage')) { return }
+
     $computer = if ($env:COMPUTERNAME) { $env:COMPUTERNAME } else { $env:HOSTNAME }
     $timestamp = (Get-Date).ToString('o')
     $cpu = $null
@@ -16,7 +18,7 @@ function Get-CPUUsage {
         $samples = Get-Counter '\\Processor(_Total)\\% Processor Time' -SampleInterval 1 -MaxSamples 3
         $cpu = [math]::Round(($samples.CounterSamples | Measure-Object -Property CookedValue -Average).Average,2)
     } else {
-        Write-Warning 'Get-Counter not available.'
+        Write-STStatus 'Get-Counter not available.' -Level WARN
     }
     $json = @{ ComputerName = $computer; CpuPercent = $cpu; Timestamp = $timestamp } | ConvertTo-Json -Compress
     Write-STRichLog -Tool 'Get-CPUUsage' -Status 'queried' -Details $json

--- a/src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1
+++ b/src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1
@@ -13,6 +13,8 @@ function Get-DiskSpaceInfo {
         [string]$TranscriptPath
     )
 
+    if (-not $PSCmdlet.ShouldProcess('disk space information')) { return }
+
     $computer = if ($env:COMPUTERNAME) { $env:COMPUTERNAME } else { $env:HOSTNAME }
     $timestamp = (Get-Date).ToString('o')
     if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
@@ -29,7 +31,7 @@ function Get-DiskSpaceInfo {
                 }
             }
         } else {
-            Get-PSDrive -PSProvider FileSystem | Where-Object { $_.Free -ne $null } | ForEach-Object {
+            Get-PSDrive -PSProvider FileSystem | Where-Object { $null -ne $_.Free } | ForEach-Object {
                 $info += [pscustomobject]@{
                     Drive       = $_.Root
                     SizeGB      = [math]::Round($_.Used/1GB + $_.Free/1GB,2)

--- a/src/MonitoringTools/Public/Start-HealthMonitor.ps1
+++ b/src/MonitoringTools/Public/Start-HealthMonitor.ps1
@@ -11,11 +11,13 @@ function Start-HealthMonitor {
     .PARAMETER Count
         Number of samples to collect before exiting. 0 runs indefinitely.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [int]$IntervalSeconds = 60,
         [int]$Count = 0
     )
+
+    if (-not $PSCmdlet.ShouldProcess('system health monitoring')) { return }
 
     try {
         $collected = 0


### PR DESCRIPTION
## Summary
- add ShouldProcess checks to select public functions
- replace a warning with Write-STStatus
- fix null comparison in disk info helper

## Testing
- `pwsh -NoLogo -NoProfile -Command '$cfg = Import-PowerShellDataFile "./PesterConfiguration.psd1"; Invoke-Pester -Configuration $cfg'` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684623713ae0832ca7043d7de0ba668f