### PR TITLE
Update docs for logging and secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ SD_ASSET_BASE_URI
 ```
 
 When set, these variables override values stored in `config/SharePointToolsSettings.psd1`.
+`Connect-STPlatform` now checks the registered SecretManagement vault for these variables
+when they are missing and loads them automatically. See
+[docs/CredentialStorage.md](docs/CredentialStorage.md) for configuring a vault.
 Set `ST_CHAOS_MODE` to `1` or use the `-ChaosMode` switch on ServiceDeskTools commands to simulate throttled or failing API calls during testing.
 For a step-by-step example of loading these variables from the SecretManagement
 module see [docs/CredentialStorage.md](docs/CredentialStorage.md).
@@ -157,6 +160,8 @@ module see [docs/CredentialStorage.md](docs/CredentialStorage.md).
 Commands automatically record their activity to `%USERPROFILE%\SupportToolsLogs\supporttools.log` by default or to `$env:ST_LOG_PATH` when set.
 Use the `-Path` parameter of `Write-STLog` to log elsewhere as needed.
 Use `-Structured` or set `ST_LOG_STRUCTURED=1` to emit rich JSON events that include user and script metadata.
+Set `ST_LOG_LEVEL` to control the minimum severity written to the log (INFO, WARN or ERROR).
+Set `ST_LOG_ENCRYPT=1` to encrypt log files with the current user's credentials.
 For the schema of these structured entries see [docs/Logging/RichLogFormat.md](docs/Logging/RichLogFormat.md).
 Use `-MaxSizeMB` and `-MaxFiles` with `Write-STLog` to control log rotation. Logs over the size limit (default 1 MB) are renamed with incrementing numeric suffixes.
 Use `-Metric` and `-Value` with `Write-STLog` to capture performance data like durations.

--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -22,6 +22,7 @@ Write-STLog [-Message] <String> [[-Level] <String>] [[-Path] <String>] [-Progres
 ## DESCRIPTION
 Records log messages in a consistent format. Logs are written to `%USERPROFILE%\SupportToolsLogs\supporttools.log` or `$env:ST_LOG_PATH` if set.
 Set `ST_LOG_STRUCTURED=1` or use `-Structured` to output JSON lines. The structure is described in [RichLogFormat.md](./RichLogFormat.md).
+`ST_LOG_LEVEL` sets the minimum severity to record and `ST_LOG_ENCRYPT=1` encrypts the log file using the current user's context.
 
 ## EXAMPLES
 

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -18,3 +18,17 @@ Once published, install the entire suite on a fresh system using the helper scri
 ```
 
 The script downloads `Logging`, `SharePointTools`, `ServiceDeskTools` and the specified version of `SupportTools` from the gallery. If the gallery can't be reached it imports the local copies from `src` instead.
+
+## Signing Scripts
+
+All PowerShell files can be signed in bulk using `Sign-STScripts.ps1`. Provide a certificate thumbprint and the path to the repository:
+
+```powershell
+./scripts/Sign-STScripts.ps1 -Thumbprint ABCDEF1234567890 -Path ./
+```
+
+To timestamp the signatures with an external service:
+
+```powershell
+./scripts/Sign-STScripts.ps1 -Thumbprint ABCDEF1234567890 -Path ./ -TimestampServer "http://timestamp.digicert.com"
+```


### PR DESCRIPTION
## Summary
- mention new secret retrieval flow in README
- document ST_LOG_LEVEL and ST_LOG_ENCRYPT
- add signing usage examples to Packaging docs

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: `powershell` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462ba2fcf0832cb38721d08e1c1ec5