### PR TITLE
Honor ST_LOG_LEVEL for Write-STStatus

### DIFF
--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -23,6 +23,7 @@ Write-STLog [-Message] <String> [[-Level] <String>] [[-Path] <String>] [-Progres
 Records log messages in a consistent format. Logs are written to `%USERPROFILE%\SupportToolsLogs\supporttools.log` or `$env:ST_LOG_PATH` if set.
 Set `ST_LOG_STRUCTURED=1` or use `-Structured` to output JSON lines. The structure is described in [RichLogFormat.md](./RichLogFormat.md).
 `ST_LOG_LEVEL` sets the minimum severity to record and `ST_LOG_ENCRYPT=1` encrypts the log file using the current user's context.
+Valid `ST_LOG_LEVEL` values are `INFO` (default), `WARN`, and `ERROR`.
 
 ## EXAMPLES
 

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -178,6 +178,14 @@ function Write-STStatus {
         [switch]$Log
     )
 
+    $levelMap = @{ INFO = 1; SUCCESS = 1; SUB = 1; FINAL = 1; WARN = 2; ERROR = 3; FATAL = 3 }
+    if ($env:ST_LOG_LEVEL) {
+        $configured = $env:ST_LOG_LEVEL.ToUpper()
+        if ($levelMap.ContainsKey($configured)) {
+            if ($levelMap[$Level] -lt $levelMap[$configured]) { return }
+        }
+    }
+
     switch ($Level) {
         'SUCCESS' { $prefix = '[+]'; $color = 'Green' }
         'ERROR'   { $prefix = '[-]'; $color = 'Red' }

--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -157,4 +157,29 @@ Describe 'Logging Module' {
             Remove-Item $logFile* -ErrorAction SilentlyContinue
         }
     }
+
+    Context 'ST_LOG_LEVEL filtering' {
+        It 'skips messages below configured level' {
+            Mock Write-Host {} -ModuleName Logging
+            try {
+                $env:ST_LOG_LEVEL = 'ERROR'
+                Write-STStatus 'warn' -Level WARN
+                Assert-MockCalled Write-Host -ModuleName Logging -Times 0
+            } finally {
+                Remove-Item env:ST_LOG_LEVEL -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'writes messages at or above configured level' {
+            Mock Write-Host {} -ModuleName Logging
+            try {
+                $env:ST_LOG_LEVEL = 'WARN'
+                Write-STStatus 'warn' -Level WARN
+                Write-STStatus 'err' -Level ERROR
+                Assert-MockCalled Write-Host -ModuleName Logging -Times 2
+            } finally {
+                Remove-Item env:ST_LOG_LEVEL -ErrorAction SilentlyContinue
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- filter `Write-STStatus` output when `$env:ST_LOG_LEVEL` is set
- document the valid log levels for `ST_LOG_LEVEL`
- add tests for log level filtering

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Configuration ./PesterConfiguration.psd1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462d26a010832c8e25455f67aaf113