### PR TITLE
Add NewHire-Automation alias

### DIFF
--- a/docs/SupportTools/Invoke-NewHireUserAutomation.md
+++ b/docs/SupportTools/Invoke-NewHireUserAutomation.md
@@ -41,3 +41,6 @@ None
 ## OUTPUTS
 None
 
+## ALIASES
+NewHire-Automation
+

--- a/src/SupportTools/SupportTools.psd1
+++ b/src/SupportTools/SupportTools.psd1
@@ -37,4 +37,8 @@
         'Sync-SupportTools',
         'Invoke-NewHireUserAutomation'
     )
+
+    AliasesToExport = @(
+        'NewHire-Automation'
+    )
 }

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -20,6 +20,9 @@ Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue |
 Get-ChildItem -Path "$PublicDir" -Filter *.ps1 -ErrorAction SilentlyContinue |
     ForEach-Object { . $_.FullName }
 
+# Alias mappings
+Set-Alias -Name 'NewHire-Automation' -Value 'Invoke-NewHireUserAutomation'
+
 
 Export-ModuleMember -Function @(
     'Clear-ArchiveFolder',
@@ -37,7 +40,7 @@ Export-ModuleMember -Function @(
     'New-STDashboard',
     'Sync-SupportTools',
     'Invoke-NewHireUserAutomation'
-)
+) -Alias 'NewHire-Automation'
 
 
 function Show-SupportToolsBanner {


### PR DESCRIPTION
### Summary
- add alias mapping in module manifest
- define alias in module code and export it
- document alias in command help

### File Citations
- `src/SupportTools/SupportTools.psd1` lines 37-44
- `src/SupportTools/SupportTools.psm1` lines 23-44
- `docs/SupportTools/Invoke-NewHireUserAutomation.md` lines 36-45

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684638aff2ac832cbf564bdf6b5d25b9