### PR TITLE
Introduce Get-STSecret helper

### DIFF
--- a/src/STCore/STCore.psd1
+++ b/src/STCore/STCore.psd1
@@ -4,5 +4,5 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000000'
     Author = 'Contoso'
     Description = 'Core utility functions.'
-    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest')
+    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest','Get-STSecret')
 }

--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -161,7 +161,27 @@ function Invoke-STRequest {
     }
 }
 
-Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest'
+function Get-STSecret {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [string]$Vault,
+        [switch]$AsPlainText
+    )
+
+    if ($env:$Name) { return $env:$Name }
+
+    if (Get-Command Get-Secret -ErrorAction SilentlyContinue) {
+        $params = @{ Name = $Name; ErrorAction = 'SilentlyContinue' }
+        if ($PSBoundParameters.ContainsKey('Vault')) { $params.Vault = $Vault }
+        if ($AsPlainText) { $params.AsPlainText = $true }
+        try { return Get-Secret @params } catch { Write-STDebug "Get-Secret failed for $Name: $_" }
+    }
+
+    return $null
+}
+
+Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest','Get-STSecret'
 
 function Show-STCoreBanner {
     <#

--- a/src/STPlatform/Public/Connect-STPlatform.ps1
+++ b/src/STPlatform/Public/Connect-STPlatform.ps1
@@ -32,9 +32,9 @@ function Connect-STPlatform {
         $requiredVars = 'SPTOOLS_CLIENT_ID','SPTOOLS_TENANT_ID','SPTOOLS_CERT_PATH','SD_API_TOKEN','SD_BASE_URI'
         foreach ($name in $requiredVars) {
             if (-not $env:$name) {
-                $getParams = @{ Name = $name; AsPlainText = $true; ErrorAction = 'SilentlyContinue' }
-                if ($PSBoundParameters.ContainsKey('Vault')) { $getParams.Vault = $Vault }
-                $val = Get-Secret @getParams
+                $params = @{ Name = $name; AsPlainText = $true }
+                if ($PSBoundParameters.ContainsKey('Vault')) { $params.Vault = $Vault }
+                $val = Get-STSecret @params
                 if ($val) {
                     $env:$name = $val
                     Write-STStatus "Loaded $name from vault" -Level SUB -Log

--- a/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
+++ b/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
@@ -12,8 +12,8 @@ function Invoke-SDRequest {
 
     $baseUri = if ($BaseUri) { $BaseUri } else { $env:SD_BASE_URI }
     if (-not $baseUri) { $baseUri = 'https://api.samanage.com' }
-    $token = $env:SD_API_TOKEN
-    if (-not $token) { throw 'SD_API_TOKEN environment variable must be set.' }
+    $token = Get-STSecret -Name 'SD_API_TOKEN' -AsPlainText
+    if (-not $token) { throw 'SD_API_TOKEN environment variable or secret is required.' }
 
     if (-not $ChaosMode) { $ChaosMode = [bool]$env:ST_CHAOS_MODE }
     if ($ChaosMode) {

--- a/tests/STCore.Helper.Tests.ps1
+++ b/tests/STCore.Helper.Tests.ps1
@@ -141,4 +141,22 @@ Describe 'STCore Helper Functions' {
             }
         }
     }
+
+    Context 'Get-STSecret' {
+        It 'returns environment value when present' {
+            InModuleScope STCore {
+                $env:MY_SECRET = 'envval'
+                Get-STSecret -Name 'MY_SECRET' -AsPlainText | Should -Be 'envval'
+                Remove-Item env:MY_SECRET -ErrorAction SilentlyContinue
+            }
+        }
+        It 'falls back to Get-Secret when missing' {
+            InModuleScope STCore {
+                Remove-Item env:MY_SECRET -ErrorAction SilentlyContinue
+                Mock Get-Secret { 'vaultval' }
+                Get-STSecret -Name 'MY_SECRET' -Vault Test -AsPlainText | Should -Be 'vaultval'
+                Assert-MockCalled Get-Secret -ParameterFilter { $Name -eq 'MY_SECRET' -and $Vault -eq 'Test' -and $AsPlainText } -Times 1
+            }
+        }
+    }
 }

--- a/tests/STPlatform.Tests.ps1
+++ b/tests/STPlatform.Tests.ps1
@@ -16,9 +16,9 @@ Describe 'STPlatform Module' {
     It 'loads secrets when variables missing' {
         InModuleScope STPlatform {
             Remove-Item env:SPTOOLS_CLIENT_ID -ErrorAction SilentlyContinue
-            Mock Get-Secret { 'fromvault' }
+            Mock Get-STSecret { 'fromvault' }
             Connect-STPlatform -Mode Cloud -Vault 'Test'
-            Assert-MockCalled Get-Secret -ParameterFilter { $Name -eq 'SPTOOLS_CLIENT_ID' -and $Vault -eq 'Test' } -Times 1
+            Assert-MockCalled Get-STSecret -ParameterFilter { $Name -eq 'SPTOOLS_CLIENT_ID' -and $Vault -eq 'Test' -and $AsPlainText } -Times 1
             $env:SPTOOLS_CLIENT_ID | Should -Be 'fromvault'
             Remove-Item env:SPTOOLS_CLIENT_ID -ErrorAction SilentlyContinue
         }
@@ -29,7 +29,7 @@ Describe 'STPlatform Module' {
             $names = 'SPTOOLS_CLIENT_ID','SPTOOLS_TENANT_ID','SPTOOLS_CERT_PATH','SD_API_TOKEN','SD_BASE_URI'
             foreach ($n in $names) { Remove-Item "env:$n" -ErrorAction SilentlyContinue }
 
-            Mock Get-Secret {
+            Mock Get-STSecret {
                 switch ($Name) {
                     'SPTOOLS_CLIENT_ID'   { 'cid' }
                     'SPTOOLS_TENANT_ID'  { 'tenant' }
@@ -42,7 +42,7 @@ Describe 'STPlatform Module' {
             Connect-STPlatform -Mode Cloud -Vault TestVault
 
             foreach ($n in $names) {
-                Assert-MockCalled Get-Secret -ParameterFilter { $Name -eq $n -and $Vault -eq 'TestVault' } -Times 1
+                Assert-MockCalled Get-STSecret -ParameterFilter { $Name -eq $n -and $Vault -eq 'TestVault' -and $AsPlainText } -Times 1
             }
             $env:SPTOOLS_CLIENT_ID  | Should -Be 'cid'
             $env:SPTOOLS_TENANT_ID | Should -Be 'tenant'

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -175,7 +175,9 @@ Describe 'ServiceDeskTools Module' {
         It 'throws when SD_API_TOKEN is missing' {
             InModuleScope ServiceDeskTools {
                 Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Mock Get-STSecret { $null }
                 { Invoke-SDRequest -Method 'GET' -Path '/incidents/1.json' } | Should -Throw
+                Assert-MockCalled Get-STSecret -ParameterFilter { $Name -eq 'SD_API_TOKEN' -and $AsPlainText } -Times 1
             }
         }
         It 'uses default base URI when SD_BASE_URI not set' {


### PR DESCRIPTION
## Summary
- add `Get-STSecret` helper to STCore
- load secrets via helper in Connect-STPlatform
- use helper for ServiceDesk API token
- update tests for new helper

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: Could not find Command Write-STStatus)*

------
https://chatgpt.com/codex/tasks/task_e_68462b823434832cbcdc6c090918886a