### PR TITLE
Add OsBuild column to IT report

### DIFF
--- a/src/SupportTools/Public/Export-ITReport.ps1
+++ b/src/SupportTools/Public/Export-ITReport.ps1
@@ -32,10 +32,11 @@ function Export-ITReport {
     )
     begin {
         $items = @()
+        $osBuild = (Get-CimInstance -ClassName Win32_OperatingSystem | Select-Object -ExpandProperty BuildNumber)
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
     }
     process {
-        $items += $Data
+        $items += ($Data | Add-Member -NotePropertyName OsBuild -NotePropertyValue $osBuild -PassThru)
     }
     end {
         try {

--- a/tests/SupportTools/Export-ITReport.Tests.ps1
+++ b/tests/SupportTools/Export-ITReport.Tests.ps1
@@ -6,13 +6,18 @@ Describe 'Export-ITReport function' {
     }
 
     Safe-It 'creates a CSV report' {
-        $path = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString() + '.csv')
-        try {
-            @([pscustomobject]@{A=1;B=2}) | Export-ITReport -Format CSV -OutputPath $path
-            Test-Path $path | Should -Be $true
-            (Get-Content $path | Select-Object -First 1) | Should -Match 'A,B'
-        } finally {
-            Remove-Item $path -ErrorAction SilentlyContinue
+        InModuleScope SupportTools {
+            Mock Get-CimInstance { [pscustomobject]@{ BuildNumber = '12345' } }
+            $path = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString() + '.csv')
+            try {
+                @([pscustomobject]@{A=1;B=2}) | Export-ITReport -Format CSV -OutputPath $path
+                Test-Path $path | Should -Be $true
+                $lines = Get-Content $path
+                $lines[0] | Should -Match 'A,B,OsBuild'
+                $lines[1] | Should -Match '1,2,12345'
+            } finally {
+                Remove-Item $path -ErrorAction SilentlyContinue
+            }
         }
     }
 


### PR DESCRIPTION
### Summary
- include an OsBuild property when exporting reports
- validate OsBuild appears in CSV output in tests

### File Citations
- `src/SupportTools/Public/Export-ITReport.ps1`
- `tests/SupportTools/Export-ITReport.Tests.ps1`

### Test Results
```
Invoke-Pester failed: MethodInvocationException: Exception calling "Add" with "2" argument(s): "Item has already been added. Key in dictionary: 'TestDrive'  Key being added: 'TestDrive'"
```


------
https://chatgpt.com/codex/tasks/task_e_684638b35170832c83a6356968115e28