### PR TITLE
Add Stop-HealthMonitor command

### DIFF
--- a/docs/MonitoringTools.md
+++ b/docs/MonitoringTools.md
@@ -16,5 +16,6 @@ Import-Module ./src/MonitoringTools/MonitoringTools.psd1
 | `Get-EventLogSummary` | Counts recent error and warning events and logs a summary. | `Get-EventLogSummary -LogName System` |
 | `Get-SystemHealth` | Summarises CPU, disk and event log data and records the snapshot. | `Get-SystemHealth` |
 | `Start-HealthMonitor` | Periodically log system health metrics. | `Start-HealthMonitor -IntervalSeconds 60` |
+| `Stop-HealthMonitor`  | Signal a running monitor to exit. | `Stop-HealthMonitor` |
 
 See [MonitoringTools/Start-HealthMonitor.md](MonitoringTools/Start-HealthMonitor.md) for full command help.

--- a/docs/MonitoringTools/Start-HealthMonitor.md
+++ b/docs/MonitoringTools/Start-HealthMonitor.md
@@ -16,7 +16,7 @@ Start-HealthMonitor [[-IntervalSeconds] <Int32>] [[-Count] <Int32>] [<CommonPara
 ```
 
 ## DESCRIPTION
-`Start-HealthMonitor` calls `Get-SystemHealth` on a recurring interval and writes each result using `Write-STRichLog`. Set `Count` to limit the number of samples; otherwise the command runs until cancelled.
+`Start-HealthMonitor` calls `Get-SystemHealth` on a recurring interval and writes each result using `Write-STRichLog`. Set `Count` to limit the number of samples; otherwise the command runs until `Stop-HealthMonitor` is called.
 
 ## EXAMPLES
 ### Example 1
@@ -41,3 +41,4 @@ None. This command writes structured log entries but does not return data.
 
 ## RELATED LINKS
 `Get-SystemHealth`
+`Stop-HealthMonitor`

--- a/src/MonitoringTools/MonitoringTools.psd1
+++ b/src/MonitoringTools/MonitoringTools.psd1
@@ -6,5 +6,5 @@
     Description = 'Commands for collecting system monitoring data.'
     RequiredModules = @('Logging','Telemetry')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','Monitoring','Internal') } }
-    FunctionsToExport = @('Get-CPUUsage','Get-DiskSpaceInfo','Get-EventLogSummary','Get-SystemHealth','Start-HealthMonitor')
+    FunctionsToExport = @('Get-CPUUsage','Get-DiskSpaceInfo','Get-EventLogSummary','Get-SystemHealth','Start-HealthMonitor','Stop-HealthMonitor')
 }

--- a/src/MonitoringTools/MonitoringTools.psm1
+++ b/src/MonitoringTools/MonitoringTools.psm1
@@ -6,7 +6,7 @@ Import-Module $telemetryModule -ErrorAction SilentlyContinue
 
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Get-CPUUsage','Get-DiskSpaceInfo','Get-EventLogSummary','Get-SystemHealth'
+Export-ModuleMember -Function 'Get-CPUUsage','Get-DiskSpaceInfo','Get-EventLogSummary','Get-SystemHealth','Start-HealthMonitor','Stop-HealthMonitor'
 
 function Show-MonitoringToolsBanner {
     <#

--- a/src/MonitoringTools/Public/Start-HealthMonitor.ps1
+++ b/src/MonitoringTools/Public/Start-HealthMonitor.ps1
@@ -21,14 +21,13 @@ function Start-HealthMonitor {
 
     try {
         $collected = 0
-        while ($true) {
+        while (-not $script:StopHealthMonitor -and ($Count -eq 0 -or $collected -lt $Count)) {
             $start = Get-Date
             $health = Get-SystemHealth
             $json = $health | ConvertTo-Json -Compress
             Write-STRichLog -Tool 'HealthMonitor' -Status 'sample' -Details $json
 
             $collected++
-            if ($Count -gt 0 -and $collected -ge $Count) { break }
 
             $elapsed = (Get-Date) - $start
             $sleep = $IntervalSeconds - [int][math]::Floor($elapsed.TotalSeconds)

--- a/src/MonitoringTools/Public/Stop-HealthMonitor.ps1
+++ b/src/MonitoringTools/Public/Stop-HealthMonitor.ps1
@@ -1,0 +1,15 @@
+function Stop-HealthMonitor {
+    <#
+    .SYNOPSIS
+        Signals Start-HealthMonitor to stop collecting health samples.
+    .DESCRIPTION
+        Sets a script-scoped flag consumed by Start-HealthMonitor so that the
+        monitoring loop exits on the next iteration.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param()
+
+    if (-not $PSCmdlet.ShouldProcess('stop health monitor')) { return }
+
+    $script:StopHealthMonitor = $true
+}

--- a/tests/MonitoringTools/Start-HealthMonitor.Tests.ps1
+++ b/tests/MonitoringTools/Start-HealthMonitor.Tests.ps1
@@ -1,0 +1,25 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Start-HealthMonitor and Stop-HealthMonitor' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/MonitoringTools/MonitoringTools.psd1 -Force
+    }
+
+    Safe-It 'exits when Stop-HealthMonitor is triggered' {
+        InModuleScope MonitoringTools {
+            $script:calls = 0
+            Mock Write-STRichLog {} -ModuleName MonitoringTools
+            Mock Get-SystemHealth {
+                $script:calls++
+                if ($script:calls -eq 3) { Stop-HealthMonitor }
+                @{ CpuPercent = 0 }
+            } -ModuleName MonitoringTools
+
+            Start-HealthMonitor -IntervalSeconds 0
+
+            Assert-MockCalled Write-STRichLog -ModuleName MonitoringTools -Times 3
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- allow Start-HealthMonitor to honor a stop flag
- export Stop-HealthMonitor in module
- mention Stop-HealthMonitor in docs
- test Start-HealthMonitor stop behaviour

### File Citations
- `src/MonitoringTools/Public/Stop-HealthMonitor.ps1`【F:src/MonitoringTools/Public/Stop-HealthMonitor.ps1†L1-L15】
- `src/MonitoringTools/Public/Start-HealthMonitor.ps1`【F:src/MonitoringTools/Public/Start-HealthMonitor.ps1†L20-L39】
- `src/MonitoringTools/MonitoringTools.psd1`【F:src/MonitoringTools/MonitoringTools.psd1†L8-L10】
- `src/MonitoringTools/MonitoringTools.psm1`【F:src/MonitoringTools/MonitoringTools.psm1†L9-L9】
- `docs/MonitoringTools/Start-HealthMonitor.md`【F:docs/MonitoringTools/Start-HealthMonitor.md†L18-L20】【F:docs/MonitoringTools/Start-HealthMonitor.md†L40-L44】
- `docs/MonitoringTools.md`【F:docs/MonitoringTools.md†L10-L21】
- `tests/MonitoringTools/Start-HealthMonitor.Tests.ps1`【F:tests/MonitoringTools/Start-HealthMonitor.Tests.ps1†L1-L25】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to run due to errors)【d0f215†L1-L8】
- ❌ Test report shows failures likely due to environment setup【070a2e†L1-L15】

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684638bd884c832c9c246dade2a45545