### PR TITLE
Add telemetry details for Connect-STPlatform

### DIFF
--- a/docs/STPlatform/Connect-STPlatform.md
+++ b/docs/STPlatform/Connect-STPlatform.md
@@ -57,5 +57,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
+When telemetry is enabled via `$env:ST_ENABLE_TELEMETRY = '1'`, each run records
+the list of imported modules and the outcome of connection attempts. These
+values appear in the Details field of the `Connect-STPlatform` metric as
+`Modules` and `Connections`.
 
 ## RELATED LINKS

--- a/tests/STPlatform.Tests.ps1
+++ b/tests/STPlatform.Tests.ps1
@@ -77,7 +77,11 @@ Describe 'STPlatform Module' {
                     Assert-MockCalled Connect-ExchangeOnline -Times 1
                     Assert-MockCalled Install-Module -Times 2
                     (Get-Content $log | Measure-Object -Line).Lines | Should -Be 1
-                    (Get-Content $log | ConvertFrom-Json).MetricName | Should -Be 'Connect-STPlatform'
+                    $json = Get-Content $log | ConvertFrom-Json
+                    $json.MetricName | Should -Be 'Connect-STPlatform'
+                    $json.Details.Modules | Should -Be @('Microsoft.Graph','ExchangeOnlineManagement')
+                    $json.Details.Connections.Graph | Should -Be 'Success'
+                    $json.Details.Connections.ExchangeOnline | Should -Be 'Success'
                 } finally {
                     Remove-Item $log -ErrorAction SilentlyContinue
                     Remove-Item env:ST_ENABLE_TELEMETRY -ErrorAction SilentlyContinue
@@ -108,7 +112,11 @@ Describe 'STPlatform Module' {
                     Assert-MockCalled Connect-ExchangeOnline -Times 1
                     Assert-MockCalled Install-Module -Times 3
                     (Get-Content $log | Measure-Object -Line).Lines | Should -Be 1
-                    (Get-Content $log | ConvertFrom-Json).MetricName | Should -Be 'Connect-STPlatform'
+                    $json = Get-Content $log | ConvertFrom-Json
+                    $json.MetricName | Should -Be 'Connect-STPlatform'
+                    $json.Details.Modules | Should -Be @('Microsoft.Graph','ExchangeOnlineManagement','ActiveDirectory')
+                    $json.Details.Connections.Graph | Should -Be 'Success'
+                    $json.Details.Connections.ExchangeOnline | Should -Be 'Success'
                 } finally {
                     Remove-Item $log -ErrorAction SilentlyContinue
                     Remove-Item env:ST_ENABLE_TELEMETRY -ErrorAction SilentlyContinue
@@ -138,7 +146,10 @@ Describe 'STPlatform Module' {
                     Assert-MockCalled Connect-ExchangeServer -Times 1 -ParameterFilter { $Auto }
                     Assert-MockCalled Install-Module -Times 2
                     (Get-Content $log | Measure-Object -Line).Lines | Should -Be 1
-                    (Get-Content $log | ConvertFrom-Json).MetricName | Should -Be 'Connect-STPlatform'
+                    $json = Get-Content $log | ConvertFrom-Json
+                    $json.MetricName | Should -Be 'Connect-STPlatform'
+                    $json.Details.Modules | Should -Be @('ActiveDirectory','ExchangePowerShell')
+                    $json.Details.Connections.ExchangeOnPrem | Should -Be 'Success'
                 } finally {
                     Remove-Item $log -ErrorAction SilentlyContinue
                     Remove-Item env:ST_ENABLE_TELEMETRY -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- include modules and connection results in telemetry payload
- document new metric fields for `Connect-STPlatform`
- verify fields via new Pester assertions

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: ServiceDeskTools not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_68462b998704832ca80cffe9cf1312ae