### PR TITLE
Add Export-SDConfig tool

### DIFF
--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -17,6 +17,7 @@ Commands for interacting with the Service Desk ticketing API. **ServiceDeskTools
 | `Set-SDTicketBulk` | Apply updates to multiple incidents | `Set-SDTicketBulk -Id 1,2,3 -Fields @{ status='Closed' }` |
 | `Link-SDTicketToSPTask` | Add a related SharePoint task link | `Link-SDTicketToSPTask -TicketId 42 -TaskUrl 'https://contoso.sharepoint.com/tasks/1'` |
 | `Submit-Ticket` | Create a Service Desk incident with minimal parameters | `Submit-Ticket -Subject 'Alert' -Description 'Issue detected' -RequesterEmail 'ops@example.com'` |
+| `Export-SDConfig` | Output current Service Desk configuration to JSON | `Export-SDConfig -Path ./sdconfig.json` |
 
 `SD_API_TOKEN` must be set in the environment. Optionally set `SD_BASE_URI` if your Service Desk API uses a custom URL. Use `SD_ASSET_BASE_URI` when assets are hosted on a separate endpoint.
 For guidance on storing the token securely see [CredentialStorage.md](./CredentialStorage.md).

--- a/src/ServiceDeskTools/Public/Export-SDConfig.ps1
+++ b/src/ServiceDeskTools/Public/Export-SDConfig.ps1
@@ -1,0 +1,30 @@
+function Export-SDConfig {
+    <#
+    .SYNOPSIS
+        Export Service Desk environment configuration to JSON.
+    .DESCRIPTION
+        Writes non-sensitive settings such as SD_BASE_URI, SD_ASSET_BASE_URI and
+        SD_RATE_LIMIT_PER_MINUTE to the specified path. The API token is not
+        included.
+    .PARAMETER Path
+        Destination path for the JSON file.
+    .EXAMPLE
+        Export-SDConfig -Path './sdconfig.json'
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Path
+    )
+
+    $config = @{}
+    if ($env:SD_BASE_URI) { $config.BaseUri = $env:SD_BASE_URI }
+    if ($env:SD_ASSET_BASE_URI) { $config.AssetBaseUri = $env:SD_ASSET_BASE_URI }
+    if ($env:SD_RATE_LIMIT_PER_MINUTE) { $config.RateLimitPerMinute = [int]$env:SD_RATE_LIMIT_PER_MINUTE }
+
+    if ($PSCmdlet.ShouldProcess($Path, 'Export config')) {
+        $config | ConvertTo-Json -Depth 5 | Set-Content -Path $Path
+        Write-STStatus "Config exported to $Path" -Level SUCCESS -Log
+    }
+}

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'ServiceDeskTools Module' {
         $expected = @(
             'Get-SDTicket','Get-SDTicketHistory','New-SDTicket','Set-SDTicket',
             'Add-SDTicketComment','Search-SDTicket','Get-ServiceDeskAsset',
-            'Set-SDTicketBulk','Link-SDTicketToSPTask'
+            'Set-SDTicketBulk','Link-SDTicketToSPTask','Export-SDConfig'
         )
         $exported = (Get-Command -Module ServiceDeskTools).Name
         foreach ($cmd in $expected) {


### PR DESCRIPTION
## Summary
- add `Export-SDConfig` to dump Service Desk config
- document the command in `ServiceDeskTools.md`
- test export list includes `Export-SDConfig`

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68462b7e4170832c83f0898a20c8fccb