### PR TITLE
Honor ST_LOG_LEVEL

### DIFF
--- a/docs/Logging/Write-STLog.md
+++ b/docs/Logging/Write-STLog.md
@@ -22,7 +22,7 @@ Write-STLog [-Message] <String> [[-Level] <String>] [[-Path] <String>] [-Progres
 ## DESCRIPTION
 Records log messages in a consistent format. Logs are written to `%USERPROFILE%\SupportToolsLogs\supporttools.log` or `$env:ST_LOG_PATH` if set.
 Set `ST_LOG_STRUCTURED=1` or use `-Structured` to output JSON lines. The structure is described in [RichLogFormat.md](./RichLogFormat.md).
-`ST_LOG_LEVEL` sets the minimum severity to record and `ST_LOG_ENCRYPT=1` encrypts the log file using the current user's context.
+`ST_LOG_LEVEL` sets the minimum severity to record (INFO, WARN or ERROR) and `ST_LOG_ENCRYPT=1` encrypts the log file using the current user's context.
 
 ## EXAMPLES
 

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -190,6 +190,14 @@ function Write-STStatus {
         [switch]$Log
     )
 
+    $levelTable = @{ INFO = 1; WARN = 2; ERROR = 3 }
+    $msgTable   = @{ INFO = 1; SUCCESS = 1; SUB = 1; FINAL = 1; WARN = 2; ERROR = 3; FATAL = 3 }
+    $envLevel   = $env:ST_LOG_LEVEL
+    $envValue   = if ($envLevel) { $levelTable[$envLevel.ToUpper()] } else { 1 }
+    if (-not $envValue) { $envValue = 1 }
+    $msgValue   = $msgTable[$Level]
+    if ($msgValue -lt $envValue) { return }
+
     switch ($Level) {
         'SUCCESS' { $prefix = '[+]'; $color = 'Green' }
         'ERROR'   { $prefix = '[-]'; $color = 'Red' }

--- a/tests/Logging.UI.Tests.ps1
+++ b/tests/Logging.UI.Tests.ps1
@@ -55,4 +55,14 @@ Describe 'Logging UI Functions' {
         $banner.Module | Should -Be 'Logging'
         $banner.Version | Should -Not -BeNullOrEmpty
     }
+
+    Safe-It 'filters messages below ST_LOG_LEVEL' {
+        try {
+            $env:ST_LOG_LEVEL = 'WARN'
+            { Write-STStatus -Message 'info hidden' -Level INFO } | Should -BeNullOrEmpty
+            { Write-STStatus -Message 'show warn' -Level WARN } | Should -Output '[!] show warn'
+        } finally {
+            Remove-Item env:ST_LOG_LEVEL -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
### Summary
- respect `ST_LOG_LEVEL` when displaying status messages
- document valid log levels
- test status filtering

### File Citations
- `src/Logging/Logging.psm1`
- `docs/Logging/Write-STLog.md`
- `tests/Logging.UI.Tests.ps1`

### Test Results
- `Invoke-Pester`: **failed** (303 failures)
  - see snippet for details

------
https://chatgpt.com/codex/tasks/task_e_684634bd8304832cbf438c642e5c2ee1