### PR TITLE
Add optional Path to Save-SPToolsSettings

### DIFF
--- a/docs/SharePointTools.md
+++ b/docs/SharePointTools.md
@@ -20,7 +20,7 @@ All functions emit short, high contrast messages following the style in [ModuleS
 
 | Command | Description | Key Parameters | Example |
 |---------|-------------|---------------|---------|
-| `Save-SPToolsSettings` | Persist the current configuration to disk. | none | `Save-SPToolsSettings` |
+| `Save-SPToolsSettings` | Persist the current configuration to disk. | `[Path]` | `Save-SPToolsSettings -Path ./mysettings.psd1` |
 | `Get-SPToolsSettings` | Return the loaded configuration. | none | `Get-SPToolsSettings` |
 | `Test-SPToolsPrereqs` | Verify PnP.PowerShell dependency. Use `-Install` to install. | `[Install]` | `Test-SPToolsPrereqs -Install` |
 | `Get-SPToolsSiteUrl` | Retrieve a site URL by friendly name. | `SiteName` | `Get-SPToolsSiteUrl -SiteName HR` |

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -187,12 +187,14 @@ function Save-SPToolsSettings {
         Save-SPToolsSettings
     #>
     [CmdletBinding(SupportsShouldProcess=$true)]
-    param()
+    param(
+        [string]$Path = $settingsFile
+    )
     process {
-        if ($PSCmdlet.ShouldProcess($settingsFile, 'Save configuration')) {
+        if ($PSCmdlet.ShouldProcess($Path, 'Save configuration')) {
             Write-SPToolsHacker 'Saving configuration'
-            $SharePointToolsSettings | Out-File -FilePath $settingsFile -Encoding utf8
-            Write-SPToolsHacker 'Configuration saved' -Level SUCCESS -Metadata @{ Path = $settingsFile }
+            $SharePointToolsSettings | Out-File -FilePath $Path -Encoding utf8
+            Write-SPToolsHacker 'Configuration saved' -Level SUCCESS -Metadata @{ Path = $Path }
         }
     }
 }

--- a/tests/SharePointTools/Helper.Tests.ps1
+++ b/tests/SharePointTools/Helper.Tests.ps1
@@ -28,4 +28,29 @@ Describe 'SharePointTools helper functions' {
             Assert-MockCalled Register-ArgumentCompleter -Times 2
         }
     }
+
+    Safe-It 'Save-SPToolsSettings uses default path when none specified' {
+        InModuleScope SharePointTools {
+            $temp = [System.IO.Path]::GetTempFileName()
+            $script:settingsFile = $temp
+            $SharePointToolsSettings = @{ A = 1 }
+            Mock Out-File {}
+            Mock Write-SPToolsHacker {}
+            Save-SPToolsSettings
+            Assert-MockCalled Out-File -Times 1 -ParameterFilter { $FilePath -eq $temp }
+            Remove-Item $temp -ErrorAction SilentlyContinue
+        }
+    }
+
+    Safe-It 'Save-SPToolsSettings accepts custom path' {
+        InModuleScope SharePointTools {
+            $temp = [System.IO.Path]::GetTempFileName()
+            $SharePointToolsSettings = @{ A = 1 }
+            Mock Out-File {}
+            Mock Write-SPToolsHacker {}
+            Save-SPToolsSettings -Path $temp
+            Assert-MockCalled Out-File -Times 1 -ParameterFilter { $FilePath -eq $temp }
+            Remove-Item $temp -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
### Summary
- allow `Save-SPToolsSettings` to save to a custom path
- document new `-Path` parameter usage
- test default and custom path behaviour

### File Citations
- [src/SharePointTools/SharePointTools.psm1](src/SharePointTools/SharePointTools.psm1#L182-L200)
- [docs/SharePointTools.md](docs/SharePointTools.md#L21-L24)
- [tests/SharePointTools/Helper.Tests.ps1](tests/SharePointTools/Helper.Tests.ps1#L31-L56)

### Test Results
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.
```

------
https://chatgpt.com/codex/tasks/task_e_684638a35088832c9b16b49e882ce63e