### PR TITLE
Refactor Graph token retrieval

### DIFF
--- a/docs/EntraIDTools.md
+++ b/docs/EntraIDTools.md
@@ -52,3 +52,5 @@ You can also set the following environment variables so parameters aren't requir
 
 When these variables are present, `Get-GraphUserDetails` and other commands will use them automatically.
 
+Authentication tokens are cached by the **MSAL.PS** module. `Get-GraphAccessToken` first attempts a silent token lookup and only prompts for interactive or device login when required.
+


### PR DESCRIPTION
### Summary
- remove custom Graph token cache logic
- update tests for new Get-GraphAccessToken behavior
- describe MSAL token caching in docs

### File Citations
- `src/EntraIDTools/Private/Get-GraphAccessToken.ps1`
- `docs/EntraIDTools.md`
- `tests/EntraIDTools.Tests.ps1`

### Test Results
- ❌ `Invoke-Pester` failed: 300 tests failed, 0 passed (see logs)


------
https://chatgpt.com/codex/tasks/task_e_684634cf126c832cacbdf93a21802ce9