### PR TITLE
Add new test for hold report fields

### DIFF
--- a/tests/SharePointTools/Integration.Tests.ps1
+++ b/tests/SharePointTools/Integration.Tests.ps1
@@ -132,6 +132,23 @@ Describe 'SharePointTools Integration Functions' {
                 $r.TotalSizeMB | Should -Be 2
             }
         }
+        Safe-It 'returns expected fields' {
+            InModuleScope SharePointTools {
+                function Connect-PnPOnline {}
+                function Get-PnPListItem {}
+                function Get-PnPProperty {}
+                function Disconnect-PnPOnline {}
+                Mock Connect-PnPOnline {}
+                Mock Disconnect-PnPOnline {}
+                Mock Get-PnPListItem { @(1) }
+                Mock Get-PnPProperty { param($ClientObject,$Property) [pscustomobject]@{ Length = 1MB } }
+                $result = Get-SPToolsPreservationHoldReport -SiteName 'A' -SiteUrl 'https://c'
+                $props = $result.PSObject.Properties.Name
+                $props | Should -Contain 'SiteName'
+                $props | Should -Contain 'ItemCount'
+                $props | Should -Contain 'TotalSizeMB'
+            }
+        }
     }
 
     Context 'Get-SPPermissionsReport' {


### PR DESCRIPTION
### Summary
- verify fields returned by `Get-SPToolsPreservationHoldReport`

### File Citations
- `tests/SharePointTools/Integration.Tests.ps1`

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (fails: BeforeAll errors)

------
https://chatgpt.com/codex/tasks/task_e_684638a8584c832cbf34b74ca9b28fa0