### PR TITLE
Add Watch-GraphSignIns cmdlet

### DIFF
--- a/docs/EntraIDTools.md
+++ b/docs/EntraIDTools.md
@@ -41,6 +41,7 @@ Install-Module MSAL.PS
 | `Get-GraphUserDetails` | Retrieve metadata for a user | `Get-GraphUserDetails -UserPrincipalName user@contoso.com -TenantId <tenant> -ClientId <app>` |
 | `Get-GraphGroupDetails` | Retrieve metadata for a group | `Get-GraphGroupDetails -GroupId <id> -TenantId <tenant> -ClientId <app>` |
 | `Get-GraphSignInLogs` | Retrieve user sign-in events | `Get-GraphSignInLogs -UserPrincipalName user@contoso.com -TenantId <tenant> -ClientId <app>` |
+| `Watch-GraphSignIns` | Ticket risky sign-ins automatically | `Watch-GraphSignIns -TenantId <tenant> -ClientId <app> -RequesterEmail admin@example.com` |
 
 The command requires an Entra ID application registration. Provide the tenant ID, client ID and optional client secret for authentication.
 

--- a/docs/EntraIDTools/Watch-GraphSignIns.md
+++ b/docs/EntraIDTools/Watch-GraphSignIns.md
@@ -1,0 +1,69 @@
+---
+external help file: EntraIDTools-help.xml
+Module Name: EntraIDTools
+online version:
+schema: 2.0.0
+---
+
+# Watch-GraphSignIns
+
+Monitor sign-in logs and create Service Desk tickets for risky events.
+
+## SYNTAX
+```powershell
+Watch-GraphSignIns [-UserPrincipalName <String>] [-StartTime <DateTime>] [-EndTime <DateTime>]
+ [-TenantId] <String> [-ClientId] <String> [-ClientSecret <String>] [-RequesterEmail] <String>
+ [-Threshold <String>] [-ChaosMode] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Combines `Get-GraphSignInLogs` with `New-SDTicket`. Sign-ins whose `riskLevelAggregated`
+meets or exceeds `-Threshold` trigger ticket creation. Use `-ChaosMode` or set
+`ST_CHAOS_MODE=1` to simulate failures during ticket creation.
+
+## EXAMPLE
+```powershell
+PS C:\> Watch-GraphSignIns -TenantId <tenant> -ClientId <app> -RequesterEmail 'admin@example.com'
+```
+Retrieves the last hour of sign-ins and opens Service Desk tickets for any high risk events.
+
+## PARAMETERS
+### -UserPrincipalName
+UPN to filter sign-ins.
+
+### -StartTime
+Start of the time range. Defaults to one hour ago.
+
+### -EndTime
+End of the time range. Defaults to now.
+
+### -TenantId
+Tenant used for authentication.
+
+### -ClientId
+Application (client) ID for Graph authentication.
+
+### -ClientSecret
+Optional client secret for app-only auth.
+
+### -RequesterEmail
+Email address used for Service Desk tickets.
+
+### -Threshold
+Risk level that triggers ticket creation. Accepts Low, Medium or High.
+
+### -ChaosMode
+Enable chaos testing when creating tickets.
+
+### CommonParameters
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`,
+`-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`,
+`-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`.
+
+## INPUTS
+None.
+
+## OUTPUTS
+An array of sign-in log objects.
+
+## NOTES

--- a/src/EntraIDTools/EntraIDTools.psd1
+++ b/src/EntraIDTools/EntraIDTools.psd1
@@ -11,5 +11,5 @@
             ReleaseNotes = 'Initial stable release of EntraIDTools.'
         }
     }
-    FunctionsToExport = @('Get-GraphUserDetails','Get-GraphGroupDetails','Get-UserInfoHybrid','Disable-GraphUser','Get-GraphSignInLogs','Get-GraphRiskySignIns')
+    FunctionsToExport = @('Get-GraphUserDetails','Get-GraphGroupDetails','Get-UserInfoHybrid','Disable-GraphUser','Get-GraphSignInLogs','Get-GraphRiskySignIns','Watch-GraphSignIns')
 }

--- a/src/EntraIDTools/EntraIDTools.psm1
+++ b/src/EntraIDTools/EntraIDTools.psm1
@@ -8,7 +8,7 @@ Import-Module $telemetryModule -ErrorAction SilentlyContinue
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Get-GraphUserDetails','Get-GraphGroupDetails','Get-UserInfoHybrid','Disable-GraphUser','Get-GraphSignInLogs','Get-GraphRiskySignIns'
+Export-ModuleMember -Function 'Get-GraphUserDetails','Get-GraphGroupDetails','Get-UserInfoHybrid','Disable-GraphUser','Get-GraphSignInLogs','Get-GraphRiskySignIns','Watch-GraphSignIns'
 
 function Show-EntraIDToolsBanner {
     <#

--- a/src/EntraIDTools/Public/Watch-GraphSignIns.ps1
+++ b/src/EntraIDTools/Public/Watch-GraphSignIns.ps1
@@ -1,0 +1,77 @@
+function Watch-GraphSignIns {
+    <#
+    .SYNOPSIS
+        Monitor sign-in logs and create Service Desk tickets when risky events are detected.
+    .DESCRIPTION
+        Combines Get-GraphSignInLogs with New-SDTicket. Sign-ins with a risk level
+        equal to or above the specified threshold trigger ticket creation.
+        Activity is logged and chaos testing can be enabled.
+    .PARAMETER UserPrincipalName
+        Optional UPN to filter the sign-in logs.
+    .PARAMETER StartTime
+        Optional start time for the query. Defaults to one hour ago.
+    .PARAMETER EndTime
+        Optional end time for the query. Defaults to now.
+    .PARAMETER TenantId
+        GUID identifier for the Entra ID tenant.
+    .PARAMETER ClientId
+        Application (client) ID used for Microsoft Graph authentication.
+    .PARAMETER ClientSecret
+        Optional client secret for app-only authentication.
+    .PARAMETER RequesterEmail
+        Email address used when creating Service Desk tickets.
+    .PARAMETER Threshold
+        Minimum risk level that triggers ticket creation. Low < Medium < High.
+    .PARAMETER ChaosMode
+        Enable chaos testing during ticket creation.
+    .EXAMPLE
+        Watch-GraphSignIns -TenantId <tenant> -ClientId <app> -RequesterEmail 'admin@example.com'
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [string]$UserPrincipalName,
+        [datetime]$StartTime = (Get-Date).AddHours(-1),
+        [datetime]$EndTime = (Get-Date),
+        [Parameter(Mandatory)]
+        [string]$TenantId,
+        [Parameter(Mandatory)]
+        [string]$ClientId,
+        [string]$ClientSecret,
+        [Parameter(Mandatory)]
+        [string]$RequesterEmail,
+        [ValidateSet('Low','Medium','High')]
+        [string]$Threshold = 'High',
+        [switch]$ChaosMode,
+        [switch]$Explain
+    )
+
+    if ($Explain) { Get-Help $MyInvocation.PSCommandPath -Full; return }
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    Write-STLog -Message 'Watch-GraphSignIns' -Structured -Metadata @{ threshold=$Threshold }
+    $result = 'Success'
+    try {
+        $logs = Get-GraphSignInLogs -UserPrincipalName $UserPrincipalName -StartTime $StartTime -EndTime $EndTime -TenantId $TenantId -ClientId $ClientId -ClientSecret $ClientSecret
+        if (-not $logs) { return }
+        $order = @{ low = 1; medium = 2; high = 3 }
+        $threshVal = $order[$Threshold.ToLower()]
+        foreach ($log in $logs) {
+            $risk = $log.riskLevelAggregated
+            if ($order[$risk.ToLower()] -ge $threshVal) {
+                $subject = "Risky sign-in for $($log.userPrincipalName)"
+                $desc = "Risk level $risk from IP $($log.ipAddress) at $($log.createdDateTime)"
+                if ($PSCmdlet.ShouldProcess($subject, 'Create Ticket')) {
+                    New-SDTicket -Subject $subject -Description $desc -RequesterEmail $RequesterEmail -ChaosMode:$ChaosMode | Out-Null
+                }
+            }
+        }
+        return $logs
+    } catch {
+        $result = 'Failure'
+        Write-STLog -Message "Watch-GraphSignIns failed: $_" -Level ERROR
+        throw
+    } finally {
+        $sw.Stop()
+        Write-STTelemetryEvent -ScriptName 'Watch-GraphSignIns' -Result $result -Duration $sw.Elapsed
+    }
+}

--- a/tests/EntraIDTools.Tests.ps1
+++ b/tests/EntraIDTools.Tests.ps1
@@ -25,6 +25,9 @@ Describe 'EntraIDTools Module' {
         Safe-It 'Exports Get-GraphSignInLogs' {
             (Get-Command -Module EntraIDTools).Name | Should -Contain 'Get-GraphSignInLogs'
         }
+        Safe-It 'Exports Watch-GraphSignIns' {
+            (Get-Command -Module EntraIDTools).Name | Should -Contain 'Watch-GraphSignIns'
+        }
     }
 
     Context 'Logging and telemetry' {
@@ -64,6 +67,12 @@ Describe 'EntraIDTools Module' {
             Get-GraphSignInLogs -UserPrincipalName 'u' -TenantId 'tid' -ClientId 'cid'
             Assert-MockCalled Write-STLog -ModuleName EntraIDTools -Times 1
             Assert-MockCalled Write-STTelemetryEvent -ModuleName EntraIDTools -Times 1
+        }
+        Safe-It 'Creates tickets for risky sign-ins' {
+            Mock Get-GraphSignInLogs { @(@{ userPrincipalName='u'; createdDateTime=(Get-Date); ipAddress='1.2.3.4'; riskLevelAggregated='high' }) } -ModuleName EntraIDTools
+            Mock New-SDTicket {} -ModuleName EntraIDTools
+            Watch-GraphSignIns -TenantId 'tid' -ClientId 'cid' -RequesterEmail 'r@contoso.com'
+            Assert-MockCalled New-SDTicket -ModuleName EntraIDTools -Times 1
         }
     }
 


### PR DESCRIPTION
### Summary
- combine sign-in log retrieval with ticket creation
- surface risk threshold parameter and chaos mode
- document Watch-GraphSignIns

### File Citations
- `src/EntraIDTools/Public/Watch-GraphSignIns.ps1`【F:src/EntraIDTools/Public/Watch-GraphSignIns.ps1†L1-L76】
- `docs/EntraIDTools/Watch-GraphSignIns.md`【F:docs/EntraIDTools/Watch-GraphSignIns.md†L1-L40】
- `docs/EntraIDTools.md` table update【F:docs/EntraIDTools.md†L40-L44】

### Test Results
Tests could not be executed: `Invoke-Pester` failed because dependencies were missing in the environment. Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684634aea290832c9badec7d73a64c49