### PR TITLE
Add Logging UI tests

### DIFF
--- a/tests/Logging.UI.Tests.ps1
+++ b/tests/Logging.UI.Tests.ps1
@@ -1,0 +1,57 @@
+Describe 'Logging UI Functions' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
+    }
+
+    It 'formats shell prompt output' {
+        $oldUser = $env:USERNAME
+        $oldComp = $env:COMPUTERNAME
+        try {
+            $env:USERNAME = 'tester'
+            $env:COMPUTERNAME = 'demo'
+            { Show-STPrompt -Command './script.ps1' -Path '/tmp' } |
+                Should -Output '┌──(tester@demo)-[/tmp]','└─$ ./script.ps1'
+        } finally {
+            if ($null -ne $oldUser) { $env:USERNAME = $oldUser } else { Remove-Item env:USERNAME -ErrorAction SilentlyContinue }
+            if ($null -ne $oldComp) { $env:COMPUTERNAME = $oldComp } else { Remove-Item env:COMPUTERNAME -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'renders dividers for light and heavy styles' {
+        function Get-ExpectedDivider($title, $style) {
+            $char = if ($style -eq 'heavy') { '═' } else { '─' }
+            $total = 65
+            $padding = $total - $title.Length - 4
+            if ($padding -lt 0) { $padding = 0 }
+            $half = [math]::Floor($padding / 2)
+            return ($char * $half) + "[ $title ]" + ($char * ($padding - $half))
+        }
+        $expectedLight = Get-ExpectedDivider 'TITLE' 'light'
+        { Write-STDivider -Title 'TITLE' -Style 'light' } | Should -Output $expectedLight
+        $expectedHeavy = Get-ExpectedDivider 'TITLE' 'heavy'
+        { Write-STDivider -Title 'TITLE' -Style 'heavy' } | Should -Output $expectedHeavy
+    }
+
+    It 'aligns block fields correctly' {
+        $data = @{ Name='Alice'; Email='alice@example.com'; Dept='IT' }
+        function FormatBlock([hashtable]$d) {
+            $max = ($d.Keys | Measure-Object -Property Length -Maximum).Maximum
+            foreach ($k in $d.Keys) {
+                $label = ($k + ':').PadRight($max + 1)
+                "> $label $($d[$k])"
+            }
+        }
+        $expected = FormatBlock $data
+        { Write-STBlock -Data $data } | Should -Output $expected
+    }
+
+    It 'prints closing banner with custom message' {
+        { Write-STClosing -Message 'Done' } | Should -Output '┌──[ Done ]──────────────'
+    }
+
+    It 'returns module name and version' {
+        $banner = Show-LoggingBanner
+        $banner.Module | Should -Be 'Logging'
+        $banner.Version | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester tests for Logging UI helpers

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: `bash: ./pwsh: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684628649e84832cb45bb31962d10f78