### PR TITLE
Add log path option to Start-HealthMonitor

### DIFF
--- a/docs/MonitoringTools/Start-HealthMonitor.md
+++ b/docs/MonitoringTools/Start-HealthMonitor.md
@@ -12,7 +12,7 @@ Periodically log system health metrics.
 
 ## SYNTAX
 ```powershell
-Start-HealthMonitor [[-IntervalSeconds] <Int32>] [[-Count] <Int32>] [<CommonParameters>]
+Start-HealthMonitor [[-IntervalSeconds] <Int32>] [[-Count] <Int32>] [[-LogPath] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,6 +30,9 @@ Collects five health samples thirty seconds apart.
 Seconds between health checks. Default is 60.
 ### -Count
 Number of samples to capture before exiting. Zero runs indefinitely.
+### -LogPath
+Path to the structured log file. Defaults to `$env:ST_LOG_PATH` or
+`~/SupportToolsLogs/supporttools.log`.
 
 ## INPUTS
 None. You cannot pipe objects to this command.

--- a/src/MonitoringTools/Public/Start-HealthMonitor.ps1
+++ b/src/MonitoringTools/Public/Start-HealthMonitor.ps1
@@ -10,11 +10,15 @@ function Start-HealthMonitor {
         Seconds between health checks. Defaults to 60.
     .PARAMETER Count
         Number of samples to collect before exiting. 0 runs indefinitely.
+    .PARAMETER LogPath
+        Optional path for the rich log file. Defaults to $env:ST_LOG_PATH or
+        ~/SupportToolsLogs/supporttools.log.
     #>
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [int]$IntervalSeconds = 60,
-        [int]$Count = 0
+        [int]$Count = 0,
+        [string]$LogPath
     )
 
     if (-not $PSCmdlet.ShouldProcess('system health monitoring')) { return }
@@ -25,7 +29,11 @@ function Start-HealthMonitor {
             $start = Get-Date
             $health = Get-SystemHealth
             $json = $health | ConvertTo-Json -Compress
-            Write-STRichLog -Tool 'HealthMonitor' -Status 'sample' -Details $json
+            if ($PSBoundParameters.ContainsKey('LogPath')) {
+                Write-STRichLog -Tool 'HealthMonitor' -Status 'sample' -Details $json -Path $LogPath
+            } else {
+                Write-STRichLog -Tool 'HealthMonitor' -Status 'sample' -Details $json
+            }
 
             $collected++
             if ($Count -gt 0 -and $collected -ge $Count) { break }

--- a/tests/MonitoringTools.Tests.ps1
+++ b/tests/MonitoringTools.Tests.ps1
@@ -33,4 +33,14 @@ Describe 'MonitoringTools Module' {
         Start-HealthMonitor -IntervalSeconds 0 -Count 2
         Assert-MockCalled Write-STRichLog -ModuleName MonitoringTools -Times 10
     }
+
+    Safe-It 'writes logs to a specified file' {
+        Mock Get-CPUUsage { 1 } -ModuleName MonitoringTools
+        Mock Get-DiskSpaceInfo { @() } -ModuleName MonitoringTools
+        Mock Get-EventLogSummary { @() } -ModuleName MonitoringTools
+        $logFile = Join-Path $TestDrive 'health.log'
+        Start-HealthMonitor -IntervalSeconds 0 -Count 1 -LogPath $logFile
+        Test-Path $logFile | Should -Be $true
+        (Get-Content $logFile | Measure-Object).Count | Should -Be 5
+    }
 }


### PR DESCRIPTION
### Summary
- allow Start-HealthMonitor to log to a custom path
- document the new -LogPath parameter
- test that Start-HealthMonitor creates logs at the specified location

### File Citations
- `src/MonitoringTools/Public/Start-HealthMonitor.ps1`
- `docs/MonitoringTools/Start-HealthMonitor.md`
- `tests/MonitoringTools.Tests.ps1`

### Test Results
```text
Tests Passed: 0, Failed: 310
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684638bedc5c832cb0c8f0f0838085fe