### PR TITLE
Add SMTP server option for system info ticket

### DIFF
--- a/docs/IncidentResponseTools/Submit-SystemInfoTicket.md
+++ b/docs/IncidentResponseTools/Submit-SystemInfoTicket.md
@@ -13,7 +13,7 @@ Collects system information, uploads it to SharePoint and creates a Service Desk
 ## SYNTAX
 
 ```
-Submit-SystemInfoTicket [-SiteName] <String> [-RequesterEmail] <String> [[-Subject] <String>] [[-Description] <String>] [[-LibraryName] <String>] [[-FolderPath] <String>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Submit-SystemInfoTicket [-SiteName] <String> [-RequesterEmail] <String> [[-Subject] <String>] [[-Description] <String>] [[-LibraryName] <String>] [[-FolderPath] <String>] [[-TranscriptPath] <String>] [[-SmtpServer] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -49,6 +49,9 @@ Optional folder path within the library.
 
 ### -TranscriptPath
 Optional transcript output path.
+
+### -SmtpServer
+SMTP server used to send the summary email.
 
 ### -ProgressAction
 Specifies how progress is displayed.

--- a/src/IncidentResponseTools/Public/Submit-SystemInfoTicket.ps1
+++ b/src/IncidentResponseTools/Public/Submit-SystemInfoTicket.ps1
@@ -29,6 +29,9 @@ function Submit-SystemInfoTicket {
         [ValidateNotNullOrEmpty()]
         [string]$TranscriptPath,
         [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SmtpServer,
+        [Parameter(Mandatory = $false)]
         [switch]$Simulate,
         [Parameter(Mandatory = $false)]
         [switch]$Explain,
@@ -45,6 +48,7 @@ function Submit-SystemInfoTicket {
         if ($PSBoundParameters.ContainsKey('Description')) { $arguments += @('-Description', $Description) }
         if ($PSBoundParameters.ContainsKey('LibraryName')) { $arguments += @('-LibraryName', $LibraryName) }
         if ($PSBoundParameters.ContainsKey('FolderPath'))  { $arguments += @('-FolderPath', $FolderPath) }
+        if ($PSBoundParameters.ContainsKey('SmtpServer'))  { $arguments += @('-SmtpServer', $SmtpServer) }
         Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Submit-SystemInfoTicket.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/tests/IncidentResponseTools/Submit-SystemInfoTicket.Tests.ps1
+++ b/tests/IncidentResponseTools/Submit-SystemInfoTicket.Tests.ps1
@@ -1,0 +1,25 @@
+. $PSScriptRoot/../TestHelpers.ps1
+Describe 'Submit-SystemInfoTicket.ps1 script' {
+    BeforeAll {
+        $ScriptPath = Join-Path $PSScriptRoot/../.. 'scripts/Submit-SystemInfoTicket.ps1'
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/IncidentResponseTools/IncidentResponseTools.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/SharePointTools/SharePointTools.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
+    }
+    BeforeEach {
+        Mock Get-CommonSystemInfo { @{ OS = 'Windows' } }
+        Mock Get-SPToolsSettings { @{ ClientId='id'; TenantId='tid'; CertPath='cert' } }
+        Mock Get-SPToolsSiteUrl { 'https://contoso.sharepoint.com/sites/it' }
+        Mock Connect-PnPOnline {}
+        Mock Add-PnPFile { [pscustomobject]@{ ServerRelativeUrl='/docs/report.json' } }
+        Mock New-SDTicket {}
+        Mock Send-MailMessage {}
+        Mock Write-STStatus {}
+    }
+
+    Safe-It 'uses provided SmtpServer when sending email' {
+        & $ScriptPath -SiteName 'IT' -RequesterEmail 'user@example.com' -SmtpServer 'smtp.contoso.com' | Out-Null
+        Assert-MockCalled Send-MailMessage -Times 1 -ParameterFilter { $SmtpServer -eq 'smtp.contoso.com' }
+    }
+}


### PR DESCRIPTION
### Summary
- allow specifying `-SmtpServer` when submitting a system info ticket
- document the SMTP server parameter
- test that the script uses the provided server when sending email

### File Citations
- `scripts/Submit-SystemInfoTicket.ps1`
- `src/IncidentResponseTools/Public/Submit-SystemInfoTicket.ps1`
- `docs/IncidentResponseTools/Submit-SystemInfoTicket.md`
- `tests/IncidentResponseTools/Submit-SystemInfoTicket.Tests.ps1`

### Test Results
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.
```


------
https://chatgpt.com/codex/tasks/task_e_684638b5d3e4832ca43377db62458c8d