### PR TITLE
Add CPU and disk metrics to audit output

### DIFF
--- a/docs/PerformanceTools/Invoke-PerformanceAudit.md
+++ b/docs/PerformanceTools/Invoke-PerformanceAudit.md
@@ -27,9 +27,9 @@ Generates a report and opens a ticket if thresholds are exceeded.
 
 #### Example Output
 ```text
-CpuPercent MemoryPercent DiskPercent NetworkMbps Uptime
---------- ------------ ----------- ----------- ------
-42        55           12          1.2          1:23:45
+CpuPercent CpuSamples MemoryPercent DiskPercent DiskSamples NetworkMbps Uptime
+--------- ---------- ------------ ----------- ----------- ----------- ------
+42        {10,10,10} 55           12          {10,10,10} 1.2          1:23:45
 ```
 
 ## PARAMETERS
@@ -58,7 +58,7 @@ Optional path for a transcript log.
 None
 
 ## OUTPUTS
-A custom object with the properties `CpuPercent`, `MemoryPercent`, `DiskPercent`, `NetworkMbps` and `Uptime`. When a ticket is created a `TicketId` property is included.
+A custom object with the properties `CpuPercent`, `CpuSamples`, `MemoryPercent`, `DiskPercent`, `DiskSamples`, `NetworkMbps` and `Uptime`. When a ticket is created a `TicketId` property is included.
 
 ## NOTES
 ## RELATED LINKS

--- a/src/PerformanceTools/Invoke-PerformanceAudit.ps1
+++ b/src/PerformanceTools/Invoke-PerformanceAudit.ps1
@@ -58,7 +58,8 @@ try {
 
     # CPU usage
     $cpuSamples = Get-Counter '\Processor(_Total)\% Processor Time' -SampleInterval 1 -MaxSamples 3
-    $cpuUsage = [math]::Round(($cpuSamples.CounterSamples | Measure-Object -Property CookedValue -Average).Average,2)
+    $cpuSampleValues = $cpuSamples.CounterSamples | Select-Object -ExpandProperty CookedValue
+    $cpuUsage = [math]::Round(($cpuSampleValues | Measure-Object -Average).Average,2)
     Write-STLog -Metric 'CPUPercent' -Value $cpuUsage -Structured
     Send-STMetric -MetricName 'CPUPercent' -Category 'Audit' -Value $cpuUsage
 
@@ -70,7 +71,8 @@ try {
 
     # Disk utilisation
     $diskSamples = Get-Counter '\PhysicalDisk(_Total)\% Disk Time' -SampleInterval 1 -MaxSamples 3
-    $diskUsage = [math]::Round(($diskSamples.CounterSamples | Measure-Object -Property CookedValue -Average).Average,2)
+    $diskSampleValues = $diskSamples.CounterSamples | Select-Object -ExpandProperty CookedValue
+    $diskUsage = [math]::Round(($diskSampleValues | Measure-Object -Average).Average,2)
     Write-STLog -Metric 'DiskPercent' -Value $diskUsage -Structured
     Send-STMetric -MetricName 'DiskPercent' -Category 'Audit' -Value $diskUsage
 
@@ -87,8 +89,10 @@ try {
 
     $report = [pscustomobject]@{
         CpuPercent     = $cpuUsage
+        CpuSamples     = $cpuSampleValues
         MemoryPercent  = $memUsedPct
         DiskPercent    = $diskUsage
+        DiskSamples    = $diskSampleValues
         NetworkMbps    = $netMbps
         Uptime         = $uptime
     }

--- a/tests/PerformanceTools/Invoke-PerformanceAudit.Tests.ps1
+++ b/tests/PerformanceTools/Invoke-PerformanceAudit.Tests.ps1
@@ -29,6 +29,15 @@ Describe 'Invoke-PerformanceAudit.ps1 script' {
         Assert-MockCalled Send-STMetric -ParameterFilter { $MetricName -eq 'PerformanceAuditDuration' } -Times 1
     }
 
+    Safe-It 'returns CPU and disk usage data' {
+        $result = & $ScriptPath -CpuThreshold 100 -MemoryThreshold 100 -DiskThreshold 100 -NetworkThreshold 100 -RequesterEmail 'user@example.com'
+        $result | Should -Not -BeNull
+        $result.CpuSamples.Count | Should -Be 3
+        $result.DiskSamples.Count | Should -Be 3
+        $result.CpuPercent | Should -BeGreaterOrEqual 0
+        $result.DiskPercent | Should -BeGreaterOrEqual 0
+    }
+
     Safe-It 'creates a ticket when thresholds exceeded' {
         & $ScriptPath -CpuThreshold 0 -MemoryThreshold 0 -DiskThreshold 0 -NetworkThreshold 0 -CreateTicket -RequesterEmail 'user@example.com' | Out-Null
         Assert-MockCalled Write-STStatus -ParameterFilter { $Message -eq 'Performance thresholds exceeded:' } -Times 1


### PR DESCRIPTION
### Summary
- collect CPU and disk samples during Invoke-PerformanceAudit
- expose those samples in the result object
- document new fields in Invoke-PerformanceAudit docs
- check new metrics in tests

### File Citations
- `src/PerformanceTools/Invoke-PerformanceAudit.ps1` lines [60-98](F:src/PerformanceTools/Invoke-PerformanceAudit.ps1#L60-L98)
- `docs/PerformanceTools/Invoke-PerformanceAudit.md` lines [24-33](F:docs/PerformanceTools/Invoke-PerformanceAudit.md#L24-L33) and [56-61](F:docs/PerformanceTools/Invoke-PerformanceAudit.md#L56-L61)
- `tests/PerformanceTools/Invoke-PerformanceAudit.Tests.ps1` lines [24-39](F:tests/PerformanceTools/Invoke-PerformanceAudit.Tests.ps1#L24-L39)

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684638c2a54c832ca04404e0c06d0235