### PR TITLE
Add vault retrieval failure test

### DIFF
--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -178,6 +178,18 @@ Describe 'ServiceDeskTools Module' {
                 { Invoke-SDRequest -Method 'GET' -Path '/incidents/1.json' } | Should -Throw
             }
         }
+        It 'throws when SD_API_TOKEN cannot be loaded from vault' {
+            InModuleScope ServiceDeskTools {
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Import-Module $PSScriptRoot/../src/STPlatform/STPlatform.psd1 -Force
+                InModuleScope STPlatform {
+                    Mock Get-Secret { $null }
+                    Connect-STPlatform -Mode Cloud -Vault 'TestVault'
+                }
+                try { Invoke-SDRequest -Method 'GET' -Path '/incidents/99.json' } catch { $err = $_ }
+                $err | Should -BeOfType 'System.Management.Automation.ErrorRecord'
+            }
+        }
         It 'uses default base URI when SD_BASE_URI not set' {
             InModuleScope ServiceDeskTools {
                 $env:SD_API_TOKEN = 't'


### PR DESCRIPTION
## Summary
- extend ServiceDeskTools tests to cover failing secret retrieval

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: Cannot process argument transformation on parameter 'Configuration')*


------
https://chatgpt.com/codex/tasks/task_e_68462b913b18832c95c6f67486fac97c