### PR TITLE
Add ChaosMode support for Connect-STPlatform

### DIFF
--- a/docs/STPlatform/Connect-STPlatform.md
+++ b/docs/STPlatform/Connect-STPlatform.md
@@ -12,7 +12,7 @@ Initializes modules and service connections for the specified environment.
 
 ## SYNTAX
 ```
-Connect-STPlatform [-Mode] <String> [-InstallMissing] [-Vault <String>] [<CommonParameters>]
+Connect-STPlatform [-Mode] <String> [-InstallMissing] [-Vault <String>] [-ChaosMode] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -46,6 +46,10 @@ Automatically install missing modules when this switch is specified.
 Secret vault name used to retrieve environment variables when they are
 not already set.
 
+### -ChaosMode
+Simulate connection delays and random failures for testing. Equivalent to
+setting the `ST_CHAOS_MODE` environment variable to `1`.
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable,
@@ -61,5 +65,7 @@ When telemetry is enabled via `$env:ST_ENABLE_TELEMETRY = '1'`, each run records
 the list of imported modules and the outcome of connection attempts. These
 values appear in the Details field of the `Connect-STPlatform` metric as
 `Modules` and `Connections`.
+Use `-ChaosMode` or set `ST_CHAOS_MODE=1` to randomly delay or fail the initial
+connection check for testing resilience.
 
 ## RELATED LINKS

--- a/src/STPlatform/Public/Connect-STPlatform.ps1
+++ b/src/STPlatform/Public/Connect-STPlatform.ps1
@@ -21,13 +21,19 @@ function Connect-STPlatform {
     param(
         [Parameter(Mandatory)][ValidateSet('Cloud','Hybrid','OnPrem')][string]$Mode,
         [switch]$InstallMissing,
-        [string]$Vault
+        [string]$Vault,
+        [switch]$ChaosMode
     )
+
+    if (-not $ChaosMode) { $ChaosMode = [bool]$env:ST_CHAOS_MODE }
 
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $result = 'Success'
     try {
         Write-STStatus "Initializing platform for $Mode" -Level INFO -Log
+        if ($ChaosMode) {
+            Invoke-STRequest -Method 'GET' -Uri 'https://example.com' -ChaosMode -ErrorAction Stop | Out-Null
+        }
 
         $requiredVars = 'SPTOOLS_CLIENT_ID','SPTOOLS_TENANT_ID','SPTOOLS_CERT_PATH','SD_API_TOKEN','SD_BASE_URI'
         foreach ($name in $requiredVars) {


### PR DESCRIPTION
### Summary
- add `-ChaosMode` switch to `Connect-STPlatform`
- randomize connection attempts when ChaosMode is enabled
- document ChaosMode usage in `Connect-STPlatform.md`
- test ChaosMode parameter and env var behavior

### File Citations
- `src/STPlatform/Public/Connect-STPlatform.ps1`
- `docs/STPlatform/Connect-STPlatform.md`
- `tests/STPlatform.Tests.ps1`

### Test Results
- `Invoke-Pester` *(failed: New-PSDrive: A drive with the name 'TestDrive' already exists)*
  - Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846389b7e00832c8bdf7f23b55d85fd