### PR TITLE
Refactor Graph token flow

### DIFF
--- a/docs/EntraIDTools.md
+++ b/docs/EntraIDTools.md
@@ -14,6 +14,10 @@ Gallery first:
 Install-Module MSAL.PS
 ```
 
+The MSAL library maintains a shared token cache. `Get-GraphAccessToken` first
+attempts to retrieve a token silently using `Get-MsalToken -Silent` and only
+prompts for interactive or device login when no cached token is available.
+
 ## Prerequisites
 
 1. Create an Entra ID application registration with Microsoft Graph permissions.

--- a/src/EntraIDTools/Private/Get-GraphAccessToken.ps1
+++ b/src/EntraIDTools/Private/Get-GraphAccessToken.ps1
@@ -1,7 +1,7 @@
 function Get-GraphAccessToken {
     <#
     .SYNOPSIS
-        Retrieves and caches a Microsoft Graph access token.
+        Retrieves a Microsoft Graph access token.
 
     .PARAMETER DeviceLogin
         Authenticate interactively using a device code instead of a client
@@ -16,9 +16,7 @@ function Get-GraphAccessToken {
         [string]$ClientId,
         [ValidateNotNullOrEmpty()]
         [string]$ClientSecret,
-        [switch]$DeviceLogin,
-        [ValidateNotNullOrEmpty()]
-        [string]$CachePath = "$env:USERPROFILE/.graphToken.json"
+        [switch]$DeviceLogin
     )
 
     if (-not $TenantId)     { $TenantId     = $env:GRAPH_TENANT_ID }
@@ -27,22 +25,16 @@ function Get-GraphAccessToken {
 
     if (-not $TenantId) { throw 'TenantId is required. Provide -TenantId or set GRAPH_TENANT_ID.' }
     if (-not $ClientId) { throw 'ClientId is required. Provide -ClientId or set GRAPH_CLIENT_ID.' }
-    if (Test-Path $CachePath) {
-        try {
-            $cache = Get-Content $CachePath | ConvertFrom-Json
-            $expiry = [datetime]$cache.expiresOn
-            if ($expiry -gt (Get-Date).AddMinutes(5)) {
-                return $cache.accessToken
-            }
-        } catch {}
-    }
 
     $params = @{ TenantId = $TenantId; ClientId = $ClientId; Scopes = 'https://graph.microsoft.com/.default' }
     if ($ClientSecret -and -not $DeviceLogin) { $params.ClientSecret = $ClientSecret }
     else { $params.DeviceCode = $true }
 
-    $tokenResponse = Get-MsalToken @params
-    $cache = @{ accessToken = $tokenResponse.AccessToken; expiresOn = $tokenResponse.ExpiresOn }
-    $cache | ConvertTo-Json | Out-File -FilePath $CachePath -Encoding utf8
-    return $tokenResponse.AccessToken
+    try {
+        $token = (Get-MsalToken @params -Silent -ErrorAction Stop).AccessToken
+    } catch {
+        $token = (Get-MsalToken @params).AccessToken
+    }
+
+    return $token
 }

--- a/tests/EntraIDTools.Tests.ps1
+++ b/tests/EntraIDTools.Tests.ps1
@@ -81,16 +81,21 @@ Describe 'EntraIDTools Module' {
         }
     }
 
-    Context 'Environment variables' {
+    Context 'Authentication' {
         It 'uses GRAPH_* variables when parameters missing' {
-            $env:GRAPH_TENANT_ID = 'tidEnv'
-            $env:GRAPH_CLIENT_ID = 'cidEnv'
+            $env:GRAPH_TENANT_ID    = 'tidEnv'
+            $env:GRAPH_CLIENT_ID    = 'cidEnv'
             $env:GRAPH_CLIENT_SECRET = 'secEnv'
-            $cache = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
             try {
-                function Get-MsalToken { @{ AccessToken='tok'; ExpiresOn=(Get-Date).AddMinutes(30) } }
-                $token = Get-GraphAccessToken -CachePath $cache
+                $silentCalled = $false
+                function Get-MsalToken {
+                    param([switch]$Silent)
+                    $script:silentCalled = $Silent.IsPresent
+                    @{ AccessToken='tok' }
+                }
+                $token = Get-GraphAccessToken
                 $token | Should -Be 'tok'
+                $script:silentCalled | Should -Be $true
             } finally {
                 Remove-Item env:GRAPH_TENANT_ID -ErrorAction SilentlyContinue
                 Remove-Item env:GRAPH_CLIENT_ID -ErrorAction SilentlyContinue
@@ -99,53 +104,32 @@ Describe 'EntraIDTools Module' {
         }
 
         It 'uses device login when switch provided' {
-            $cache = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
-            try {
-                $deviceUsed = $false
-                function Get-MsalToken {
-                    param([switch]$DeviceCode)
-                    $script:deviceUsed = $DeviceCode.IsPresent
-                    @{ AccessToken='tok'; ExpiresOn=(Get-Date).AddMinutes(30) }
-                }
-                $token = Get-GraphAccessToken -TenantId 'tid' -ClientId 'cid' -ClientSecret 'sec' -DeviceLogin -CachePath $cache
-                $token | Should -Be 'tok'
-                $script:deviceUsed | Should -Be $true
-            } finally {
-                Remove-Item $cache -ErrorAction SilentlyContinue
+            $deviceUsed = $false
+            $callCount = 0
+            function Get-MsalToken {
+                param([switch]$DeviceCode, [switch]$Silent)
+                $script:callCount++
+                $script:deviceUsed = $DeviceCode.IsPresent
+                if ($Silent.IsPresent) { throw 'none' }
+                @{ AccessToken='tok' }
             }
-        }
-    }
-
-    Context 'Token caching' {
-        It 'returns cached token when not expired' {
-            $cache = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
-            try {
-                @{ accessToken='cached'; expiresOn=(Get-Date).AddMinutes(10) } |
-                    ConvertTo-Json | Out-File -FilePath $cache -Encoding utf8
-                $script:called = 0
-                function Get-MsalToken { $script:called++; throw 'should not call' }
-                $token = Get-GraphAccessToken -TenantId 'tid' -ClientId 'cid' -ClientSecret 'sec' -CachePath $cache
-                $token | Should -Be 'cached'
-                $script:called | Should -Be 0
-            } finally {
-                Remove-Item $cache -ErrorAction SilentlyContinue
-            }
+            $token = Get-GraphAccessToken -TenantId 'tid' -ClientId 'cid' -DeviceLogin
+            $token | Should -Be 'tok'
+            $script:callCount | Should -Be 2
+            $script:deviceUsed | Should -Be $true
         }
 
-        It 'refreshes expired token' {
-            $cache = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
-            try {
-                @{ accessToken='old'; expiresOn=(Get-Date).AddMinutes(-10) } |
-                    ConvertTo-Json | Out-File -FilePath $cache -Encoding utf8
-                $script:called = 0
-                function Get-MsalToken { $script:called++; @{ AccessToken='new'; ExpiresOn=(Get-Date).AddMinutes(30) } }
-                $token = Get-GraphAccessToken -TenantId 'tid' -ClientId 'cid' -ClientSecret 'sec' -CachePath $cache
-                $token | Should -Be 'new'
-                $script:called | Should -Be 1
-                (Get-Content $cache | ConvertFrom-Json).accessToken | Should -Be 'new'
-            } finally {
-                Remove-Item $cache -ErrorAction SilentlyContinue
+        It 'falls back to interactive when silent retrieval fails' {
+            $callCount = 0
+            function Get-MsalToken {
+                param([switch]$Silent)
+                $script:callCount++
+                if ($Silent.IsPresent) { throw 'no token' }
+                @{ AccessToken='tok' }
             }
+            $token = Get-GraphAccessToken -TenantId 'tid' -ClientId 'cid' -ClientSecret 'sec'
+            $token | Should -Be 'tok'
+            $script:callCount | Should -Be 2
         }
     }
 


### PR DESCRIPTION
## Summary
- remove custom cache logic from Get-GraphAccessToken
- retry Get-MsalToken silently first and fall back to interactive/device login
- update documentation for new MSAL cache behavior
- revise EntraIDTools tests for new auth flow

## Testing
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: The required module 'ServiceDeskTools' is not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_68462e518330832cbc32f32a2696d4c0