### PR TITLE
Add telemetry summary email script

### DIFF
--- a/docs/Telemetry/Get-STTelemetryMetrics.md
+++ b/docs/Telemetry/Get-STTelemetryMetrics.md
@@ -46,3 +46,4 @@ A list of objects with Script, Executions, Successes, Failures, AverageSeconds a
 
 ## NOTES
 The `sqlite3` command line tool must be available when using `-SqlitePath`.
+Use `Send-TelemetrySummary.ps1` to email the resulting metrics.

--- a/scripts/Send-TelemetrySummary.ps1
+++ b/scripts/Send-TelemetrySummary.ps1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+    Emails a summary of SupportTools telemetry metrics.
+.DESCRIPTION
+    Reads telemetry events from the local log and summarizes them using
+    Get-STTelemetryMetrics. The formatted summary is emailed using
+    Send-MailMessage.
+.PARAMETER To
+    Recipient email address for the summary.
+.PARAMETER From
+    Sender email address.
+.PARAMETER SmtpServer
+    SMTP server used to send the message.
+.PARAMETER LogPath
+    Optional path to the telemetry log.
+.PARAMETER Subject
+    Optional subject line for the email. Defaults to "Telemetry Summary".
+.EXAMPLE
+    ./Send-TelemetrySummary.ps1 -To admin@contoso.com -From noreply@contoso.com -SmtpServer smtp.contoso.com
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$To,
+
+    [Parameter(Mandatory)]
+    [string]$From,
+
+    [Parameter(Mandatory)]
+    [string]$SmtpServer,
+
+    [string]$LogPath,
+
+    [string]$Subject = 'Telemetry Summary'
+)
+
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+
+Show-STPrompt './scripts/Send-TelemetrySummary.ps1'
+
+if ($env:ST_ENABLE_TELEMETRY -ne '1') {
+    Write-STStatus -Message 'ST_ENABLE_TELEMETRY is not set. Telemetry will not be read.' -Level WARN
+    return
+}
+
+if ($LogPath) {
+    $path = $LogPath
+} elseif ($env:ST_TELEMETRY_PATH) {
+    $path = $env:ST_TELEMETRY_PATH
+} else {
+    $profile = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
+    $path = Join-Path $profile 'SupportToolsTelemetry/telemetry.jsonl'
+}
+
+if (-not (Test-Path $path)) {
+    Write-STStatus "Telemetry log not found: $path" -Level ERROR
+    return
+}
+
+Write-STStatus -Message 'Generating telemetry metrics...' -Level INFO -Log
+$metrics = Get-STTelemetryMetrics -LogPath $path
+
+if (-not $metrics) {
+    Write-STStatus -Message 'No telemetry events found.' -Level WARN
+    return
+}
+
+$body = $metrics | Format-Table -AutoSize | Out-String
+
+Write-STStatus -Message 'Sending email...' -Level INFO -Log
+Send-MailMessage -To $To -From $From -Subject $Subject -Body $body -SmtpServer $SmtpServer
+
+Write-STStatus -Message 'Telemetry summary sent.' -Level SUCCESS -Log
+Write-STClosing

--- a/tests/ScriptFiles.Tests.ps1
+++ b/tests/ScriptFiles.Tests.ps1
@@ -20,4 +20,22 @@ Describe 'Standalone Scripts' {
         $result | Should -Match 'digraph'
         $result | Should -Match 'Start-Main'
     }
+
+    Safe-It 'sends telemetry summary via email' {
+        $log = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+        $events = @(
+            @{Timestamp='2024-01-01T00:00:00Z'; Script='Test.ps1'; Result='Success'; Duration=1}
+        ) | ForEach-Object { $_ | ConvertTo-Json -Compress }
+        Set-Content -Path $log -Value $events
+        Mock Send-MailMessage {} -Verifiable
+        Mock Get-STTelemetryMetrics { @([pscustomobject]@{ Script='Test.ps1'; Executions=1; Successes=1; Failures=0; AverageSeconds=1; LastRun='2024-01-01T00:00:00Z' }) }
+        try {
+            $env:ST_ENABLE_TELEMETRY = '1'
+            & $PSScriptRoot/../scripts/Send-TelemetrySummary.ps1 -To 'a@b.com' -From 'n@c.com' -SmtpServer 'smtp' -LogPath $log
+            Assert-MockCalled Send-MailMessage -ParameterFilter { $To -eq 'a@b.com' -and $From -eq 'n@c.com' -and $SmtpServer -eq 'smtp' -and $Body -match 'Test.ps1' } -Times 1
+        } finally {
+            Remove-Item $log -ErrorAction SilentlyContinue
+            Remove-Item env:ST_ENABLE_TELEMETRY -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
### Summary
- add Send-TelemetrySummary.ps1 for emailing telemetry summaries
- document the script in Get-STTelemetryMetrics
- add Pester test for Send-TelemetrySummary.ps1

### File Citations
- **scripts/Send-TelemetrySummary.ps1** shows generating metrics and emailing them【F:scripts/Send-TelemetrySummary.ps1†L1-L75】
- **docs/Telemetry/Get-STTelemetryMetrics.md** notes using the new script to email metrics【F:docs/Telemetry/Get-STTelemetryMetrics.md†L45-L49】
- **tests/ScriptFiles.Tests.ps1** contains a unit test mocking Send-MailMessage to verify email sending【F:tests/ScriptFiles.Tests.ps1†L24-L40】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684638c72170832c85460e858820be90