### PR TITLE
Add Get-SDUser cmdlet

### DIFF
--- a/docs/ServiceDeskTools/Get-SDUser.md
+++ b/docs/ServiceDeskTools/Get-SDUser.md
@@ -1,0 +1,47 @@
+---
+external help file: ServiceDeskTools-help.xml
+Module Name: ServiceDeskTools
+online version:
+schema: 2.0.0
+---
+
+# Get-SDUser
+
+## SYNOPSIS
+Retrieves user details from the Service Desk.
+
+## SYNTAX
+```
+Get-SDUser [-Id] <Int32> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-SDUser [-Email] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Queries the Service Desk `/users` API for information about a single user. You can
+provide either a numeric id or an email address to locate the user record.
+
+## PARAMETERS
+### -Id
+Identifier of the user to retrieve.
+
+### -Email
+Email address used to look up the user.
+
+### -ProgressAction
+Specifies how progress is displayed.
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable,
+-Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+### PSObject
+User object returned from the Service Desk API.
+
+## NOTES
+
+## RELATED LINKS

--- a/src/ServiceDeskTools/Public/Get-SDUser.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDUser.ps1
@@ -1,0 +1,50 @@
+function Get-SDUser {
+    <#
+    .SYNOPSIS
+        Retrieves user details from the Service Desk.
+    .DESCRIPTION
+        Queries the Service Desk /users API for information about a single user
+        by id or email address.
+    .PARAMETER Id
+        Numeric id of the user to retrieve.
+    .PARAMETER Email
+        Email address used to find the user.
+    .PARAMETER ChaosMode
+        Enables random delays and failures for chaos testing.
+    .PARAMETER Explain
+        Shows the full help content.
+    .EXAMPLE
+        Get-SDUser -Id 42
+    .EXAMPLE
+        Get-SDUser -Email 'john.doe@example.com'
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true, DefaultParameterSetName='ById')]
+    param(
+        [Parameter(Mandatory, ParameterSetName='ById')]
+        [int]$Id,
+        [Parameter(Mandatory, ParameterSetName='ByEmail')]
+        [string]$Email,
+        [switch]$ChaosMode,
+        [switch]$Explain
+    )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
+
+    $target = if ($PSCmdlet.ParameterSetName -eq 'ById') { $Id } else { $Email }
+    Write-STLog -Message "Get-SDUser $target" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+
+    if ($PSCmdlet.ParameterSetName -eq 'ById') {
+        $path = "/users/$Id.json"
+    }
+    else {
+        $encoded = [uri]::EscapeDataString($Email)
+        $path = "/users.json?email=$encoded"
+    }
+
+    if ($PSCmdlet.ShouldProcess("user $target", 'Get')) {
+        return Invoke-SDRequest -Method 'GET' -Path $path -ChaosMode:$ChaosMode
+    }
+}

--- a/src/ServiceDeskTools/ServiceDeskTools.psd1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psd1
@@ -6,5 +6,11 @@
     Description = 'Commands for interacting with the Service Desk ticketing system.'
     RequiredModules = @('Logging','Telemetry')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','ServiceDesk','Internal') } }
-    FunctionsToExport = '*'
+    FunctionsToExport = @(
+        'Add-SDTicketComment','Export-SDConfig','Get-SDTicket',
+        'Get-SDTicketHistory','Get-SDUser','Get-ServiceDeskAsset',
+        'Get-ServiceDeskRelationship','Get-ServiceDeskStats',
+        'Link-SDTicketToSPTask','New-SDTicket','Search-SDTicket',
+        'Set-SDTicket','Set-SDTicketBulk','Submit-Ticket'
+    )
 }

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -10,7 +10,8 @@ Describe 'ServiceDeskTools Module' {
         $expected = @(
             'Get-SDTicket','Get-SDTicketHistory','New-SDTicket','Set-SDTicket',
             'Add-SDTicketComment','Search-SDTicket','Get-ServiceDeskAsset',
-            'Set-SDTicketBulk','Link-SDTicketToSPTask','Export-SDConfig'
+            'Set-SDTicketBulk','Link-SDTicketToSPTask','Export-SDConfig',
+            'Get-SDUser'
         )
         $exported = (Get-Command -Module ServiceDeskTools).Name
         foreach ($cmd in $expected) {

--- a/tests/ServiceDeskTools/Get-SDUser.Tests.ps1
+++ b/tests/ServiceDeskTools/Get-SDUser.Tests.ps1
@@ -1,0 +1,41 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Get-SDUser' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
+    }
+
+    Safe-It 'requests user by id' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { @{ id = 1 } }
+            $res = Get-SDUser -Id 1
+            Assert-MockCalled Invoke-SDRequest -Times 1 -ParameterFilter { $Method -eq 'GET' -and $Path -eq '/users/1.json' }
+            $res.id | Should -Be 1
+        }
+    }
+
+    Safe-It 'requests user by email' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { @{ email = 'a@b.com' } }
+            $res = Get-SDUser -Email 'a@b.com'
+            Assert-MockCalled Invoke-SDRequest -Times 1 -ParameterFilter { $Method -eq 'GET' -and $Path -eq '/users.json?email=a%40b.com' }
+            $res.email | Should -Be 'a@b.com'
+        }
+    }
+
+    Safe-It 'passes ChaosMode' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { @{ ok = $true } }
+            Get-SDUser -Id 2 -ChaosMode
+            Assert-MockCalled Invoke-SDRequest -Times 1 -ParameterFilter { $ChaosMode -eq $true }
+        }
+    }
+
+    Safe-It 'throws when Invoke-SDRequest fails' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { throw 'bad' }
+            { Get-SDUser -Id 1 } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- add `Get-SDUser` command to query `/users` API
- export new cmdlet in ServiceDeskTools
- document `Get-SDUser`
- test `Get-SDUser`
- update exported command tests

### File Citations
- `src/ServiceDeskTools/Public/Get-SDUser.ps1`【F:src/ServiceDeskTools/Public/Get-SDUser.ps1†L1-L50】
- `docs/ServiceDeskTools/Get-SDUser.md`【F:docs/ServiceDeskTools/Get-SDUser.md†L1-L37】
- `src/ServiceDeskTools/ServiceDeskTools.psd1` export list【F:src/ServiceDeskTools/ServiceDeskTools.psd1†L10-L15】
- `tests/ServiceDeskTools.Tests.ps1` updated expected exports【F:tests/ServiceDeskTools.Tests.ps1†L10-L15】
- `tests/ServiceDeskTools/Get-SDUser.Tests.ps1`【F:tests/ServiceDeskTools/Get-SDUser.Tests.ps1†L1-L40】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684638a1daa4832cb6464b42bd95fb1d