### PR TITLE
Add ST_LOG_LEVEL filtering

### DIFF
--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -23,6 +23,15 @@ Write-STLog [-Message] <String> [[-Level] <String>] [[-Path] <String>] [-Progres
 Records log messages in a consistent format. Logs are written to `%USERPROFILE%\SupportToolsLogs\supporttools.log` or `$env:ST_LOG_PATH` if set.
 Set `ST_LOG_STRUCTURED=1` or use `-Structured` to output JSON lines. The structure is described in [RichLogFormat.md](./RichLogFormat.md).
 
+## LOG LEVELS
+The `-Level` parameter accepts the following values:
+
+- **INFO** - informational messages
+- **WARN** - warnings that may require attention
+- **ERROR** - errors that prevented an action
+
+`Write-STStatus` respects the `$env:ST_LOG_LEVEL` variable using the same values to filter console output.
+
 ## EXAMPLES
 
 ### Example 1

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -178,6 +178,16 @@ function Write-STStatus {
         [switch]$Log
     )
 
+    $rank = @{ INFO = 1; WARN = 2; ERROR = 3 }
+    $aliases = @{ SUCCESS='INFO'; SUB='INFO'; FINAL='INFO'; FATAL='ERROR' }
+    $thresholdName = if ($env:ST_LOG_LEVEL -and $rank.ContainsKey($env:ST_LOG_LEVEL)) {
+        $env:ST_LOG_LEVEL
+    } else {
+        'INFO'
+    }
+    $normalized = if ($aliases.ContainsKey($Level)) { $aliases[$Level] } else { $Level }
+    if ($rank[$normalized] -lt $rank[$thresholdName]) { return }
+
     switch ($Level) {
         'SUCCESS' { $prefix = '[+]'; $color = 'Green' }
         'ERROR'   { $prefix = '[-]'; $color = 'Red' }

--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -157,4 +157,17 @@ Describe 'Logging Module' {
             Remove-Item $logFile* -ErrorAction SilentlyContinue
         }
     }
+
+    It 'filters messages according to ST_LOG_LEVEL' {
+        $env:ST_LOG_LEVEL = 'WARN'
+        try {
+            { Write-STStatus -Message 'info msg' -Level INFO } | Should -BeNullOrEmpty
+            { Write-STStatus -Message 'warn msg' -Level WARN } | Should -Output '[!] warn msg'
+            $env:ST_LOG_LEVEL = 'ERROR'
+            { Write-STStatus -Message 'warn skip' -Level WARN } | Should -BeNullOrEmpty
+            { Write-STStatus -Message 'err msg' -Level ERROR } | Should -Output '[-] err msg'
+        } finally {
+            Remove-Item env:ST_LOG_LEVEL -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- support log level filtering in `Write-STStatus`
- document valid log levels
- test `ST_LOG_LEVEL` filtering

## Testing
- `Invoke-Pester -Configuration $cfg` *(fails: ServiceDeskTools not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_68462b760380832c80933c27f92163cd