### PR TITLE
Add repository signing helper

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -33,3 +33,13 @@ This document summarizes the key security aspects of the PowerShell modules cont
 - API tokens stored in environment variables should be protected to prevent unauthorized access.
 - Always review scripts before execution and run test mode (`-Simulate` or `-ChaosMode` switches where available) in non‑production environments first.
 
+
+## Script Signing
+
+All PowerShell files can be signed with the provided `Sign-RepositoryFiles.ps1` script. The script scans the `src` and `scripts` folders for `.ps1`, `.psm1`, and `.psd1` files and applies `Set-AuthenticodeSignature` to each file. Supply the code-signing certificate using the `-CertificatePath` parameter or set the `ST_SIGN_CERT_PATH` environment variable.
+
+```powershell
+$env:ST_SIGN_CERT_PATH = 'C:\certs\internal.pfx'
+./scripts/Sign-RepositoryFiles.ps1
+```
+

--- a/scripts/Sign-RepositoryFiles.ps1
+++ b/scripts/Sign-RepositoryFiles.ps1
@@ -1,0 +1,49 @@
+<#$
+.SYNOPSIS
+    Signs all PowerShell files in the repository.
+.DESCRIPTION
+    Iterates through the `src` and `scripts` folders and signs every
+    `.ps1`, `.psm1` and `.psd1` file using Set-AuthenticodeSignature.
+.PARAMETER CertificatePath
+    Path to the code-signing certificate (PFX). If not provided,
+    the script uses the ST_SIGN_CERT_PATH environment variable.
+.EXAMPLE
+    $env:ST_SIGN_CERT_PATH = 'C:\certs\internal.pfx'
+    ./Sign-RepositoryFiles.ps1
+#>
+param(
+    [string]$CertificatePath = $env:ST_SIGN_CERT_PATH
+)
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+Import-Module (Join-Path $repoRoot 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+
+Show-STPrompt './scripts/Sign-RepositoryFiles.ps1'
+
+if (-not $CertificatePath) {
+    Write-STStatus 'Code signing certificate path not specified.' -Level ERROR
+    return
+}
+
+if (-not (Test-Path $CertificatePath)) {
+    Write-STStatus "Certificate not found at $CertificatePath" -Level ERROR
+    return
+}
+
+$cert = Get-PfxCertificate -FilePath $CertificatePath
+
+Write-STDivider 'SIGNING FILES'
+
+$folders = @('src','scripts') | ForEach-Object { Join-Path $repoRoot $_ }
+foreach ($folder in $folders) {
+    Get-ChildItem -Path $folder -Recurse -Include '*.ps1','*.psm1','*.psd1' | ForEach-Object {
+        Write-STStatus "Signing $($_.FullName)" -Level INFO
+        try {
+            Set-AuthenticodeSignature -FilePath $_.FullName -Certificate $cert | Out-Null
+        } catch {
+            Write-STStatus "Failed to sign $($_.FullName): $_" -Level ERROR
+        }
+    }
+}
+
+Write-STClosing 'Repository signing complete'


### PR DESCRIPTION
## Summary
- add script `Sign-RepositoryFiles.ps1` to sign `src` and `scripts` files
- document code signing usage in `security.md`

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile -Path ./PesterConfiguration.psd1)` *(fails: missing modules)*


------
https://chatgpt.com/codex/tasks/task_e_68462b7d7d00832c911d4b501a26d428