### PR TITLE
Refactor ServiceDeskTools request helpers

### DIFF
--- a/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
+++ b/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
@@ -26,63 +26,12 @@ function Invoke-SDRequest {
     }
 
     $rateLimit = if ($env:SD_RATE_LIMIT_PER_MINUTE) { [int]$env:SD_RATE_LIMIT_PER_MINUTE } else { $null }
-    if ($rateLimit) {
-        if (-not $script:SDRequestHistory) { $script:SDRequestHistory = @() }
-        $now = Get-Date
-        $script:SDRequestHistory = $script:SDRequestHistory | Where-Object { $_ -gt $now.AddMinutes(-1) }
-        if ($script:SDRequestHistory.Count -ge $rateLimit) {
-            $oldest = $script:SDRequestHistory[0]
-            if ($oldest) {
-                $wait = 60 - ($now - $oldest).TotalSeconds
-                if ($wait -gt 0) {
-                    Write-Verbose "Rate limit reached, pausing for $wait seconds"
-                    Start-Sleep -Seconds [math]::Ceiling($wait)
-                }
-            }
-        }
-        $script:SDRequestHistory += $now
-    }
+    Wait-SDRateLimit -RateLimit $rateLimit
 
     $headers = @{ 'X-Samanage-Authorization' = "Bearer $token"; Accept = 'application/json' }
     $uri = $baseUri.TrimEnd('/') + $Path
     Write-STLog -Message "SDRequest $Method $uri" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
     Write-Verbose "Invoking $Method $uri"
     $json = if ($Body) { $Body | ConvertTo-Json -Depth 10 } else { $null }
-    $maxRetries = 3
-    $attempt = 1
-    while ($true) {
-        try {
-            if ($json) {
-                $response = Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers -Body $json -ContentType 'application/json'
-            } else {
-                $response = Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers
-            }
-            Write-STLog -Message "SUCCESS $Method $uri" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
-            return $response
-        } catch [System.Net.WebException],[Microsoft.PowerShell.Commands.HttpResponseException] {
-            $status = $_.Exception.Response.StatusCode.value__
-            $msg    = $_.Exception.Message
-            Write-STLog -Message "HTTP $status $msg" -Level 'ERROR' -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
-            if ($status -eq 429 -or ($status -ge 500 -and $status -lt 600)) {
-                if ($attempt -lt $maxRetries) {
-                    $retryAfter = $_.Exception.Response.Headers['Retry-After']
-                    if ($retryAfter) {
-                        $delay = [int]$retryAfter
-                    } else {
-                        $delay = [math]::Pow(2, $attempt)
-                    }
-                    Write-STLog -Message "Retry $attempt in $delay sec" -Level WARN -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
-                    Write-Verbose "Retrying in $delay seconds"
-                    Start-Sleep -Seconds $delay
-                    $attempt++
-                    continue
-                }
-            }
-            $errorObj = New-STErrorObject -Message "HTTP $status $msg" -Category 'HTTP'
-            throw $errorObj
-        } catch {
-            Write-STLog -Message "ERROR $Method $uri :: $_" -Level 'ERROR' -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
-            throw
-        }
-    }
+    Invoke-SDRestWithRetry -Method $Method -Uri $uri -Headers $headers -Body $json
 }

--- a/src/ServiceDeskTools/Private/Invoke-SDRestWithRetry.ps1
+++ b/src/ServiceDeskTools/Private/Invoke-SDRestWithRetry.ps1
@@ -1,0 +1,42 @@
+function Invoke-SDRestWithRetry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Method,
+        [Parameter(Mandatory)][string]$Uri,
+        [hashtable]$Headers,
+        [string]$Body
+    )
+    $maxRetries = 3
+    $attempt = 1
+    while ($true) {
+        try {
+            if ($null -ne $Body) {
+                $response = Invoke-RestMethod -Method $Method -Uri $Uri -Headers $Headers -Body $Body -ContentType 'application/json'
+            } else {
+                $response = Invoke-RestMethod -Method $Method -Uri $Uri -Headers $Headers
+            }
+            Write-STLog -Message "SUCCESS $Method $Uri" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+            return $response
+        } catch [System.Net.WebException],[Microsoft.PowerShell.Commands.HttpResponseException] {
+            $status = $_.Exception.Response.StatusCode.value__
+            $msg    = $_.Exception.Message
+            Write-STLog -Message "HTTP $status $msg" -Level 'ERROR' -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+            if ($status -eq 429 -or ($status -ge 500 -and $status -lt 600)) {
+                if ($attempt -lt $maxRetries) {
+                    $retryAfter = $_.Exception.Response.Headers['Retry-After']
+                    if ($retryAfter) { $delay = [int]$retryAfter } else { $delay = [math]::Pow(2, $attempt) }
+                    Write-STLog -Message "Retry $attempt in $delay sec" -Level WARN -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+                    Write-Verbose "Retrying in $delay seconds"
+                    Start-Sleep -Seconds $delay
+                    $attempt++
+                    continue
+                }
+            }
+            $errorObj = New-STErrorObject -Message "HTTP $status $msg" -Category 'HTTP'
+            throw $errorObj
+        } catch {
+            Write-STLog -Message "ERROR $Method $Uri :: $_" -Level 'ERROR' -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+            throw
+        }
+    }
+}

--- a/src/ServiceDeskTools/Private/Wait-SDRateLimit.ps1
+++ b/src/ServiceDeskTools/Private/Wait-SDRateLimit.ps1
@@ -1,0 +1,21 @@
+function Wait-SDRateLimit {
+    [CmdletBinding()]
+    param(
+        [int]$RateLimit
+    )
+    if (-not $RateLimit) { return }
+    if (-not $script:SDRequestHistory) { $script:SDRequestHistory = @() }
+    $now = Get-Date
+    $script:SDRequestHistory = $script:SDRequestHistory | Where-Object { $_ -gt $now.AddMinutes(-1) }
+    if ($script:SDRequestHistory.Count -ge $RateLimit) {
+        $oldest = $script:SDRequestHistory[0]
+        if ($oldest) {
+            $wait = 60 - ($now - $oldest).TotalSeconds
+            if ($wait -gt 0) {
+                Write-Verbose "Rate limit reached, pausing for $wait seconds"
+                Start-Sleep -Seconds [math]::Ceiling($wait)
+            }
+        }
+    }
+    $script:SDRequestHistory += $now
+}

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -240,6 +240,17 @@ Describe 'ServiceDeskTools Module' {
                 Remove-Item env:SD_API_TOKEN
             }
         }
+
+        It 'uses retry helper for requests' {
+            InModuleScope ServiceDeskTools {
+                $env:SD_API_TOKEN = 't'
+                Mock Write-STLog {} -ModuleName ServiceDeskTools
+                Mock Invoke-SDRestWithRetry {} -ModuleName ServiceDeskTools
+                Invoke-SDRequest -Method 'GET' -Path '/test'
+                Assert-MockCalled Invoke-SDRestWithRetry -ModuleName ServiceDeskTools -Times 1
+                Remove-Item env:SD_API_TOKEN
+            }
+        }
     }
 
     Context 'WhatIf support' {
@@ -268,12 +279,14 @@ Describe 'ServiceDeskTools Module' {
                 $i = 0
                 Mock Get-Date { $dates[$i++] } -ModuleName ServiceDeskTools
                 Mock Start-Sleep {} -ModuleName ServiceDeskTools
+                Mock Wait-SDRateLimit { } -ModuleName ServiceDeskTools
                 Mock Invoke-RestMethod {} -ModuleName ServiceDeskTools
 
                 Invoke-SDRequest -Method 'GET' -Path '/one'
                 Invoke-SDRequest -Method 'GET' -Path '/two'
                 Invoke-SDRequest -Method 'GET' -Path '/three'
 
+                Assert-MockCalled Wait-SDRateLimit -ModuleName ServiceDeskTools -Times 3
                 Assert-MockCalled Start-Sleep -ModuleName ServiceDeskTools -Times 1
 
                 Remove-Item env:SD_API_TOKEN


### PR DESCRIPTION
## Summary
- extract rate limit tracking and retry logic
- adjust module to use new helpers
- update ServiceDeskTools unit tests

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)` *(fails: The required module 'ServiceDeskTools' is not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_68462b87a3d4832c832d39a5ddbc3b9a