### PR TITLE
Add ServiceDeskTools error record test

### DIFF
--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -208,6 +208,16 @@ Describe 'ServiceDeskTools Module' {
                 { Invoke-SDRequest -Method 'GET' -Path '/incidents/1.json' } | Should -Throw
             }
         }
+        It 'throws an ErrorRecord when token cleared and vault missing' {
+            InModuleScope ServiceDeskTools {
+                $env:SD_API_TOKEN = 't'
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Mock Get-Secret { $null }
+                try { Invoke-SDRequest -Method 'GET' -Path '/incidents/1.json' } catch { $err = $_ }
+                $err | Should -BeOfType 'System.Management.Automation.ErrorRecord'
+                $err.Exception.Message | Should -Be 'SD_API_TOKEN environment variable must be set.'
+            }
+        }
         Safe-It 'uses default base URI when SD_BASE_URI not set' {
             InModuleScope ServiceDeskTools {
                 $env:SD_API_TOKEN = 't'


### PR DESCRIPTION
### Summary
- add test that clears token variable and expects thrown error record when vault lacks value

### File Citations
- `tests/ServiceDeskTools.Tests.ps1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463444ae38832c9e30ec3848e47f8f