### PR TITLE
Add secret retrieval to Invoke-SDRequest

### DIFF
--- a/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
+++ b/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
@@ -5,15 +5,22 @@ function Invoke-SDRequest {
         [Parameter(Mandatory)][string]$Path,
         [hashtable]$Body,
         [switch]$ChaosMode,
-        [string]$BaseUri
+        [string]$BaseUri,
+        [string]$Vault
     )
     Assert-ParameterNotNull $Method 'Method'
     Assert-ParameterNotNull $Path 'Path'
 
     $baseUri = if ($BaseUri) { $BaseUri } else { $env:SD_BASE_URI }
     if (-not $baseUri) { $baseUri = 'https://api.samanage.com' }
+
     $token = $env:SD_API_TOKEN
-    if (-not $token) { throw 'SD_API_TOKEN environment variable must be set.' }
+    if (-not $token) {
+        $getParams = @{ Name = 'SD_API_TOKEN'; AsPlainText = $true; ErrorAction = 'SilentlyContinue' }
+        if ($PSBoundParameters.ContainsKey('Vault')) { $getParams.Vault = $Vault }
+        $token = Get-Secret @getParams
+        if ($token) { $env:SD_API_TOKEN = $token } else { throw 'SD_API_TOKEN environment variable must be set.' }
+    }
 
     if (-not $ChaosMode) { $ChaosMode = [bool]$env:ST_CHAOS_MODE }
     if ($ChaosMode) {


### PR DESCRIPTION
## Summary
- read ServiceDesk token from secret vault when missing from env
- add optional `-Vault` parameter
- test secret loading behavior and parameter usage

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: required modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68462b727f30832c83905b24fb8e811d