### PR TITLE
Enable log forwarding

### DIFF
--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -14,7 +14,7 @@ Writes a message or metric to the SupportTools log.
 
 ```
 Write-STLog [-Message] <String> [[-Level] <String>] [[-Path] <String>] [-ProgressAction <ActionPreference>]
-[[-Metadata] <Hashtable>] [-Structured]
+[[-Metadata] <Hashtable>] [-Structured] [-ForwardUri <String>]
 [[-Metric] <String>] [[-Value] <Double>]
 [<CommonParameters>]
 ```
@@ -33,6 +33,12 @@ PS C:\> $sw.Stop()
 PS C:\> Write-STLog -Metric 'Duration' -Value $sw.Elapsed.TotalSeconds
 ```
 Records how long the task took in seconds using a structured log entry.
+
+### Example 2
+```powershell
+PS C:\> Write-STLog -Message 'Job started' -Structured -ForwardUri 'https://log.example.com/ingest'
+```
+Forwards the structured entry to the specified HTTP endpoint.
 
 ## PARAMETERS
 
@@ -107,6 +113,20 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ForwardUri
+HTTP endpoint to send structured log entries. Ignored when `-Structured` is not used.
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
## Summary
- support `-ForwardUri` parameter for `Write-STLog`
- forward structured logs via `Invoke-RestMethod`
- document `-ForwardUri` usage and show forwarding example

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68462b973e14832c9f9975529361fe04