### PR TITLE
Add Sanitize-STMessage

### DIFF
--- a/src/Logging/Logging.psd1
+++ b/src/Logging/Logging.psd1
@@ -5,5 +5,5 @@
     Author = 'Contoso'
     Description = 'Provides centralized logging utilities for all modules.'
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','Logging','Internal') } }
-    FunctionsToExport = @('Write-STLog','Write-STRichLog','Write-STStatus','Show-STPrompt','Write-STDivider','Write-STBlock','Write-STClosing')
+    FunctionsToExport = @('Write-STLog','Write-STRichLog','Write-STStatus','Show-STPrompt','Write-STDivider','Write-STBlock','Write-STClosing','Sanitize-STMessage')
 }

--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -173,4 +173,28 @@ Describe 'Logging Module' {
             Remove-Item env:ST_LOG_MAX_BYTES -ErrorAction SilentlyContinue
         }
     }
+
+    Safe-It 'sanitizes email addresses in logs' {
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            Write-STLog -Message 'contact admin@example.com for help' -Path $temp
+            $content = Get-Content $temp
+            $content | Should -Not -Match 'admin@example.com'
+            $content | Should -Match '\[REDACTED\]'
+        } finally {
+            Remove-Item $temp -ErrorAction SilentlyContinue
+        }
+    }
+
+    Safe-It 'sanitizes secret patterns in logs' {
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            Write-STLog -Message 'token=abc123def456ghi789jkl' -Path $temp
+            $content = Get-Content $temp
+            $content | Should -Not -Match 'abc123def456ghi789jkl'
+            $content | Should -Match 'token=\[REDACTED\]'
+        } finally {
+            Remove-Item $temp -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
### Summary
- add Sanitize-STMessage helper and call it from logging functions
- mask emails and secrets before writing logs
- test sanitization logic

### File Citations
- `src/Logging/Logging.psm1` lines 14-27, 63-71, 183-195, 286
- `src/Logging/Logging.psd1` lines 1-9
- `tests/Logging.Tests.ps1` lines 177-199

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(failed: missing modules)*
- Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463466bb10832cbb571b64f79c9f87