### PR TITLE
Add LogLines parameter to New-STDashboard

### DIFF
--- a/docs/SupportTools.md
+++ b/docs/SupportTools.md
@@ -51,4 +51,4 @@ The table below lists each command and the script it invokes. Arguments not list
 | `Sync-SupportTools` | *git* | `[RepositoryUrl]`, `[InstallPath]` | `Sync-SupportTools` |
 | `New-SPUsageReport` | `Generate-SPUsageReport.ps1` | `[ItemThreshold]`, `[RequesterEmail]`, `[CsvPath]`, `[TranscriptPath]` | `New-SPUsageReport -RequesterEmail 'user@contoso.com'` |
 | `Invoke-NewHireUserAutomation` | `Create-NewHireUser.ps1` | `[PollMinutes]`, `[-Once]` | `Invoke-NewHireUserAutomation -Once` |
-| `New-STDashboard` | *built-in* | `[LogPath]`, `[TelemetryLogPath]`, `[OutputPath]` | `New-STDashboard` |
+| `New-STDashboard` | *built-in* | `[LogPath]`, `[TelemetryLogPath]`, `[OutputPath]`, `[LogLines]` | `New-STDashboard` |

--- a/docs/SupportTools/New-STDashboard.md
+++ b/docs/SupportTools/New-STDashboard.md
@@ -1,0 +1,55 @@
+---
+external help file: SupportTools-help.xml
+Module Name: SupportTools
+online version:
+schema: 2.0.0
+---
+
+# New-STDashboard
+
+## SYNOPSIS
+Generates an HTML dashboard summarizing logs and telemetry metrics.
+
+## SYNTAX
+
+```
+New-STDashboard [[-LogPath] <String>] [[-TelemetryLogPath] <String>] [[-OutputPath] <String>] [[-LogLines] <Int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Reads SupportTools log files and telemetry events then creates a simple HTML page showing the latest log lines and aggregated metrics.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> New-STDashboard -LogPath log.txt -TelemetryLogPath telemetry.jsonl -LogLines 50
+```
+
+Creates a dashboard using custom log paths and shows the last 50 log entries.
+
+## PARAMETERS
+### -LogPath
+Optional path to the structured log file. Defaults to `$env:ST_LOG_PATH` or `~/SupportToolsLogs/supporttools.log`.
+
+### -TelemetryLogPath
+Optional path to the telemetry log file. Defaults to `$env:ST_TELEMETRY_PATH` or `~/SupportToolsTelemetry/telemetry.jsonl`.
+
+### -OutputPath
+Optional path for the resulting HTML file. A timestamped file is created in the current directory when omitted.
+
+### -LogLines
+Number of log file lines to display. Defaults to `20`.
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+Path to the generated dashboard HTML file.
+
+## NOTES
+
+## RELATED LINKS

--- a/src/SupportTools/Public/New-STDashboard.ps1
+++ b/src/SupportTools/Public/New-STDashboard.ps1
@@ -14,6 +14,8 @@ function New-STDashboard {
     .PARAMETER OutputPath
         Optional path for the resulting HTML file. A timestamped file is created
         in the current directory when omitted.
+    .PARAMETER LogLines
+        Number of log file lines to display. Defaults to 20.
     .EXAMPLE
         New-STDashboard -LogPath log.txt -TelemetryLogPath telemetry.jsonl
     #>
@@ -21,7 +23,8 @@ function New-STDashboard {
     param(
         [string]$LogPath,
         [string]$TelemetryLogPath,
-        [string]$OutputPath
+        [string]$OutputPath,
+        [int]$LogLines = 20
     )
     try {
         if (-not $OutputPath) {
@@ -36,7 +39,7 @@ function New-STDashboard {
             else { $TelemetryLogPath = Join-Path $HOME 'SupportToolsTelemetry/telemetry.jsonl' }
         }
 
-        $logLines = if (Test-Path $LogPath) { Get-Content $LogPath -Tail 20 } else { @() }
+        $logLines = if (Test-Path $LogPath) { Get-Content $LogPath -Tail $LogLines } else { @() }
         $metrics  = if (Test-Path $TelemetryLogPath) { Get-STTelemetryMetrics -LogPath $TelemetryLogPath } else { @() }
 
         $html = @()


### PR DESCRIPTION
### Summary
- add `LogLines` parameter to `New-STDashboard`
- document usage in `New-STDashboard` help
- include parameter in support tools overview table
- test that log line count is respected

### File Citations
- `src/SupportTools/Public/New-STDashboard.ps1`
- `docs/SupportTools/New-STDashboard.md`
- `docs/SupportTools.md`
- `tests/SupportTools/New-STDashboard.Tests.ps1`

### Test Results
- ❌ `Invoke-Pester -Configuration (Import-PowerShellDataFile './PesterConfiguration.psd1')`

------
https://chatgpt.com/codex/tasks/task_e_684638ab0b04832c9297065ae053e769