### PR TITLE
Add Remove-SDTicketAttachment function

### DIFF
--- a/docs/ServiceDeskTools/Remove-SDTicketAttachment.md
+++ b/docs/ServiceDeskTools/Remove-SDTicketAttachment.md
@@ -1,0 +1,37 @@
+---
+external help file: ServiceDeskTools-help.xml
+Module Name: ServiceDeskTools
+online version:
+schema: 2.0.0
+---
+
+# Remove-SDTicketAttachment
+
+## SYNOPSIS
+Deletes an attachment from a Service Desk ticket.
+
+## SYNTAX
+```powershell
+Remove-SDTicketAttachment [-Id] <Int32> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Sends a DELETE request to the Service Desk API to remove an attachment from a ticket.
+
+## PARAMETERS
+### -Id
+Attachment ID to delete.
+
+### -ProgressAction
+Specifies how progress is displayed.
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/src/ServiceDeskTools/Public/Remove-SDTicketAttachment.ps1
+++ b/src/ServiceDeskTools/Public/Remove-SDTicketAttachment.ps1
@@ -1,0 +1,28 @@
+function Remove-SDTicketAttachment {
+    <#
+    .SYNOPSIS
+        Deletes an attachment from a Service Desk ticket.
+    .PARAMETER Id
+        Attachment ID to remove.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [int]$Id,
+        [Parameter(Mandatory=$false)]
+        [switch]$ChaosMode,
+        [Parameter(Mandatory=$false)]
+        [switch]$Explain
+    )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
+
+    Write-STLog -Message "Remove-SDTicketAttachment $Id" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    if ($PSCmdlet.ShouldProcess("attachment $Id", 'Remove')) {
+        Invoke-SDRequest -Method 'DELETE' -Path "/attachments/$Id.json" -ChaosMode:$ChaosMode
+    }
+}

--- a/src/ServiceDeskTools/ServiceDeskTools.psd1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psd1
@@ -6,5 +6,5 @@
     Description = 'Commands for interacting with the Service Desk ticketing system.'
     RequiredModules = @('Logging','Telemetry')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','ServiceDesk','Internal') } }
-    FunctionsToExport = '*'
+    FunctionsToExport = @('Add-SDTicketComment','Export-SDConfig','Get-SDTicket','Get-SDTicketHistory','Get-ServiceDeskAsset','Get-ServiceDeskRelationship','Get-ServiceDeskStats','Link-SDTicketToSPTask','New-SDTicket','Remove-SDTicketAttachment','Search-SDTicket','Set-SDTicket','Set-SDTicketBulk','Submit-Ticket')
 }

--- a/tests/ServiceDeskTools/Remove-SDTicketAttachment.Tests.ps1
+++ b/tests/ServiceDeskTools/Remove-SDTicketAttachment.Tests.ps1
@@ -1,0 +1,26 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Remove-SDTicketAttachment' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
+    }
+
+    Safe-It 'returns API response on success' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { @{ ok = $true } }
+            $res = Remove-SDTicketAttachment -Id 7
+            Assert-MockCalled Invoke-SDRequest -Times 1 -ParameterFilter {
+                $Method -eq 'DELETE' -and $Path -eq '/attachments/7.json'
+            }
+            $res.ok | Should -Be $true
+        }
+    }
+
+    Safe-It 'throws when Invoke-SDRequest fails' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { throw 'bad' }
+            { Remove-SDTicketAttachment -Id 2 } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- implement `Remove-SDTicketAttachment` to delete attachments
- export the new function in the module manifest
- test success and failure cases
- document the cmdlet

### File Citations
- `src/ServiceDeskTools/Public/Remove-SDTicketAttachment.ps1`
- `src/ServiceDeskTools/ServiceDeskTools.psd1`
- `tests/ServiceDeskTools/Remove-SDTicketAttachment.Tests.ps1`
- `docs/ServiceDeskTools/Remove-SDTicketAttachment.md`

### Test Results
```text
$(tail -n 20 /tmp/pester.log)
```


------
https://chatgpt.com/codex/tasks/task_e_6846389ea890832c91bc1cd2c0799f19