### PR TITLE
Fix vault error test style

### DIFF
--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -201,7 +201,7 @@ Describe 'ServiceDeskTools Module' {
                 Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
             }
         }
-        It 'throws when token missing from env and vault' {
+        Safe-It 'throws when SD_API_TOKEN cannot be loaded from vault' {
             InModuleScope ServiceDeskTools {
                 Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
                 Mock Get-Secret { $null }


### PR DESCRIPTION
### Summary
- update test to use Safe-It when SD_API_TOKEN can't be loaded

### File Citations
- `tests/ServiceDeskTools.Tests.ps1`【F:tests/ServiceDeskTools.Tests.ps1†L200-L208】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to complete due to environment issues)【95327c†L1-L33】

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463428b914832cb39369ce26477555