### PR TITLE
Add Get-ServiceDeskRelationship command

### DIFF
--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -13,6 +13,7 @@ Commands for interacting with the Service Desk ticketing API. **ServiceDeskTools
 | `Add-SDTicketComment` | Add a comment to an incident | `Add-SDTicketComment -Id 42 -Comment 'Investigating'` |
 | `Search-SDTicket` | Search incidents by keyword | `Search-SDTicket -Query 'printer'` |
 | `Get-ServiceDeskAsset` | Retrieve an asset by ID | `Get-ServiceDeskAsset -Id 99` |
+| `Get-ServiceDeskRelationship` | Retrieve asset relationships | `Get-ServiceDeskRelationship -AssetId 99 -Type 'component'` |
 | `Get-ServiceDeskStats` | Summarize incidents by status | `Get-ServiceDeskStats -StartDate (Get-Date).AddDays(-1) -EndDate (Get-Date)` |
 | `Set-SDTicketBulk` | Apply updates to multiple incidents | `Set-SDTicketBulk -Id 1,2,3 -Fields @{ status='Closed' }` |
 | `Link-SDTicketToSPTask` | Add a related SharePoint task link | `Link-SDTicketToSPTask -TicketId 42 -TaskUrl 'https://contoso.sharepoint.com/tasks/1'` |

--- a/docs/ServiceDeskTools/Get-ServiceDeskRelationship.md
+++ b/docs/ServiceDeskTools/Get-ServiceDeskRelationship.md
@@ -1,0 +1,43 @@
+---
+external help file: ServiceDeskTools-help.xml
+Module Name: ServiceDeskTools
+online version:
+schema: 2.0.0
+---
+
+# Get-ServiceDeskRelationship
+
+## SYNOPSIS
+Retrieves asset relationship records from the Service Desk.
+
+## SYNTAX
+```powershell
+Get-ServiceDeskRelationship [-AssetId <Int32>] [-Type <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Queries the Service Desk API for asset relationships. Use the optional parameters to filter by asset ID and relationship type.
+
+## PARAMETERS
+### -AssetId
+Asset identifier used to filter relationships.
+
+### -Type
+Relationship type filter.
+
+### -ProgressAction
+Specifies how progress is displayed.
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+### PSObject
+Relationship objects returned from the Service Desk API.
+
+## NOTES
+`SD_ASSET_BASE_URI` can be set to override the default Service Desk base URL for asset requests.
+
+## RELATED LINKS

--- a/src/ServiceDeskTools/Public/Get-ServiceDeskRelationship.ps1
+++ b/src/ServiceDeskTools/Public/Get-ServiceDeskRelationship.ps1
@@ -1,0 +1,44 @@
+function Get-ServiceDeskRelationship {
+    <#
+    .SYNOPSIS
+        Retrieves asset relationship records from the Service Desk.
+    .DESCRIPTION
+        Queries the Service Desk API for asset relationships. Results can be
+        filtered by asset identifier and relationship type.
+    .PARAMETER AssetId
+        Optional asset ID to filter relationships.
+    .PARAMETER Type
+        Optional relationship type to filter results.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [Parameter()] [int]$AssetId,
+        [Parameter()] [string]$Type,
+        [switch]$ChaosMode,
+        [switch]$Explain
+    )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
+
+    Write-STLog -Message "Get-ServiceDeskRelationship $AssetId $Type" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+
+    $path = '/asset_relationships.json'
+    $query = @()
+    if ($PSBoundParameters.ContainsKey('AssetId')) {
+        $query += 'asset_id=' + [uri]::EscapeDataString($AssetId)
+    }
+    if ($PSBoundParameters.ContainsKey('Type')) {
+        $query += 'relationship_type=' + [uri]::EscapeDataString($Type)
+    }
+    if ($query.Count -gt 0) { $path += '?' + ($query -join '&') }
+
+    $params = @{ Method = 'GET'; Path = $path; ChaosMode = $ChaosMode }
+    if ($env:SD_ASSET_BASE_URI) { $params.BaseUri = $env:SD_ASSET_BASE_URI }
+
+    if ($PSCmdlet.ShouldProcess('asset relationships', 'Get')) {
+        return Invoke-SDRequest @params
+    }
+}

--- a/tests/ServiceDeskTools/Get-ServiceDeskRelationship.Tests.ps1
+++ b/tests/ServiceDeskTools/Get-ServiceDeskRelationship.Tests.ps1
@@ -1,0 +1,35 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Get-ServiceDeskRelationship' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
+    }
+
+    Safe-It 'filters by asset id and type' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { @{ ok = $true } }
+            $res = Get-ServiceDeskRelationship -AssetId 5 -Type 'parent'
+            Assert-MockCalled Invoke-SDRequest -Times 1 -ParameterFilter {
+                $Method -eq 'GET' -and
+                $Path -eq '/asset_relationships.json?asset_id=5&relationship_type=parent'
+            }
+            $res.ok | Should -Be $true
+        }
+    }
+
+    Safe-It 'passes ChaosMode' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { @{ ok = $true } }
+            Get-ServiceDeskRelationship -ChaosMode
+            Assert-MockCalled Invoke-SDRequest -Times 1 -ParameterFilter { $ChaosMode -eq $true }
+        }
+    }
+
+    Safe-It 'throws when Invoke-SDRequest fails' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { throw 'bad' }
+            { Get-ServiceDeskRelationship -AssetId 1 } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- implement `Get-ServiceDeskRelationship` for querying asset relationships
- document new cmdlet
- test asset relationship queries
- mention new cmdlet in ServiceDeskTools overview

### File Citations
- `src/ServiceDeskTools/Public/Get-ServiceDeskRelationship.ps1`
- `docs/ServiceDeskTools/Get-ServiceDeskRelationship.md`
- `docs/ServiceDeskTools.md`
- `tests/ServiceDeskTools/Get-ServiceDeskRelationship.Tests.ps1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684634883da0832cbe0ce8b893703a62