### PR TITLE
Convert Pester It blocks to Safe-It

### DIFF
--- a/tests/AddUsersToGroup.Tests.ps1
+++ b/tests/AddUsersToGroup.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'AddUsersToGroup Script' {
     BeforeAll {
         function Install-Module {}
@@ -36,21 +37,21 @@ Describe 'AddUsersToGroup Script' {
         Mock Get-ADGroupMember {}
         Mock Get-ADUser {}
     }
-    It 'connects and disconnects from Graph' {
+    Safe-It 'connects and disconnects from Graph' {
         Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' | Out-Null
         Assert-MockCalled Connect-MgGraph -Times 1
         Assert-MockCalled Disconnect-MgGraph -Times 1
     }
-    It 'imports the CSV' {
+    Safe-It 'imports the CSV' {
         Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' | Out-Null
         Assert-MockCalled Import-Csv -ParameterFilter { $Path -eq 'dummy.csv' } -Times 1
     }
-    It 'adds only missing users' {
+    Safe-It 'adds only missing users' {
         Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' | Out-Null
         Assert-MockCalled New-MgGroupMember -Times 1
     }
 
-    It 'uses AD cmdlets when Cloud is AD' {
+    Safe-It 'uses AD cmdlets when Cloud is AD' {
         Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' -Cloud 'AD' | Out-Null
         Assert-MockCalled Add-ADGroupMember -Times 1
         Assert-MockCalled Connect-MgGraph -Times 0

--- a/tests/ArchiveCleanup.Tests.ps1
+++ b/tests/ArchiveCleanup.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'Invoke-ArchiveCleanup' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
@@ -22,7 +23,7 @@ Describe 'Invoke-ArchiveCleanup' {
             Mock Get-SPToolsSiteUrl { 'https://contoso' }
         }
     }
-    It 'removes archived files and folders' {
+    Safe-It 'removes archived files and folders' {
         InModuleScope SharePointTools {
             $script:testItems = @(
                 [pscustomobject]@{ FileSystemObjectType='File'; FieldValues=@{ FileRef='Shared Documents/zzz_Archive/file.txt' } },

--- a/tests/ChaosTools.Tests.ps1
+++ b/tests/ChaosTools.Tests.ps1
@@ -1,24 +1,25 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'ChaosTools Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/ChaosTools/ChaosTools.psd1 -Force
     }
 
-    It 'exports Invoke-ChaosTest' {
+    Safe-It 'exports Invoke-ChaosTest' {
         (Get-Command -Module ChaosTools).Name | Should -Contain 'Invoke-ChaosTest'
     }
 
-    It 'executes a script block when failure rate is zero' {
+    Safe-It 'executes a script block when failure rate is zero' {
         $script:ran = $false
         Invoke-ChaosTest -ScriptBlock { $script:ran = $true } -FailureRate 0 -MaxDelaySeconds 0
         $script:ran | Should -BeTrue
     }
 
-    It 'throws when failure rate is one' {
+    Safe-It 'throws when failure rate is one' {
         { Invoke-ChaosTest -ScriptBlock { } -FailureRate 1 -MaxDelaySeconds 0 } | Should -Throw
     }
 
-    It 'bypasses chaos when CHAOSTOOLS_ENABLED=0' {
+    Safe-It 'bypasses chaos when CHAOSTOOLS_ENABLED=0' {
         $script:ran = $false
         try {
             $env:CHAOSTOOLS_ENABLED = '0'
@@ -29,7 +30,7 @@ Describe 'ChaosTools Module' {
         $script:ran | Should -BeTrue
     }
 
-    It 'bypasses chaos when CHAOSTOOLS_ENABLED=False' {
+    Safe-It 'bypasses chaos when CHAOSTOOLS_ENABLED=False' {
         $script:ran = $false
         try {
             $env:CHAOSTOOLS_ENABLED = 'False'

--- a/tests/ConfigManagementTools.Tests.ps1
+++ b/tests/ConfigManagementTools.Tests.ps1
@@ -1,14 +1,15 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'ConfigManagementTools Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/ConfigManagementTools/ConfigManagementTools.psd1 -Force
     }
 
-    It 'exports Add-UserToGroup' {
+    Safe-It 'exports Add-UserToGroup' {
         (Get-Command -Module ConfigManagementTools).Name | Should -Contain 'Add-UserToGroup'
     }
 
-    It 'exports Set-ComputerIPAddress' {
+    Safe-It 'exports Set-ComputerIPAddress' {
         (Get-Command -Module ConfigManagementTools).Name | Should -Contain 'Set-ComputerIPAddress'
     }
 }

--- a/tests/ConfigManagementTools/Add-UserToGroup.Tests.ps1
+++ b/tests/ConfigManagementTools/Add-UserToGroup.Tests.ps1
@@ -1,10 +1,11 @@
+. $PSScriptRoot/../TestHelpers.ps1
 Describe 'Add-UserToGroup function' {
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/ConfigManagementTools/ConfigManagementTools.psd1 -Force
     }
 
-    It 'passes parameters to Invoke-ScriptFile' {
+    Safe-It 'passes parameters to Invoke-ScriptFile' {
         InModuleScope ConfigManagementTools {
             Mock Invoke-ScriptFile {} -ModuleName ConfigManagementTools
             Add-UserToGroup -CsvPath 'users.csv' -GroupName 'TeamA'
@@ -14,7 +15,7 @@ Describe 'Add-UserToGroup function' {
         }
     }
 
-    It 'accepts pipeline input' {
+    Safe-It 'accepts pipeline input' {
         InModuleScope ConfigManagementTools {
             Mock Invoke-ScriptFile {} -ModuleName ConfigManagementTools
             [pscustomobject]@{ CsvPath='input.csv'; GroupName='G1' } | Add-UserToGroup
@@ -24,7 +25,7 @@ Describe 'Add-UserToGroup function' {
         }
     }
 
-    It 'forwards transcript and switches' {
+    Safe-It 'forwards transcript and switches' {
         InModuleScope ConfigManagementTools {
             Mock Invoke-ScriptFile {} -ModuleName ConfigManagementTools
             Add-UserToGroup -CsvPath 'users.csv' -GroupName 'G1' -TranscriptPath 't.log' -Simulate -Explain
@@ -34,7 +35,7 @@ Describe 'Add-UserToGroup function' {
         }
     }
 
-    It 'passes Cloud parameter' {
+    Safe-It 'passes Cloud parameter' {
         InModuleScope ConfigManagementTools {
             Mock Invoke-ScriptFile {} -ModuleName ConfigManagementTools
             Add-UserToGroup -CsvPath 'users.csv' -GroupName 'G1' -Cloud 'AD'
@@ -44,7 +45,7 @@ Describe 'Add-UserToGroup function' {
         }
     }
 
-    It 'returns error record on failure' {
+    Safe-It 'returns error record on failure' {
         InModuleScope ConfigManagementTools {
             function Invoke-ScriptFile { throw 'oops' }
             $res = Add-UserToGroup -CsvPath 'u.csv' -GroupName 'G1'

--- a/tests/ConfigManagementTools/PublicFunctions.Tests.ps1
+++ b/tests/ConfigManagementTools/PublicFunctions.Tests.ps1
@@ -38,14 +38,14 @@ Describe 'ConfigManagementTools public functions' {
     }
 
     Context 'Invoke-GroupMembershipCleanup' {
-        It 'calls cleanup script' {
+        Safe-It 'calls cleanup script' {
             InModuleScope ConfigManagementTools {
                 Mock Invoke-ScriptFile {} -ModuleName ConfigManagementTools
                 Invoke-GroupMembershipCleanup -CsvPath 'c.csv' -GroupName 'g1'
                 Assert-MockCalled Invoke-ScriptFile -ModuleName ConfigManagementTools -Times 1 -ParameterFilter { $Name -eq 'CleanupGroupMembership.ps1' }
             }
         }
-        It 'throws on failure' {
+        Safe-It 'throws on failure' {
             InModuleScope ConfigManagementTools {
                 Mock Invoke-ScriptFile { throw 'oops' } -ModuleName ConfigManagementTools
                 { Invoke-GroupMembershipCleanup -CsvPath 'c.csv' -GroupName 'g1' } | Should -Throw
@@ -55,14 +55,14 @@ Describe 'ConfigManagementTools public functions' {
 
     Context 'Set-SharedMailboxAutoReply' {
         $commonParams = @{ MailboxIdentity='mb'; StartTime=(Get-Date); EndTime=(Get-Date).AddHours(1); InternalMessage='msg'; AdminUser='admin' }
-        It 'returns simulation object' {
+        Safe-It 'returns simulation object' {
             InModuleScope ConfigManagementTools {
                 Mock Write-STStatus {}
                 $res = Set-SharedMailboxAutoReply @commonParams -Simulate
                 $res.Simulated | Should -BeTrue
             }
         }
-        It 'returns error object when connection fails' {
+        Safe-It 'returns error object when connection fails' {
             InModuleScope ConfigManagementTools {
                 Mock Write-STStatus {}
                 Mock Write-STLog {}
@@ -76,7 +76,7 @@ Describe 'ConfigManagementTools public functions' {
                 $res.Category | Should -Be 'Exchange'
             }
         }
-        It 'returns error object when connection fails without web login' {
+        Safe-It 'returns error object when connection fails without web login' {
             InModuleScope ConfigManagementTools {
                 Mock Write-STStatus {}
                 Mock Write-STLog {}
@@ -93,14 +93,14 @@ Describe 'ConfigManagementTools public functions' {
     }
 
     Context 'Invoke-ExchangeCalendarManager' {
-        It 'returns simulation object' {
+        Safe-It 'returns simulation object' {
             InModuleScope ConfigManagementTools {
                 Mock Write-STStatus {}
                 $res = Invoke-ExchangeCalendarManager -Simulate
                 $res.Simulated | Should -BeTrue
             }
         }
-        It 'returns error object when connect fails' {
+        Safe-It 'returns error object when connect fails' {
             InModuleScope ConfigManagementTools {
                 Mock Write-STStatus {}
                 Mock Write-STLog {}
@@ -115,7 +115,7 @@ Describe 'ConfigManagementTools public functions' {
                 $res.Category | Should -Be 'Exchange'
             }
         }
-        It 'returns error object when connect fails without parameters' {
+        Safe-It 'returns error object when connect fails without parameters' {
             InModuleScope ConfigManagementTools {
                 Mock Write-STStatus {}
                 Mock Write-STLog {}

--- a/tests/ConfigManagementTools/Test-Drift.Tests.ps1
+++ b/tests/ConfigManagementTools/Test-Drift.Tests.ps1
@@ -1,10 +1,11 @@
+. $PSScriptRoot/../TestHelpers.ps1
 Describe 'Test-Drift function' {
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/ConfigManagementTools/ConfigManagementTools.psd1 -Force
     }
 
-    It 'detects configuration drift' {
+    Safe-It 'detects configuration drift' {
         InModuleScope ConfigManagementTools {
             $baseline = @{ timezone='UTC'; hostname='HOST1'; services=@{ svc1='Running' } }
             $file = [System.IO.Path]::GetTempFileName()
@@ -21,7 +22,7 @@ Describe 'Test-Drift function' {
         }
     }
 
-    It 'returns empty when system matches baseline' {
+    Safe-It 'returns empty when system matches baseline' {
         InModuleScope ConfigManagementTools {
             $baseline = @{ timezone='UTC'; hostname='HOST1'; services=@{ svc1='Running' } }
             $file = [System.IO.Path]::GetTempFileName()

--- a/tests/Create-NewHireUser.Tests.ps1
+++ b/tests/Create-NewHireUser.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'Create-NewHireUser script' {
     BeforeAll {
         function Search-SDTicket {}
@@ -18,7 +19,7 @@ Describe 'Create-NewHireUser script' {
         Mock Disconnect-MgGraph {}
         Mock New-MgUser {}
     }
-    It 'creates a user and resolves the ticket' {
+    Safe-It 'creates a user and resolves the ticket' {
         Start-Main -PollMinutes 1 -Once | Out-Null
         Assert-MockCalled Search-SDTicket -Times 1
         Assert-MockCalled New-MgUser -Times 1

--- a/tests/EntraIDTools.Tests.ps1
+++ b/tests/EntraIDTools.Tests.ps1
@@ -13,22 +13,22 @@ Describe 'EntraIDTools Module' {
     }
 
     Context 'Exported commands' {
-        It 'Exports Get-GraphUserDetails' {
+        Safe-It 'Exports Get-GraphUserDetails' {
             (Get-Command -Module EntraIDTools).Name | Should -Contain 'Get-GraphUserDetails'
         }
-        It 'Exports Get-GraphGroupDetails' {
+        Safe-It 'Exports Get-GraphGroupDetails' {
             (Get-Command -Module EntraIDTools).Name | Should -Contain 'Get-GraphGroupDetails'
         }
-        It 'Exports Get-UserInfoHybrid' {
+        Safe-It 'Exports Get-UserInfoHybrid' {
             (Get-Command -Module EntraIDTools).Name | Should -Contain 'Get-UserInfoHybrid'
         }
-        It 'Exports Get-GraphSignInLogs' {
+        Safe-It 'Exports Get-GraphSignInLogs' {
             (Get-Command -Module EntraIDTools).Name | Should -Contain 'Get-GraphSignInLogs'
         }
     }
 
     Context 'Logging and telemetry' {
-        It 'Logs requests and writes telemetry' {
+        Safe-It 'Logs requests and writes telemetry' {
             Mock Get-GraphAccessToken { 't' } -ModuleName EntraIDTools
             Mock Invoke-STRequest { @{ id='1'; displayName='User'; userPrincipalName='u' } } -ModuleName EntraIDTools -ParameterFilter { $Method -eq 'GET' }
             Mock Write-STLog {} -ModuleName EntraIDTools
@@ -38,7 +38,7 @@ Describe 'EntraIDTools Module' {
             Assert-MockCalled Write-STTelemetryEvent -ModuleName EntraIDTools -Times 1
         }
 
-        It 'Logs group requests and writes telemetry' {
+        Safe-It 'Logs group requests and writes telemetry' {
             Mock Get-GraphAccessToken { 't' } -ModuleName EntraIDTools
             Mock Invoke-STRequest { @{ displayName='G'; description='D'; value=@(@{displayName='U'}) } } -ModuleName EntraIDTools -ParameterFilter { $Method -eq 'GET' }
             Mock Write-STLog {} -ModuleName EntraIDTools
@@ -47,7 +47,7 @@ Describe 'EntraIDTools Module' {
             Assert-MockCalled Write-STLog -ModuleName EntraIDTools -Times 1
             Assert-MockCalled Write-STTelemetryEvent -ModuleName EntraIDTools -Times 1
         }
-        It 'Logs hybrid requests and writes telemetry' {
+        Safe-It 'Logs hybrid requests and writes telemetry' {
             Mock Get-GraphUserDetails { @{ UserPrincipalName='u'; DisplayName='User'; Licenses='L'; Groups='G'; LastSignIn='t' } } -ModuleName EntraIDTools
             Mock Get-ADUser { [pscustomobject]@{ SamAccountName='sam'; Enabled=$true } } -ModuleName EntraIDTools
             Mock Write-STLog {} -ModuleName EntraIDTools
@@ -56,7 +56,7 @@ Describe 'EntraIDTools Module' {
             Assert-MockCalled Write-STLog -ModuleName EntraIDTools -Times 1
             Assert-MockCalled Write-STTelemetryEvent -ModuleName EntraIDTools -Times 1
         }
-        It 'Logs sign-in log requests and writes telemetry' {
+        Safe-It 'Logs sign-in log requests and writes telemetry' {
             Mock Get-GraphAccessToken { 't' } -ModuleName EntraIDTools
             Mock Invoke-RestMethod { @{ value=@(@{id='1'}) } } -ModuleName EntraIDTools -ParameterFilter { $Method -eq 'GET' }
             Mock Write-STLog {} -ModuleName EntraIDTools
@@ -68,12 +68,12 @@ Describe 'EntraIDTools Module' {
     }
 
     Context 'Cloud parameter' {
-        It 'uses AD for user details when Cloud is AD' {
+        Safe-It 'uses AD for user details when Cloud is AD' {
             Mock Get-ADUser { @{ UserPrincipalName='u'; Name='User'; MemberOf=@(); LastLogonDate=(Get-Date) } } -ModuleName EntraIDTools
             $res = Get-GraphUserDetails -UserPrincipalName 'u' -TenantId 'tid' -ClientId 'cid' -Cloud 'AD'
             Assert-MockCalled Get-ADUser -ModuleName EntraIDTools -Times 1
         }
-        It 'uses AD for group details when Cloud is AD' {
+        Safe-It 'uses AD for group details when Cloud is AD' {
             Mock Get-ADGroup { @{ Name='G'; Description='D' } } -ModuleName EntraIDTools
             Mock Get-ADGroupMember { @{Name='User'} } -ModuleName EntraIDTools
             $res = Get-GraphGroupDetails -GroupId 'gid' -TenantId 'tid' -ClientId 'cid' -Cloud 'AD'
@@ -82,7 +82,7 @@ Describe 'EntraIDTools Module' {
     }
 
     Context 'Environment variables' {
-        It 'uses GRAPH_* variables when parameters missing' {
+        Safe-It 'uses GRAPH_* variables when parameters missing' {
             $env:GRAPH_TENANT_ID = 'tidEnv'
             $env:GRAPH_CLIENT_ID = 'cidEnv'
             $env:GRAPH_CLIENT_SECRET = 'secEnv'
@@ -100,7 +100,7 @@ Describe 'EntraIDTools Module' {
     }
 
     Context 'Token caching' {
-        It 'returns cached token when not expired' {
+        Safe-It 'returns cached token when not expired' {
             $cache = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
             try {
                 @{ accessToken='cached'; expiresOn=(Get-Date).AddMinutes(10) } |
@@ -115,7 +115,7 @@ Describe 'EntraIDTools Module' {
             }
         }
 
-        It 'refreshes expired token' {
+        Safe-It 'refreshes expired token' {
             $cache = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
             try {
                 @{ accessToken='old'; expiresOn=(Get-Date).AddMinutes(-10) } |
@@ -133,7 +133,7 @@ Describe 'EntraIDTools Module' {
     }
 
     Context 'Failure telemetry' {
-        It 'logs user detail failures' {
+        Safe-It 'logs user detail failures' {
             Mock Get-GraphAccessToken { 't' } -ModuleName EntraIDTools
             Mock Invoke-STRequest { throw 'bad' } -ModuleName EntraIDTools -ParameterFilter { $Method -eq 'GET' }
             Mock Write-STTelemetryEvent {} -ModuleName EntraIDTools
@@ -141,20 +141,20 @@ Describe 'EntraIDTools Module' {
             Assert-MockCalled Write-STTelemetryEvent -ModuleName EntraIDTools -Times 1 -ParameterFilter { $Result -eq 'Failure' }
         }
 
-        It 'logs group detail failures' {
+        Safe-It 'logs group detail failures' {
             Mock Get-GraphAccessToken { 't' } -ModuleName EntraIDTools
             Mock Invoke-STRequest { throw 'bad' } -ModuleName EntraIDTools -ParameterFilter { $Method -eq 'GET' }
             Mock Write-STTelemetryEvent {} -ModuleName EntraIDTools
             { Get-GraphGroupDetails -GroupId 'gid' -TenantId 'tid' -ClientId 'cid' } | Should -Throw
             Assert-MockCalled Write-STTelemetryEvent -ModuleName EntraIDTools -Times 1 -ParameterFilter { $Result -eq 'Failure' }
         }
-        It 'logs hybrid failures' {
+        Safe-It 'logs hybrid failures' {
             Mock Get-GraphUserDetails { throw 'bad' } -ModuleName EntraIDTools
             Mock Write-STTelemetryEvent {} -ModuleName EntraIDTools
             { Get-UserInfoHybrid -UserPrincipalName 'u' -TenantId 'tid' -ClientId 'cid' } | Should -Throw
             Assert-MockCalled Write-STTelemetryEvent -ModuleName EntraIDTools -Times 1 -ParameterFilter { $Result -eq 'Failure' }
         }
-        It 'logs sign-in log failures' {
+        Safe-It 'logs sign-in log failures' {
             Mock Get-GraphAccessToken { 't' } -ModuleName EntraIDTools
             Mock Invoke-RestMethod { throw 'bad' } -ModuleName EntraIDTools -ParameterFilter { $Method -eq 'GET' }
             Mock Write-STTelemetryEvent {} -ModuleName EntraIDTools

--- a/tests/IncidentResponseTools.Tests.ps1
+++ b/tests/IncidentResponseTools.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'IncidentResponseTools Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
@@ -5,15 +6,15 @@ Describe 'IncidentResponseTools Module' {
         Import-Module $PSScriptRoot/../src/IncidentResponseTools/IncidentResponseTools.psd1 -Force
     }
 
-    It 'exports Invoke-IncidentResponse' {
+    Safe-It 'exports Invoke-IncidentResponse' {
         (Get-Command -Module IncidentResponseTools).Name | Should -Contain 'Invoke-IncidentResponse'
     }
 
-    It 'exports Invoke-RemoteAudit' {
+    Safe-It 'exports Invoke-RemoteAudit' {
         (Get-Command -Module IncidentResponseTools).Name | Should -Contain 'Invoke-RemoteAudit'
     }
 
-    It 'exports Search-Indicators' {
+    Safe-It 'exports Search-Indicators' {
         (Get-Command -Module IncidentResponseTools).Name | Should -Contain 'Search-Indicators'
     }
 }

--- a/tests/IncidentResponseTools/PublicFunctions.Tests.ps1
+++ b/tests/IncidentResponseTools/PublicFunctions.Tests.ps1
@@ -39,7 +39,7 @@ Describe 'IncidentResponseTools public functions' {
     }
 
     Context 'Get-CommonSystemInfo' {
-        It 'returns system info when CIM available' {
+        Safe-It 'returns system info when CIM available' {
             InModuleScope IncidentResponseTools {
                 Mock Get-Command { @{ Name='Get-CimInstance' } } -ParameterFilter { $Name -eq 'Get-CimInstance' }
                 Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Get-WmiObject' }
@@ -58,7 +58,7 @@ Describe 'IncidentResponseTools public functions' {
                 Assert-MockCalled Send-STMetric -ParameterFilter { $MetricName -eq 'Get-CommonSystemInfo' } -Times 1
             }
         }
-        It 'returns error object on failure' {
+        Safe-It 'returns error object on failure' {
             InModuleScope IncidentResponseTools {
                 Mock Get-Command { @{ Name='Get-CimInstance' } } -ParameterFilter { $Name -eq 'Get-CimInstance' }
                 Mock Get-CimInstance { throw 'bad' }
@@ -72,7 +72,7 @@ Describe 'IncidentResponseTools public functions' {
     }
 
     Context 'Invoke-RemoteAudit' {
-        It 'collects info from computers' {
+        Safe-It 'collects info from computers' {
             InModuleScope IncidentResponseTools {
                 Mock Invoke-Command { [pscustomobject]@{ ComputerName=$ComputerName; Info='i' } }
                 $r = Invoke-RemoteAudit -ComputerName 'PC1'
@@ -80,7 +80,7 @@ Describe 'IncidentResponseTools public functions' {
                 $r.Info | Should -Be 'i'
             }
         }
-        It 'captures errors from Invoke-Command' {
+        Safe-It 'captures errors from Invoke-Command' {
             InModuleScope IncidentResponseTools {
                 Mock Invoke-Command { throw 'fail' }
                 $r = Invoke-RemoteAudit -ComputerName 'PC1'
@@ -91,7 +91,7 @@ Describe 'IncidentResponseTools public functions' {
     }
 
     Context 'Invoke-FullSystemAudit' {
-        It 'aggregates step output' {
+        Safe-It 'aggregates step output' {
             InModuleScope IncidentResponseTools {
                 Mock Get-CommonSystemInfo { 'info' }
                 Mock Get-FailedLogin { 'fails' }
@@ -102,7 +102,7 @@ Describe 'IncidentResponseTools public functions' {
                 $s.Errors.Count | Should -Be 0
             }
         }
-        It 'records errors when steps fail' {
+        Safe-It 'records errors when steps fail' {
             InModuleScope IncidentResponseTools {
                 Mock Get-CommonSystemInfo { throw 'boom' }
                 Mock Get-FailedLogin { 'fails' }

--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -1,9 +1,10 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'Logging Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
     }
 
-    It 'writes to the path parameter' {
+    Safe-It 'writes to the path parameter' {
         $temp = [System.IO.Path]::GetTempFileName()
         try {
             Write-STLog -Message 'path test' -Path $temp
@@ -13,7 +14,7 @@ Describe 'Logging Module' {
         }
     }
 
-    It 'writes to ST_LOG_PATH when set' {
+    Safe-It 'writes to ST_LOG_PATH when set' {
         $temp = [System.IO.Path]::GetTempFileName()
         try {
             $env:ST_LOG_PATH = $temp
@@ -25,7 +26,7 @@ Describe 'Logging Module' {
         }
     }
 
-    It 'writes to the default log path' {
+    Safe-It 'writes to the default log path' {
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         New-Item -ItemType Directory -Path $tempDir | Out-Null
         $oldHome = $env:HOME
@@ -44,7 +45,7 @@ Describe 'Logging Module' {
         }
     }
 
-    It 'creates the log directory when needed' {
+    Safe-It 'creates the log directory when needed' {
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         $logPath = Join-Path $tempDir 'nested/log.txt'
         try {
@@ -55,7 +56,7 @@ Describe 'Logging Module' {
         }
     }
 
-    It 'includes timestamp and level in the output' {
+    Safe-It 'includes timestamp and level in the output' {
         $temp = [System.IO.Path]::GetTempFileName()
         try {
             Write-STLog -Message 'format test' -Level WARN -Path $temp
@@ -66,7 +67,7 @@ Describe 'Logging Module' {
         }
     }
 
-    It 'writes structured log entries when requested' {
+    Safe-It 'writes structured log entries when requested' {
         $temp = [System.IO.Path]::GetTempFileName()
         try {
             Write-STLog -Message 'json test' -Path $temp -Structured -Metadata @{action='test'}
@@ -79,7 +80,7 @@ Describe 'Logging Module' {
         }
     }
 
-    It 'writes structured log entries when ST_LOG_STRUCTURED is set' {
+    Safe-It 'writes structured log entries when ST_LOG_STRUCTURED is set' {
         $temp = [System.IO.Path]::GetTempFileName()
         try {
             $env:ST_LOG_STRUCTURED = '1'
@@ -93,7 +94,7 @@ Describe 'Logging Module' {
         }
     }
 
-    It 'module functions respect ST_LOG_STRUCTURED' {
+    Safe-It 'module functions respect ST_LOG_STRUCTURED' {
         $temp = [System.IO.Path]::GetTempFileName()
         try {
             Import-Module $PSScriptRoot/../src/OutTools/OutTools.psd1 -Force
@@ -109,7 +110,7 @@ Describe 'Logging Module' {
         }
     }
 
-    It 'throws on invalid log level' {
+    Safe-It 'throws on invalid log level' {
         $temp = [System.IO.Path]::GetTempFileName()
         try {
             { Write-STLog -Message 'bad level' -Level INVALID -Path $temp } | Should -Throw
@@ -118,7 +119,7 @@ Describe 'Logging Module' {
         }
     }
 
-    It 'writes rich JSON log entries' {
+    Safe-It 'writes rich JSON log entries' {
         $temp = [System.IO.Path]::GetTempFileName()
         try {
             Write-STRichLog -Tool 'TestTool' -Status 'success' -User 'a@b.com' -Duration ([TimeSpan]::FromSeconds(5)) -Details 'ok' -Path $temp
@@ -134,7 +135,7 @@ Describe 'Logging Module' {
         }
     }
 
-    It 'logs metric entries' {
+    Safe-It 'logs metric entries' {
         $temp = [System.IO.Path]::GetTempFileName()
         try {
             Write-STLog -Metric 'Duration' -Value 2.5 -Path $temp
@@ -146,7 +147,7 @@ Describe 'Logging Module' {
         }
     }
 
-    It 'rotates log files exceeding the maximum size' {
+    Safe-It 'rotates log files exceeding the maximum size' {
         $logFile = Join-Path $TestDrive 'rotate.log'
         try {
             Set-Content -Path $logFile -Value ('x' * 30)

--- a/tests/Logging.UI.Tests.ps1
+++ b/tests/Logging.UI.Tests.ps1
@@ -1,9 +1,10 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'Logging UI Functions' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
     }
 
-    It 'formats shell prompt output' {
+    Safe-It 'formats shell prompt output' {
         $oldUser = $env:USERNAME
         $oldComp = $env:COMPUTERNAME
         try {
@@ -17,7 +18,7 @@ Describe 'Logging UI Functions' {
         }
     }
 
-    It 'renders dividers for light and heavy styles' {
+    Safe-It 'renders dividers for light and heavy styles' {
         function Get-ExpectedDivider($title, $style) {
             $char = if ($style -eq 'heavy') { '═' } else { '─' }
             $total = 65
@@ -32,7 +33,7 @@ Describe 'Logging UI Functions' {
         { Write-STDivider -Title 'TITLE' -Style 'heavy' } | Should -Output $expectedHeavy
     }
 
-    It 'aligns block fields correctly' {
+    Safe-It 'aligns block fields correctly' {
         $data = @{ Name='Alice'; Email='alice@example.com'; Dept='IT' }
         function FormatBlock([hashtable]$d) {
             $max = ($d.Keys | Measure-Object -Property Length -Maximum).Maximum
@@ -45,11 +46,11 @@ Describe 'Logging UI Functions' {
         { Write-STBlock -Data $data } | Should -Output $expected
     }
 
-    It 'prints closing banner with custom message' {
+    Safe-It 'prints closing banner with custom message' {
         { Write-STClosing -Message 'Done' } | Should -Output '┌──[ Done ]──────────────'
     }
 
-    It 'returns module name and version' {
+    Safe-It 'returns module name and version' {
         $banner = Show-LoggingBanner
         $banner.Module | Should -Be 'Logging'
         $banner.Version | Should -Not -BeNullOrEmpty

--- a/tests/MaintenancePlan.Tests.ps1
+++ b/tests/MaintenancePlan.Tests.ps1
@@ -1,14 +1,15 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'MaintenancePlan Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/MaintenancePlan/MaintenancePlan.psd1 -Force
     }
 
-    It 'exports New-MaintenancePlan' {
+    Safe-It 'exports New-MaintenancePlan' {
         (Get-Command -Module MaintenancePlan).Name | Should -Contain 'New-MaintenancePlan'
     }
 
-    It 'creates and persists a plan' {
+    Safe-It 'creates and persists a plan' {
         $temp = [System.IO.Path]::GetTempFileName()
         try {
             $plan = New-MaintenancePlan -Name Test -Steps @('Write-Host "hi"')
@@ -21,7 +22,7 @@ Describe 'MaintenancePlan Module' {
         }
     }
 
-    It 'executes script steps' {
+    Safe-It 'executes script steps' {
         $scriptPath = Join-Path ([IO.Path]::GetTempPath()) 'step.ps1'
         Set-Content $scriptPath '$script:ran = $true'
         try {
@@ -34,7 +35,7 @@ Describe 'MaintenancePlan Module' {
         }
     }
 
-    It 'builds scheduled task command on Windows' {
+    Safe-It 'builds scheduled task command on Windows' {
         InModuleScope MaintenancePlan {
             Set-Variable -Name IsWindows -Value $true -Scope Script -Force
             function Register-ScheduledTask {}
@@ -47,7 +48,7 @@ Describe 'MaintenancePlan Module' {
         }
     }
 
-    It 'returns cron entry on non-windows' {
+    Safe-It 'returns cron entry on non-windows' {
         InModuleScope MaintenancePlan {
             Set-Variable -Name IsWindows -Value $false -Scope Script -Force
             $entry = Schedule-MaintenancePlan -PlanPath '/tmp/p.json' -Cron '5 1 * * *' -Name 'MP'

--- a/tests/MonitoringTools.Tests.ps1
+++ b/tests/MonitoringTools.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'MonitoringTools Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
@@ -5,19 +6,19 @@ Describe 'MonitoringTools Module' {
         Import-Module $PSScriptRoot/../src/MonitoringTools/MonitoringTools.psd1 -Force
     }
 
-    It 'exports Get-CPUUsage' {
+    Safe-It 'exports Get-CPUUsage' {
         (Get-Command -Module MonitoringTools).Name | Should -Contain 'Get-CPUUsage'
     }
 
-    It 'exports Get-SystemHealth' {
+    Safe-It 'exports Get-SystemHealth' {
         (Get-Command -Module MonitoringTools).Name | Should -Contain 'Get-SystemHealth'
     }
 
-    It 'exports Start-HealthMonitor' {
+    Safe-It 'exports Start-HealthMonitor' {
         (Get-Command -Module MonitoringTools).Name | Should -Contain 'Start-HealthMonitor'
     }
 
-    It 'returns system health object' {
+    Safe-It 'returns system health object' {
         Mock Get-CPUUsage { 10 } -ModuleName MonitoringTools
         Mock Get-DiskSpaceInfo { @() } -ModuleName MonitoringTools
         Mock Get-EventLogSummary { @() } -ModuleName MonitoringTools
@@ -26,7 +27,7 @@ Describe 'MonitoringTools Module' {
         $result.DiskInfo   | Should -Be @()
     }
 
-    It 'logs health samples on a loop' {
+    Safe-It 'logs health samples on a loop' {
         Mock Get-SystemHealth { @{ CpuPercent=1; DiskInfo=@(); EventLogSummary=@() } } -ModuleName MonitoringTools
         Mock Write-STRichLog {} -ModuleName MonitoringTools
         Start-HealthMonitor -IntervalSeconds 0 -Count 2

--- a/tests/MonitoringTools/Get-SystemHealth.Tests.ps1
+++ b/tests/MonitoringTools/Get-SystemHealth.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/../TestHelpers.ps1
 Describe 'Get-SystemHealth function' {
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
@@ -5,7 +6,7 @@ Describe 'Get-SystemHealth function' {
         Import-Module $PSScriptRoot/../../src/MonitoringTools/MonitoringTools.psd1 -Force
     }
 
-    It 'returns expected health object' {
+    Safe-It 'returns expected health object' {
         Mock Get-CPUUsage { 42 } -ModuleName MonitoringTools
         $disk = @([pscustomobject]@{ Drive='C:'; SizeGB=100; FreeGB=50 })
         Mock Get-DiskSpaceInfo { $disk } -ModuleName MonitoringTools

--- a/tests/OutTools.OutSTStatus.Tests.ps1
+++ b/tests/OutTools.OutSTStatus.Tests.ps1
@@ -1,16 +1,17 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'Out-STStatus function' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/OutTools/OutTools.psd1 -Force
     }
 
-    It 'forwards parameters to Write-STStatus' {
+    Safe-It 'forwards parameters to Write-STStatus' {
         Mock Write-STStatus {} -ModuleName OutTools
         Out-STStatus -Message 'hello' -Level WARN
         Assert-MockCalled Write-STStatus -ModuleName OutTools -ParameterFilter { $Message -eq 'hello' -and $Level -eq 'WARN' } -Times 1
     }
 
-    It 'invokes Write-STLog when -Log specified' {
+    Safe-It 'invokes Write-STLog when -Log specified' {
         Mock Write-STStatus {} -ModuleName OutTools
         Mock Write-STLog {} -ModuleName Logging
         Out-STStatus -Message 'log me' -Level INFO -Log

--- a/tests/OutTools.Tests.ps1
+++ b/tests/OutTools.Tests.ps1
@@ -1,10 +1,11 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'OutTools Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/OutTools/OutTools.psd1 -Force
     }
 
-    It 'formats banner objects' {
+    Safe-It 'formats banner objects' {
         $obj = [pscustomobject]@{ Module='TestMod'; Version='1.0' }
         { $obj | Out-STBanner } | Should -Not -Throw
     }

--- a/tests/PerformanceTools.Tests.ps1
+++ b/tests/PerformanceTools.Tests.ps1
@@ -1,25 +1,26 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'PerformanceTools Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/PerformanceTools/PerformanceTools.psd1 -Force
     }
 
-    It 'exports Measure-STCommand' {
+    Safe-It 'exports Measure-STCommand' {
         (Get-Command -Module PerformanceTools).Name | Should -Contain 'Measure-STCommand'
     }
 
-    It 'exports Invoke-PerformanceAudit' {
+    Safe-It 'exports Invoke-PerformanceAudit' {
         (Get-Command -Module PerformanceTools).Name | Should -Contain 'Invoke-PerformanceAudit'
     }
 
-    It 'measures a script block' {
+    Safe-It 'measures a script block' {
         $result = Measure-STCommand { Start-Sleep -Milliseconds 50 }
         $result.DurationSeconds | Should -BeGreaterThan 0
         $result.PSObject.Properties.Name | Should -Contain 'CpuSeconds'
         $result.PSObject.Properties.Name | Should -Contain 'MemoryDeltaMB'
     }
 
-    It 'references bundled script path' {
+    Safe-It 'references bundled script path' {
         InModuleScope PerformanceTools {
             $definition = (Get-Command Invoke-PerformanceAudit).ScriptBlock.ToString()
             $definition | Should -Match 'Invoke-PerformanceAudit.ps1'

--- a/tests/PerformanceTools/Invoke-PerformanceAudit.Tests.ps1
+++ b/tests/PerformanceTools/Invoke-PerformanceAudit.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/../TestHelpers.ps1
 Describe 'Invoke-PerformanceAudit.ps1 script' {
     BeforeAll {
         $ScriptPath = Join-Path $PSScriptRoot/../.. 'src/PerformanceTools/Invoke-PerformanceAudit.ps1'
@@ -19,7 +20,7 @@ Describe 'Invoke-PerformanceAudit.ps1 script' {
         Mock New-SDTicket { @{ id = 1 } }
     }
 
-    It 'logs performance metrics' {
+    Safe-It 'logs performance metrics' {
         & $ScriptPath -CpuThreshold 100 -MemoryThreshold 100 -DiskThreshold 100 -NetworkThreshold 100 -RequesterEmail 'user@example.com' | Out-Null
         Assert-MockCalled Write-STLog -ParameterFilter { $Metric -eq 'CPUPercent' } -Times 1
         Assert-MockCalled Write-STLog -ParameterFilter { $Metric -eq 'MemoryPercent' } -Times 1
@@ -28,7 +29,7 @@ Describe 'Invoke-PerformanceAudit.ps1 script' {
         Assert-MockCalled Send-STMetric -ParameterFilter { $MetricName -eq 'PerformanceAuditDuration' } -Times 1
     }
 
-    It 'creates a ticket when thresholds exceeded' {
+    Safe-It 'creates a ticket when thresholds exceeded' {
         & $ScriptPath -CpuThreshold 0 -MemoryThreshold 0 -DiskThreshold 0 -NetworkThreshold 0 -CreateTicket -RequesterEmail 'user@example.com' | Out-Null
         Assert-MockCalled Write-STStatus -ParameterFilter { $Message -eq 'Performance thresholds exceeded:' } -Times 1
         Assert-MockCalled New-SDTicket -Times 1

--- a/tests/PerformanceTools/Measure-STCommand.Tests.ps1
+++ b/tests/PerformanceTools/Measure-STCommand.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/../TestHelpers.ps1
 Describe 'Measure-STCommand function' {
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
@@ -5,7 +6,7 @@ Describe 'Measure-STCommand function' {
         InModuleScope PerformanceTools { function Send-STMetric {} }
     }
 
-    It 'returns timing metrics' {
+    Safe-It 'returns timing metrics' {
         InModuleScope PerformanceTools {
             function Send-STMetric {}
             Mock Write-STStatus {}
@@ -16,7 +17,7 @@ Describe 'Measure-STCommand function' {
         }
     }
 
-    It 'writes status messages when not quiet' {
+    Safe-It 'writes status messages when not quiet' {
         InModuleScope PerformanceTools {
             function Send-STMetric {}
             Mock Write-STStatus {} -Verifiable
@@ -25,7 +26,7 @@ Describe 'Measure-STCommand function' {
         }
     }
 
-    It 'suppresses status when Quiet' {
+    Safe-It 'suppresses status when Quiet' {
         InModuleScope PerformanceTools {
             function Send-STMetric {}
             Mock Write-STStatus {}

--- a/tests/STCore.Helper.Tests.ps1
+++ b/tests/STCore.Helper.Tests.ps1
@@ -1,15 +1,16 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'STCore Helper Functions' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/STCore/STCore.psd1 -Force
     }
 
-    It 'Assert-ParameterNotNull throws on null' {
+    Safe-It 'Assert-ParameterNotNull throws on null' {
         { Assert-ParameterNotNull $null 'Param' } | Should -Throw
     }
 
     Context 'Get-STConfig' {
-        It 'reads JSON files' {
+        Safe-It 'reads JSON files' {
             $path = Join-Path $TestDrive 'c.json'
             Set-Content -Path $path -Value '{"x":42}'
             try {
@@ -20,7 +21,7 @@ Describe 'STCore Helper Functions' {
             }
         }
 
-        It 'reads PSD1 files' {
+        Safe-It 'reads PSD1 files' {
             $path = Join-Path $TestDrive 'c.psd1'
             Set-Content -Path $path -Value '@{ y = 99 }'
             try {
@@ -31,7 +32,7 @@ Describe 'STCore Helper Functions' {
             }
         }
 
-        It 'returns empty for missing file' {
+        Safe-It 'returns empty for missing file' {
             $path = Join-Path $TestDrive 'nofile.json'
             $cfg = Get-STConfig -Path $path
             $cfg | Should -BeOfType 'hashtable'
@@ -40,7 +41,7 @@ Describe 'STCore Helper Functions' {
     }
 
     Context 'Write-STDebug' {
-        It 'emits output only when ST_DEBUG=1' {
+        Safe-It 'emits output only when ST_DEBUG=1' {
             InModuleScope STCore {
                 Mock Write-STStatus {}
                 Mock Write-STLog {}
@@ -59,7 +60,7 @@ Describe 'STCore Helper Functions' {
     }
 
     Context 'Test-IsElevated' {
-        It 'uses Windows APIs when IsWindows is true' {
+        Safe-It 'uses Windows APIs when IsWindows is true' {
             InModuleScope STCore {
                 Set-Variable -Name IsWindows -Value $true -Scope Script -Force
                 Mock id { 0 }
@@ -67,7 +68,7 @@ Describe 'STCore Helper Functions' {
                 Assert-MockCalled id -Times 0
             }
         }
-        It 'checks uid 0 when IsWindows is false' {
+        Safe-It 'checks uid 0 when IsWindows is false' {
             InModuleScope STCore {
                 Set-Variable -Name IsWindows -Value $false -Scope Script -Force
                 Mock id { '0' }
@@ -79,7 +80,7 @@ Describe 'STCore Helper Functions' {
     }
 
     Context 'Invoke-STRequest' {
-        It 'invokes once on success' {
+        Safe-It 'invokes once on success' {
             InModuleScope STCore {
                 Mock Write-STLog {}
                 Mock Invoke-RestMethod { @{ ok = 1 } }
@@ -89,7 +90,7 @@ Describe 'STCore Helper Functions' {
             }
         }
 
-        It 'retries on server error' {
+        Safe-It 'retries on server error' {
             InModuleScope STCore {
                 Mock Write-STLog {}
                 Mock Start-Sleep {}
@@ -112,7 +113,7 @@ Describe 'STCore Helper Functions' {
             }
         }
 
-        It 'honors -ChaosMode' {
+        Safe-It 'honors -ChaosMode' {
             InModuleScope STCore {
                 Mock Write-STLog {}
                 Mock Start-Sleep {}
@@ -124,7 +125,7 @@ Describe 'STCore Helper Functions' {
             }
         }
 
-        It 'honors ST_CHAOS_MODE environment variable' {
+        Safe-It 'honors ST_CHAOS_MODE environment variable' {
             InModuleScope STCore {
                 Mock Write-STLog {}
                 Mock Start-Sleep {}

--- a/tests/STCore.Tests.ps1
+++ b/tests/STCore.Tests.ps1
@@ -1,9 +1,10 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'STCore Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/STCore/STCore.psd1 -Force
     }
 
-    It 'exports Invoke-STRequest' {
+    Safe-It 'exports Invoke-STRequest' {
         (Get-Command -Module STCore).Name | Should -Contain 'Invoke-STRequest'
     }
 }

--- a/tests/STPlatform.Tests.ps1
+++ b/tests/STPlatform.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'STPlatform Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
@@ -5,15 +6,15 @@ Describe 'STPlatform Module' {
         Import-Module $PSScriptRoot/../src/STPlatform/STPlatform.psd1 -Force
     }
 
-    It 'exports Connect-STPlatform' {
+    Safe-It 'exports Connect-STPlatform' {
         (Get-Command -Module STPlatform).Name | Should -Contain 'Connect-STPlatform'
     }
 
-    It 'includes Vault parameter' {
+    Safe-It 'includes Vault parameter' {
         (Get-Command Connect-STPlatform).Parameters.Keys | Should -Contain 'Vault'
     }
 
-    It 'loads secrets when variables missing' {
+    Safe-It 'loads secrets when variables missing' {
         InModuleScope STPlatform {
             Remove-Item env:SPTOOLS_CLIENT_ID -ErrorAction SilentlyContinue
             Mock Get-Secret { 'fromvault' }
@@ -24,7 +25,7 @@ Describe 'STPlatform Module' {
         }
     }
 
-    It 'loads all required secrets from the vault' {
+    Safe-It 'loads all required secrets from the vault' {
         InModuleScope STPlatform {
             $names = 'SPTOOLS_CLIENT_ID','SPTOOLS_TENANT_ID','SPTOOLS_CERT_PATH','SD_API_TOKEN','SD_BASE_URI'
             foreach ($n in $names) { Remove-Item "env:$n" -ErrorAction SilentlyContinue }
@@ -55,7 +56,7 @@ Describe 'STPlatform Module' {
     }
 
     Context 'Mode connections' {
-        It 'initializes Cloud mode and logs metrics' {
+        Safe-It 'initializes Cloud mode and logs metrics' {
             InModuleScope STPlatform {
                 function Install-Module {}
                 function Import-Module {}
@@ -86,7 +87,7 @@ Describe 'STPlatform Module' {
             }
         }
 
-        It 'initializes Hybrid mode and logs metrics' {
+        Safe-It 'initializes Hybrid mode and logs metrics' {
             InModuleScope STPlatform {
                 function Install-Module {}
                 function Import-Module {}
@@ -117,7 +118,7 @@ Describe 'STPlatform Module' {
             }
         }
 
-        It 'initializes OnPrem mode and logs metrics' {
+        Safe-It 'initializes OnPrem mode and logs metrics' {
             InModuleScope STPlatform {
                 function Install-Module {}
                 function Import-Module {}

--- a/tests/ScriptFiles.Tests.ps1
+++ b/tests/ScriptFiles.Tests.ps1
@@ -1,5 +1,6 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'Standalone Scripts' {
-    It 'generates maintenance task XML without registering' {
+    Safe-It 'generates maintenance task XML without registering' {
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         New-Item -ItemType Directory -Path $tempDir | Out-Null
         Push-Location $tempDir
@@ -14,7 +15,7 @@ Describe 'Standalone Scripts' {
         }
     }
 
-    It 'builds a function dependency graph' {
+    Safe-It 'builds a function dependency graph' {
         $result = & $PSScriptRoot/../scripts/Get-FunctionDependencyGraph.ps1 -Path $PSScriptRoot/../scripts/AddUsersToGroup.ps1 -Format Graphviz
         $result | Should -Match 'digraph'
         $result | Should -Match 'Start-Main'

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'ServiceDeskTools Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
@@ -12,31 +13,31 @@ Describe 'ServiceDeskTools Module' {
         )
         $exported = (Get-Command -Module ServiceDeskTools).Name
         foreach ($cmd in $expected) {
-            It "Exports $cmd" {
+            Safe-It "Exports $cmd" {
                 $exported | Should -Contain $cmd
             }
         }
     }
 
     Context 'Request routing' {
-        It 'Get-SDTicket calls Invoke-SDRequest' {
+        Safe-It 'Get-SDTicket calls Invoke-SDRequest' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Get-SDTicket -Id 1
             Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter { $Method -eq 'GET' -and $Path -eq '/incidents/1.json' } -Times 1
         }
-        It 'Get-SDTicketHistory calls Invoke-SDRequest' {
+        Safe-It 'Get-SDTicketHistory calls Invoke-SDRequest' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Get-SDTicketHistory -Id 1
             Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter { $Method -eq 'GET' -and $Path -eq '/incidents/1/audits.json' } -Times 1
         }
-        It 'Get-SDTicketHistory passes ChaosMode' {
+        Safe-It 'Get-SDTicketHistory passes ChaosMode' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Get-SDTicketHistory -Id 1 -ChaosMode
             Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter {
                 $ChaosMode -eq $true -and $Method -eq 'GET' -and $Path -eq '/incidents/1/audits.json'
             } -Times 1
         }
-        It 'New-SDTicket calls Invoke-SDRequest' {
+        Safe-It 'New-SDTicket calls Invoke-SDRequest' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             New-SDTicket -Subject 'S' -Description 'D' -RequesterEmail 'a@b.com'
             Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter {
@@ -47,7 +48,7 @@ Describe 'ServiceDeskTools Module' {
                 $Body.incident.requester_email -eq 'a@b.com'
             } -Times 1
         }
-        It 'Set-SDTicket calls Invoke-SDRequest' {
+        Safe-It 'Set-SDTicket calls Invoke-SDRequest' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Set-SDTicket -Id 2 -Fields @{status='Open'}
             Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter {
@@ -56,7 +57,7 @@ Describe 'ServiceDeskTools Module' {
                 $Body.incident.status -eq 'Open'
             } -Times 1
         }
-        It 'Add-SDTicketComment calls Invoke-SDRequest' {
+        Safe-It 'Add-SDTicketComment calls Invoke-SDRequest' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Add-SDTicketComment -Id 5 -Comment 'c'
             Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter {
@@ -65,7 +66,7 @@ Describe 'ServiceDeskTools Module' {
                 $Body.comment.body -eq 'c'
             } -Times 1
         }
-        It 'Add-SDTicketComment passes ChaosMode' {
+        Safe-It 'Add-SDTicketComment passes ChaosMode' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Add-SDTicketComment -Id 5 -Comment 'c' -ChaosMode
             Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter {
@@ -74,34 +75,34 @@ Describe 'ServiceDeskTools Module' {
                 $Path -eq '/incidents/5/comments.json'
             } -Times 1
         }
-        It 'Search-SDTicket calls Invoke-SDRequest' {
+        Safe-It 'Search-SDTicket calls Invoke-SDRequest' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Search-SDTicket -Query 'error'
             Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter {
                 $Method -eq 'GET' -and $Path -eq '/incidents.json?search=error'
             } -Times 1
         }
-        It 'Get-ServiceDeskAsset calls Invoke-SDRequest' {
+        Safe-It 'Get-ServiceDeskAsset calls Invoke-SDRequest' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Get-ServiceDeskAsset -Id 4
             Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter {
                 $Method -eq 'GET' -and $Path -eq '/assets/4.json'
             } -Times 1
         }
-        It 'Get-ServiceDeskAsset passes ChaosMode' {
+        Safe-It 'Get-ServiceDeskAsset passes ChaosMode' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Get-ServiceDeskAsset -Id 4 -ChaosMode
             Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter {
                 $ChaosMode -eq $true -and $Method -eq 'GET' -and $Path -eq '/assets/4.json'
             } -Times 1
         }
-        It 'Set-SDTicketBulk calls Set-SDTicket for each id' {
+        Safe-It 'Set-SDTicketBulk calls Set-SDTicket for each id' {
             Mock Set-SDTicket {} -ModuleName ServiceDeskTools
             Set-SDTicketBulk -Id 10,11 -Fields @{status='Closed'}
             Assert-MockCalled Set-SDTicket -ModuleName ServiceDeskTools -ParameterFilter { $Id -eq 10 } -Times 1
             Assert-MockCalled Set-SDTicket -ModuleName ServiceDeskTools -ParameterFilter { $Id -eq 11 } -Times 1
         }
-        It 'Link-SDTicketToSPTask calls Set-SDTicket' {
+        Safe-It 'Link-SDTicketToSPTask calls Set-SDTicket' {
             Mock Set-SDTicket {} -ModuleName ServiceDeskTools
             Link-SDTicketToSPTask -TicketId 12 -TaskUrl 'https://contoso/tasks/1'
             Assert-MockCalled Set-SDTicket -ModuleName ServiceDeskTools -ParameterFilter {
@@ -111,56 +112,56 @@ Describe 'ServiceDeskTools Module' {
     }
 
     Context 'Logging' {
-        It 'Get-SDTicket logs the request' {
+        Safe-It 'Get-SDTicket logs the request' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Mock Write-STLog {} -ModuleName ServiceDeskTools
             Get-SDTicket -Id 5
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Get-SDTicket 5' } -Times 1
         }
-        It 'New-SDTicket logs the request' {
+        Safe-It 'New-SDTicket logs the request' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Mock Write-STLog {} -ModuleName ServiceDeskTools
             New-SDTicket -Subject 'S' -Description 'D' -RequesterEmail 'a@b.com'
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'New-SDTicket S' } -Times 1
         }
-        It 'Set-SDTicket logs the request' {
+        Safe-It 'Set-SDTicket logs the request' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Mock Write-STLog {} -ModuleName ServiceDeskTools
             Set-SDTicket -Id 3 -Fields @{status='Closed'}
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Set-SDTicket 3' } -Times 1
         }
-        It 'Search-SDTicket logs the request' {
+        Safe-It 'Search-SDTicket logs the request' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Mock Write-STLog {} -ModuleName ServiceDeskTools
             Search-SDTicket -Query 'fail'
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Search-SDTicket fail' } -Times 1
         }
-        It 'Get-ServiceDeskAsset logs the request' {
+        Safe-It 'Get-ServiceDeskAsset logs the request' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Mock Write-STLog {} -ModuleName ServiceDeskTools
             Get-ServiceDeskAsset -Id 6
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Get-ServiceDeskAsset 6' } -Times 1
         }
-        It 'Set-SDTicketBulk logs each id' {
+        Safe-It 'Set-SDTicketBulk logs each id' {
             Mock Set-SDTicket {} -ModuleName ServiceDeskTools
             Mock Write-STLog {} -ModuleName ServiceDeskTools
             Set-SDTicketBulk -Id 7,8 -Fields @{priority='High'}
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Set-SDTicketBulk 7' } -Times 1
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Set-SDTicketBulk 8' } -Times 1
         }
-        It 'Add-SDTicketComment logs the request' {
+        Safe-It 'Add-SDTicketComment logs the request' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Mock Write-STLog {} -ModuleName ServiceDeskTools
             Add-SDTicketComment -Id 8 -Comment 'c'
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Add-SDTicketComment 8' } -Times 1
         }
-        It 'Link-SDTicketToSPTask logs the update' {
+        Safe-It 'Link-SDTicketToSPTask logs the update' {
             Mock Set-SDTicket {} -ModuleName ServiceDeskTools
             Mock Write-STLog {} -ModuleName ServiceDeskTools
             Link-SDTicketToSPTask -TicketId 9 -TaskUrl 'https://contoso/tasks/9'
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Link-SDTicketToSPTask 9 https://contoso/tasks/9' } -Times 1
         }
-        It 'Submit-Ticket calls New-SDTicket and logs the action' {
+        Safe-It 'Submit-Ticket calls New-SDTicket and logs the action' {
             Mock New-SDTicket {} -ModuleName ServiceDeskTools
             Mock Write-STLog {} -ModuleName ServiceDeskTools
             Submit-Ticket -Subject 'S' -Description 'D' -RequesterEmail 'a@b.com'
@@ -172,13 +173,13 @@ Describe 'ServiceDeskTools Module' {
     }
 
     Context 'Invoke-SDRequest behavior' {
-        It 'throws when SD_API_TOKEN is missing' {
+        Safe-It 'throws when SD_API_TOKEN is missing' {
             InModuleScope ServiceDeskTools {
                 Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
                 { Invoke-SDRequest -Method 'GET' -Path '/incidents/1.json' } | Should -Throw
             }
         }
-        It 'uses default base URI when SD_BASE_URI not set' {
+        Safe-It 'uses default base URI when SD_BASE_URI not set' {
             InModuleScope ServiceDeskTools {
                 $env:SD_API_TOKEN = 't'
                 Remove-Item env:SD_BASE_URI -ErrorAction SilentlyContinue
@@ -189,7 +190,7 @@ Describe 'ServiceDeskTools Module' {
                 Remove-Item env:SD_API_TOKEN
             }
         }
-        It 'uses SD_BASE_URI when set' {
+        Safe-It 'uses SD_BASE_URI when set' {
             InModuleScope ServiceDeskTools {
                 $env:SD_API_TOKEN = 't'
                 $env:SD_BASE_URI = 'https://custom.example.com/api/'
@@ -201,7 +202,7 @@ Describe 'ServiceDeskTools Module' {
                 Remove-Item env:SD_BASE_URI
             }
         }
-        It 'uses SD_BASE_URI for assets when SD_ASSET_BASE_URI not set' {
+        Safe-It 'uses SD_BASE_URI for assets when SD_ASSET_BASE_URI not set' {
             InModuleScope ServiceDeskTools {
                 $env:SD_API_TOKEN = 't'
                 $env:SD_BASE_URI = 'https://custom.example.com/api/'
@@ -214,7 +215,7 @@ Describe 'ServiceDeskTools Module' {
                 Remove-Item env:SD_BASE_URI
             }
         }
-        It 'uses SD_ASSET_BASE_URI when set' {
+        Safe-It 'uses SD_ASSET_BASE_URI when set' {
             InModuleScope ServiceDeskTools {
                 $env:SD_API_TOKEN = 't'
                 $env:SD_ASSET_BASE_URI = 'https://assets.example.com/api/'
@@ -226,7 +227,7 @@ Describe 'ServiceDeskTools Module' {
                 Remove-Item env:SD_ASSET_BASE_URI
             }
         }
-        It 'converts body to JSON' {
+        Safe-It 'converts body to JSON' {
             InModuleScope ServiceDeskTools {
                 $env:SD_API_TOKEN = 't'
                 Mock Write-STLog {} -ModuleName ServiceDeskTools
@@ -243,12 +244,12 @@ Describe 'ServiceDeskTools Module' {
     }
 
     Context 'WhatIf support' {
-        It 'New-SDTicket does not invoke request when -WhatIf used' {
+        Safe-It 'New-SDTicket does not invoke request when -WhatIf used' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             New-SDTicket -Subject 's' -Description 'd' -RequesterEmail 'a@b.com' -WhatIf
             Assert-MockCalled Invoke-SDRequest -Times 0 -ModuleName ServiceDeskTools
         }
-        It 'Set-SDTicket does not invoke request when -WhatIf used' {
+        Safe-It 'Set-SDTicket does not invoke request when -WhatIf used' {
             Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
             Set-SDTicket -Id 1 -Fields @{status='Open'} -WhatIf
             Assert-MockCalled Invoke-SDRequest -Times 0 -ModuleName ServiceDeskTools
@@ -256,7 +257,7 @@ Describe 'ServiceDeskTools Module' {
     }
 
     Context 'Rate limiting and chaos mode' {
-        It 'pauses when SD_RATE_LIMIT_PER_MINUTE reached' {
+        Safe-It 'pauses when SD_RATE_LIMIT_PER_MINUTE reached' {
             InModuleScope ServiceDeskTools {
                 $env:SD_API_TOKEN = 't'
                 $env:SD_RATE_LIMIT_PER_MINUTE = '2'
@@ -281,7 +282,7 @@ Describe 'ServiceDeskTools Module' {
             }
         }
 
-        It 'honors ST_CHAOS_MODE with simulated failures' {
+        Safe-It 'honors ST_CHAOS_MODE with simulated failures' {
             InModuleScope ServiceDeskTools {
                 $env:SD_API_TOKEN = 't'
                 $env:ST_CHAOS_MODE = '1'

--- a/tests/ServiceDeskTools/Add-SDTicketComment.Tests.ps1
+++ b/tests/ServiceDeskTools/Add-SDTicketComment.Tests.ps1
@@ -6,7 +6,7 @@ Describe 'Add-SDTicketComment' {
         Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
     }
 
-    It 'returns API response on success' {
+    Safe-It 'returns API response on success' {
         InModuleScope ServiceDeskTools {
             Mock Invoke-SDRequest { @{ ok = $true } }
             $res = Add-SDTicketComment -Id 1 -Comment 'done'
@@ -19,7 +19,7 @@ Describe 'Add-SDTicketComment' {
         }
     }
 
-    It 'throws when Invoke-SDRequest fails' {
+    Safe-It 'throws when Invoke-SDRequest fails' {
         InModuleScope ServiceDeskTools {
             Mock Invoke-SDRequest { throw 'bad' }
             { Add-SDTicketComment -Id 2 -Comment 'x' } | Should -Throw

--- a/tests/ServiceDeskTools/Get-ServiceDeskStats.Tests.ps1
+++ b/tests/ServiceDeskTools/Get-ServiceDeskStats.Tests.ps1
@@ -7,7 +7,7 @@ Describe 'Get-ServiceDeskStats' {
         Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
     }
 
-    It 'groups incidents by status' {
+    Safe-It 'groups incidents by status' {
         InModuleScope ServiceDeskTools {
             $data = @(
                 @{ state = 'Open' },
@@ -22,7 +22,7 @@ Describe 'Get-ServiceDeskStats' {
         }
     }
 
-    It 'throws when Invoke-SDRequest fails' {
+    Safe-It 'throws when Invoke-SDRequest fails' {
         InModuleScope ServiceDeskTools {
             Mock Invoke-SDRequest { throw 'bad' }
             { Get-ServiceDeskStats -StartDate (Get-Date) -EndDate (Get-Date) } | Should -Throw

--- a/tests/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'SharePointTools Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
@@ -38,7 +39,7 @@ Describe 'SharePointTools Module' {
         $exported = (Get-Command -Module SharePointTools).Name
         foreach ($cmd in $expected) {
             $c = $cmd
-            It "Exports $c" {
+            Safe-It "Exports $c" {
                 $exported | Should -Contain $c
             }
         }
@@ -61,7 +62,7 @@ Describe 'SharePointTools Module' {
             @{ Fn = $m.Fn; Target = $m.Target }
         }
 
-        It '<Fn> calls <Target>' -ForEach $cases {
+        Safe-It '<Fn> calls <Target>' -ForEach $cases {
             Mock $Target {} -ModuleName SharePointTools
             & $Fn
             Assert-MockCalled $Target -ModuleName SharePointTools -Times 1
@@ -69,7 +70,7 @@ Describe 'SharePointTools Module' {
     }
 
     Context 'Library reporting wrapper' {
-        It 'calls Get-SPToolsLibraryReport for each site' {
+        Safe-It 'calls Get-SPToolsLibraryReport for each site' {
             $SharePointToolsSettings.Sites.Clear()
             $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso.sharepoint.com/sites/a'
             $SharePointToolsSettings.Sites['SiteB'] = 'https://contoso.sharepoint.com/sites/b'
@@ -80,7 +81,7 @@ Describe 'SharePointTools Module' {
         }
     }
     Context 'Recycle bin reporting wrapper' {
-        It 'calls Get-SPToolsRecycleBinReport for each site' {
+        Safe-It 'calls Get-SPToolsRecycleBinReport for each site' {
             $SharePointToolsSettings.Sites.Clear()
             $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso.sharepoint.com/sites/a'
             $SharePointToolsSettings.Sites['SiteB'] = 'https://contoso.sharepoint.com/sites/b'
@@ -91,7 +92,7 @@ Describe 'SharePointTools Module' {
         }
     }
     Context 'Preservation hold reporting wrapper' {
-        It 'calls Get-SPToolsPreservationHoldReport for each site' {
+        Safe-It 'calls Get-SPToolsPreservationHoldReport for each site' {
             $SharePointToolsSettings.Sites.Clear()
             $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso.sharepoint.com/sites/a'
             $SharePointToolsSettings.Sites['SiteB'] = 'https://contoso.sharepoint.com/sites/b'
@@ -115,7 +116,7 @@ Describe 'SharePointTools Module' {
             Remove-Item $tempCfg -ErrorAction SilentlyContinue
         }
 
-        It 'Add-SPToolsSite stores the URL and saves settings' {
+        Safe-It 'Add-SPToolsSite stores the URL and saves settings' {
             InModuleScope SharePointTools {
                 Mock Save-SPToolsSettings {}
                 Add-SPToolsSite -Name 'SiteA' -Url 'https://contoso.sharepoint.com/sites/a'
@@ -124,7 +125,7 @@ Describe 'SharePointTools Module' {
             }
         }
 
-        It 'Set-SPToolsSite updates an existing entry' {
+        Safe-It 'Set-SPToolsSite updates an existing entry' {
             InModuleScope SharePointTools {
                 Mock Save-SPToolsSettings {}
                 $SharePointToolsSettings.Sites['SiteA'] = 'https://old'
@@ -134,7 +135,7 @@ Describe 'SharePointTools Module' {
             }
         }
 
-        It 'Remove-SPToolsSite deletes the entry' {
+        Safe-It 'Remove-SPToolsSite deletes the entry' {
             InModuleScope SharePointTools {
                 Mock Save-SPToolsSettings {}
                 $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso'
@@ -144,7 +145,7 @@ Describe 'SharePointTools Module' {
             }
         }
 
-        It 'Add-SPToolsSite accepts pipeline input for Name' {
+        Safe-It 'Add-SPToolsSite accepts pipeline input for Name' {
             InModuleScope SharePointTools {
                 Mock Save-SPToolsSettings {}
                 'PipeSite' | Add-SPToolsSite -Url 'https://pipe'
@@ -153,7 +154,7 @@ Describe 'SharePointTools Module' {
             }
         }
 
-        It 'Set-SPToolsSite accepts pipeline input for Name' {
+        Safe-It 'Set-SPToolsSite accepts pipeline input for Name' {
             InModuleScope SharePointTools {
                 Mock Save-SPToolsSettings {}
                 $SharePointToolsSettings.Sites['PipeSite'] = 'https://old'
@@ -163,7 +164,7 @@ Describe 'SharePointTools Module' {
             }
         }
 
-        It 'Remove-SPToolsSite accepts pipeline input' {
+        Safe-It 'Remove-SPToolsSite accepts pipeline input' {
             InModuleScope SharePointTools {
                 Mock Save-SPToolsSettings {}
                 $SharePointToolsSettings.Sites['PipeSite'] = 'https://contoso'
@@ -173,7 +174,7 @@ Describe 'SharePointTools Module' {
             }
         }
 
-        It 'Get-SPToolsSiteUrl returns the url and throws when missing' {
+        Safe-It 'Get-SPToolsSiteUrl returns the url and throws when missing' {
             InModuleScope SharePointTools {
                 $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso'
                 Get-SPToolsSiteUrl -SiteName 'SiteA' | Should -Be 'https://contoso'
@@ -181,7 +182,7 @@ Describe 'SharePointTools Module' {
             }
         }
 
-        It 'Get-SPToolsSettings returns the current settings object' {
+        Safe-It 'Get-SPToolsSettings returns the current settings object' {
             InModuleScope SharePointTools {
                 $SharePointToolsSettings.Sites['SiteA'] = 'https://contoso'
                 (Get-SPToolsSettings).Sites['SiteA'] | Should -Be 'https://contoso'

--- a/tests/SharePointTools/Get-SPToolsSiteUrl.Tests.ps1
+++ b/tests/SharePointTools/Get-SPToolsSiteUrl.Tests.ps1
@@ -1,9 +1,10 @@
+. $PSScriptRoot/../TestHelpers.ps1
 Describe 'Get-SPToolsSiteUrl function' {
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/SharePointTools/SharePointTools.psd1 -Force
     }
-    It 'returns the matching URL' {
+    Safe-It 'returns the matching URL' {
         InModuleScope SharePointTools {
             $ExecutionContext.SessionState.PSVariable.Set('SharePointToolsSettings', @{ Sites = @{ A='https://a'; B='https://b' } })
             Mock Write-SPToolsHacker {}
@@ -11,7 +12,7 @@ Describe 'Get-SPToolsSiteUrl function' {
         }
     }
 
-    It 'parameter does not accept pipeline input' {
+    Safe-It 'parameter does not accept pipeline input' {
         InModuleScope SharePointTools {
             $meta = Get-Command Get-SPToolsSiteUrl
             $paramAttr = $meta.Parameters['SiteName'].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
@@ -20,7 +21,7 @@ Describe 'Get-SPToolsSiteUrl function' {
         }
     }
 
-    It 'throws when site is missing' {
+    Safe-It 'throws when site is missing' {
         InModuleScope SharePointTools {
             $ExecutionContext.SessionState.PSVariable.Set('SharePointToolsSettings', @{ Sites = @{ A='https://a' } })
             Mock Write-SPToolsHacker {}
@@ -28,7 +29,7 @@ Describe 'Get-SPToolsSiteUrl function' {
         }
     }
 
-    It 'logs lookup messages' {
+    Safe-It 'logs lookup messages' {
         InModuleScope SharePointTools {
             $ExecutionContext.SessionState.PSVariable.Set('SharePointToolsSettings', @{ Sites = @{ A='https://a' } })
             Mock Write-SPToolsHacker {}

--- a/tests/SharePointTools/Helper.Tests.ps1
+++ b/tests/SharePointTools/Helper.Tests.ps1
@@ -1,9 +1,10 @@
+. $PSScriptRoot/../TestHelpers.ps1
 Describe 'SharePointTools helper functions' {
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/SharePointTools/SharePointTools.psd1 -Force
     }
-    It 'Connect-SPToolsOnline retries until success' {
+    Safe-It 'Connect-SPToolsOnline retries until success' {
         InModuleScope SharePointTools {
             $script:attempt = 0
             function Connect-PnPOnline {}
@@ -15,12 +16,12 @@ Describe 'SharePointTools helper functions' {
             Assert-MockCalled Connect-PnPOnline -Times 2
         }
     }
-    It 'Invoke-SPPnPCommand rethrows errors' {
+    Safe-It 'Invoke-SPPnPCommand rethrows errors' {
         InModuleScope SharePointTools {
             { Invoke-SPPnPCommand { throw 'boom' } -ErrorMessage 'fail' } | Should -Throw
         }
     }
-    It 'Register-SPToolsCompleters registers completer commands' {
+    Safe-It 'Register-SPToolsCompleters registers completer commands' {
         InModuleScope SharePointTools {
             Mock Register-ArgumentCompleter {}
             Register-SPToolsCompleters

--- a/tests/SharePointTools/Integration.Tests.ps1
+++ b/tests/SharePointTools/Integration.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/../TestHelpers.ps1
 Describe 'SharePointTools Integration Functions' {
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
@@ -16,7 +17,7 @@ Describe 'SharePointTools Integration Functions' {
     }
 
     Context 'Get-SPToolsLibraryReport' {
-        It 'returns library information' {
+        Safe-It 'returns library information' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
                 function Get-PnPList {}
@@ -33,7 +34,7 @@ Describe 'SharePointTools Integration Functions' {
     }
 
     Context 'Get-SPToolsRecycleBinReport' {
-        It 'summarizes recycle bin usage' {
+        Safe-It 'summarizes recycle bin usage' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
                 function Get-PnPRecycleBinItem {}
@@ -51,7 +52,7 @@ Describe 'SharePointTools Integration Functions' {
 
 
     Context 'Invoke-FileVersionCleanup' {
-        It 'exports a CSV report' {
+        Safe-It 'exports a CSV report' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
                 function Get-PnPFolder {}
@@ -75,7 +76,7 @@ Describe 'SharePointTools Integration Functions' {
     }
 
     Context 'Invoke-SharingLinkCleanup' {
-        It 'removes sharing links from specified folder' {
+        Safe-It 'removes sharing links from specified folder' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
                 function Get-PnPFolderItem {}
@@ -101,7 +102,7 @@ Describe 'SharePointTools Integration Functions' {
     }
 
     Context 'Clear-SPToolsRecycleBin' {
-        It 'clears the first stage bin by default' {
+        Safe-It 'clears the first stage bin by default' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
                 function Clear-PnPRecycleBinItem { param([switch]$FirstStage,[switch]$SecondStage,[switch]$Force) }
@@ -116,7 +117,7 @@ Describe 'SharePointTools Integration Functions' {
     }
 
     Context 'Get-SPToolsPreservationHoldReport' {
-        It 'reports total hold size' {
+        Safe-It 'reports total hold size' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
                 function Get-PnPListItem {}
@@ -134,7 +135,7 @@ Describe 'SharePointTools Integration Functions' {
     }
 
     Context 'Get-SPPermissionsReport' {
-        It 'returns permission assignments' {
+        Safe-It 'returns permission assignments' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
                 function Get-PnPSite {}
@@ -151,7 +152,7 @@ Describe 'SharePointTools Integration Functions' {
     }
 
     Context 'Clean-SPVersionHistory' {
-        It 'invokes version cleanup when versions exceed threshold' {
+        Safe-It 'invokes version cleanup when versions exceed threshold' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
                 function Get-PnPListItem {}
@@ -172,7 +173,7 @@ Describe 'SharePointTools Integration Functions' {
     }
 
     Context 'Find-OrphanedSPFiles' {
-        It 'returns files older than specified days' {
+        Safe-It 'returns files older than specified days' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
                 function Get-PnPListItem {}
@@ -191,7 +192,7 @@ Describe 'SharePointTools Integration Functions' {
     }
 
     Context 'Select-SPToolsFolder' {
-        It 'returns chosen folder object' {
+        Safe-It 'returns chosen folder object' {
             InModuleScope SharePointTools {
                 function Get-PnPConnection {}
                 function Connect-PnPOnline {}
@@ -213,7 +214,7 @@ Describe 'SharePointTools Integration Functions' {
     }
 
     Context 'Get-SPToolsFileReport' {
-        It 'returns report entries for files' {
+        Safe-It 'returns report entries for files' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
                 function Get-PnPListItem {}
@@ -229,7 +230,7 @@ Describe 'SharePointTools Integration Functions' {
     }
 
     Context 'List-OneDriveUsage' {
-        It 'reports tenant site usage' {
+        Safe-It 'reports tenant site usage' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
                 function Get-PnPTenantSite {}
@@ -246,7 +247,7 @@ Describe 'SharePointTools Integration Functions' {
     }
 
     Context 'Test-SPToolsPrereqs' {
-        It 'installs module when missing and install flag used' {
+        Safe-It 'installs module when missing and install flag used' {
             InModuleScope SharePointTools {
                 function Install-Module {}
                 Mock Get-Module { $null } -ModuleName SharePointTools

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'SupportTools Module' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
@@ -28,7 +29,7 @@ Describe 'SupportTools Module' {
 
         $exported = (Get-Command -Module SupportTools).Name
         foreach ($cmd in $expected) {
-            It "Exports $cmd" {
+            Safe-It "Exports $cmd" {
                 $exported | Should -Contain $cmd
             }
         }
@@ -36,7 +37,7 @@ Describe 'SupportTools Module' {
 
 
     Context 'Sync-SupportTools behavior' {
-        It 'clones when repository is missing' {
+        Safe-It 'clones when repository is missing' {
             InModuleScope SupportTools {
                 function git {}
                 function Import-Module {}
@@ -48,7 +49,7 @@ Describe 'SupportTools Module' {
             }
         }
 
-        It 'pulls when repository exists' {
+        Safe-It 'pulls when repository exists' {
             InModuleScope SupportTools {
                 function git {}
                 function Import-Module {}
@@ -61,7 +62,7 @@ Describe 'SupportTools Module' {
             }
         }
 
-        It 'records transcript when path provided' {
+        Safe-It 'records transcript when path provided' {
             InModuleScope SupportTools {
                 function git {}
                 function Import-Module {}
@@ -80,7 +81,7 @@ Describe 'SupportTools Module' {
     }
 
     Context 'Search-ReadMe transcript' {
-        It 'starts and stops transcript when path is given' {
+        Safe-It 'starts and stops transcript when path is given' {
             InModuleScope SupportTools {
                 function Start-Transcript {}
                 function Stop-Transcript {}
@@ -94,7 +95,7 @@ Describe 'SupportTools Module' {
     }
 
     Context 'Error handling' {
-        It 'returns error record when git fails' {
+        Safe-It 'returns error record when git fails' {
             InModuleScope SupportTools {
                 function git { throw 'git fail' }
                 $res = Sync-SupportTools -RepositoryUrl 'url' -InstallPath 'path'
@@ -103,7 +104,7 @@ Describe 'SupportTools Module' {
             }
         }
 
-        It 'returns error record when search fails' {
+        Safe-It 'returns error record when search fails' {
             InModuleScope SupportTools {
                 function Get-ChildItem { throw 'bad' }
                 $res = Search-ReadMe

--- a/tests/SupportTools/CommandBehavior.Tests.ps1
+++ b/tests/SupportTools/CommandBehavior.Tests.ps1
@@ -1,10 +1,11 @@
+. $PSScriptRoot/../TestHelpers.ps1
 Describe 'SupportTools command behaviors' {
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force
     }
 
-    It 'Clear-TempFile removes tmp and log files' {
+    Safe-It 'Clear-TempFile removes tmp and log files' {
         $repoRoot = Resolve-Path "$PSScriptRoot/../.."
         $dir = Join-Path $repoRoot 'TempTest'
         New-Item -ItemType Directory -Path $dir | Out-Null
@@ -21,7 +22,7 @@ Describe 'SupportTools command behaviors' {
         }
     }
 
-    It 'Convert-ExcelToCsv passes correct path to Excel' {
+    Safe-It 'Convert-ExcelToCsv passes correct path to Excel' {
         InModuleScope SupportTools {
             Mock Import-Csv { @() } -ModuleName SupportTools
             function New-Object { param([string]$ComObject)
@@ -45,7 +46,7 @@ Describe 'SupportTools command behaviors' {
         }
     }
 
-    It 'Export-ProductKey writes key to file' {
+    Safe-It 'Export-ProductKey writes key to file' {
         InModuleScope SupportTools {
             Mock Get-CimInstance { [pscustomobject]@{ OA3xOriginalProductKey='AAAAA-BBBBB-CCCCC-DDDDD' } }
             $out = Join-Path $TestDrive 'key.txt'
@@ -60,14 +61,14 @@ Describe 'SupportTools command behaviors' {
     }
 
     Context 'Get-UniquePermission' {
-        It 'accepts pipeline input and forwards arguments' {
+        Safe-It 'accepts pipeline input and forwards arguments' {
             InModuleScope SupportTools {
                 Mock Invoke-ScriptFile {} -ModuleName SupportTools
                 'arg1','arg2' | Get-UniquePermission
                 Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -Times 2
             }
         }
-        It 'produces ErrorRecord when script fails' {
+        Safe-It 'produces ErrorRecord when script fails' {
             InModuleScope SupportTools {
                 function Invoke-ScriptFile { throw 'fail' }
                 try { Get-UniquePermission -Arguments 'a' } catch { $err = $_ }
@@ -76,7 +77,7 @@ Describe 'SupportTools command behaviors' {
         }
     }
 
-    It 'Start-Countdown loops ten times' {
+    Safe-It 'Start-Countdown loops ten times' {
         InModuleScope SupportTools {
             $count = 0
             Mock Write-STStatus {}
@@ -87,7 +88,7 @@ Describe 'SupportTools command behaviors' {
     }
 
     Context 'Invoke-JobBundle' {
-        It 'passes bundle path to script' {
+        Safe-It 'passes bundle path to script' {
             InModuleScope SupportTools {
                 Mock Compress-Archive {}
                 Mock Invoke-ScriptFile {} -ModuleName SupportTools
@@ -97,7 +98,7 @@ Describe 'SupportTools command behaviors' {
                 }
             }
         }
-        It 'returns ErrorRecord when script fails' {
+        Safe-It 'returns ErrorRecord when script fails' {
             InModuleScope SupportTools {
                 function Invoke-ScriptFile { throw 'oops' }
                 try { Invoke-JobBundle -Path 'bad.job.zip' } catch { $err = $_ }
@@ -106,7 +107,7 @@ Describe 'SupportTools command behaviors' {
         }
     }
 
-    It 'New-SPUsageReport forwards parameters' {
+    Safe-It 'New-SPUsageReport forwards parameters' {
         InModuleScope SupportTools {
             Mock Invoke-ScriptFile { 'report.csv' } -ModuleName SupportTools
             $res = New-SPUsageReport -CsvPath 'input.csv' -TranscriptPath 't.log'

--- a/tests/SupportTools/Export-ITReport.Tests.ps1
+++ b/tests/SupportTools/Export-ITReport.Tests.ps1
@@ -1,10 +1,11 @@
+. $PSScriptRoot/../TestHelpers.ps1
 Describe 'Export-ITReport function' {
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force
     }
 
-    It 'creates a CSV report' {
+    Safe-It 'creates a CSV report' {
         $path = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString() + '.csv')
         try {
             @([pscustomobject]@{A=1;B=2}) | Export-ITReport -Format CSV -OutputPath $path
@@ -15,7 +16,7 @@ Describe 'Export-ITReport function' {
         }
     }
 
-    It 'returns generated path when OutputPath not provided' {
+    Safe-It 'returns generated path when OutputPath not provided' {
         $path = @([pscustomobject]@{A=1}) | Export-ITReport -Format JSON
         try {
             Test-Path $path | Should -Be $true

--- a/tests/SupportTools/New-STDashboard.Tests.ps1
+++ b/tests/SupportTools/New-STDashboard.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/../TestHelpers.ps1
 Describe 'New-STDashboard function' {
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
@@ -5,7 +6,7 @@ Describe 'New-STDashboard function' {
         Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force
     }
 
-    It 'creates an HTML dashboard with metrics' {
+    Safe-It 'creates an HTML dashboard with metrics' {
         $log = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString() + '.log')
         $tlog = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString() + '.jsonl')
         $out = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString() + '.html')

--- a/tests/SupportTools/NewHireUserAutomation.Tests.ps1
+++ b/tests/SupportTools/NewHireUserAutomation.Tests.ps1
@@ -1,10 +1,11 @@
+. $PSScriptRoot/../TestHelpers.ps1
 Describe 'Invoke-NewHireUserAutomation function' {
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force
     }
 
-    It 'passes parameters to Invoke-ScriptFile' {
+    Safe-It 'passes parameters to Invoke-ScriptFile' {
         InModuleScope SupportTools {
             Mock Invoke-ScriptFile {} -ModuleName SupportTools
             Invoke-NewHireUserAutomation -PollMinutes 1 -Once -TranscriptPath 't.log'

--- a/tests/SystemScripts.Tests.ps1
+++ b/tests/SystemScripts.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'System Scripts' {
     BeforeAll {
         . "$PSScriptRoot/../scripts/Get-NetworkShares.ps1"
@@ -17,7 +18,7 @@ Describe 'System Scripts' {
             }
             Mock Write-STStatus {}
         }
-        It 'returns network share objects' {
+        Safe-It 'returns network share objects' {
             $result = Get-NetworkShares -ComputerName 'PC1'
             $result.ComputerName | Should -Be 'PC1'
             $result.Shares.Count | Should -Be 2
@@ -36,7 +37,7 @@ Describe 'System Scripts' {
             }
             Mock Write-STStatus {}
         }
-        It 'retrieves failed login events' {
+        Safe-It 'retrieves failed login events' {
             $result = Get-FailedLogins -ComputerName 'PC2'
             $result.Count | Should -Be 2
         }
@@ -48,7 +49,7 @@ Describe 'System Scripts' {
             function Set-TimeZone { param([string]$ID) $script:tz = $ID }
             function Write-STStatus {}
         }
-        It 'calls Set-TimeZone with the EST identifier' {
+        Safe-It 'calls Set-TimeZone with the EST identifier' {
             Set-TimeZoneEasternStandardTime
             $script:tz | Should -Be 'Eastern Standard Time'
         }
@@ -61,7 +62,7 @@ Describe 'System Scripts' {
             Mock Get-CimInstance { [pscustomobject]@{ OA3xOriginalProductKey = 'AAAAA-BBBBB-CCCCC-DDDDD-EEEEE' } }
             Mock Write-STStatus {}
         }
-        It 'writes the product key to output file' {
+        Safe-It 'writes the product key to output file' {
             $temp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
             & $PSScriptRoot/../scripts/ProductKey.ps1 -OutputPath $temp
             (Get-Content $temp) | Should -Be 'AAAAA-BBBBB-CCCCC-DDDDD-EEEEE'

--- a/tests/Telemetry.Tests.ps1
+++ b/tests/Telemetry.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'Telemetry Opt-In' {
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
@@ -7,7 +8,7 @@ Describe 'Telemetry Opt-In' {
         Import-Module $PSScriptRoot/../src/SupportTools/SupportTools.psd1 -Force
     }
 
-    It 'does not log telemetry when not opted in' {
+    Safe-It 'does not log telemetry when not opted in' {
         $log = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         $scriptFile = Join-Path $PSScriptRoot/.. 'scripts/TelemetryTest.ps1'
         Set-Content $scriptFile "Write-Host 'test'"
@@ -24,7 +25,7 @@ Describe 'Telemetry Opt-In' {
         }
     }
 
-    It 'logs telemetry when opt-in variable is set' {
+    Safe-It 'logs telemetry when opt-in variable is set' {
         $log = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         $scriptFile = Join-Path $PSScriptRoot/.. 'scripts/TelemetryTest.ps1'
         Set-Content $scriptFile "Write-Host 'test'"
@@ -56,7 +57,7 @@ Describe 'Telemetry Metrics Summary' {
         Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force
     }
 
-    It 'aggregates telemetry data' {
+    Safe-It 'aggregates telemetry data' {
         $log = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         $events = @(
             @{Timestamp='2024-01-01T00:00:00Z'; Script='Test.ps1'; Result='Success'; Duration=2},
@@ -75,7 +76,7 @@ Describe 'Telemetry Metrics Summary' {
         }
     }
 
-    It 'records metrics using Send-STMetric' {
+    Safe-It 'records metrics using Send-STMetric' {
         $log = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         try {
             $env:ST_ENABLE_TELEMETRY = '1'
@@ -93,7 +94,7 @@ Describe 'Telemetry Metrics Summary' {
         }
     }
 
-    It 'writes metrics to a sqlite database' {
+    Safe-It 'writes metrics to a sqlite database' {
         $log = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         $db  = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         $events = @(
@@ -127,7 +128,7 @@ Describe 'Telemetry Banner' {
         Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force
     }
 
-    It 'returns module and version data' {
+    Safe-It 'returns module and version data' {
         InModuleScope Telemetry {
             $expected = (Import-PowerShellDataFile "$PSScriptRoot/../src/Telemetry/Telemetry.psd1").ModuleVersion
             $banner = Show-TelemetryBanner


### PR DESCRIPTION
## Summary
- load TestHelpers in all tests
- switch Pester `It` blocks to `Safe-It`

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile './PesterConfiguration.psd1')` *(fails: New-PSDrive: A drive with the name 'TestDrive' already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68462b8c06d4832cbae87aff8de5e4cf