### PR TITLE
Add Show-MaintenancePlan function

### DIFF
--- a/docs/MaintenancePlan.md
+++ b/docs/MaintenancePlan.md
@@ -14,6 +14,7 @@ Import-Module ./src/MaintenancePlan/MaintenancePlan.psd1
 | `Export-MaintenancePlan` | Save a plan to a JSON file. | `$plan | Export-MaintenancePlan -Path plan.json` |
 | `Import-MaintenancePlan` | Load a plan from JSON. | `Import-MaintenancePlan -Path plan.json` |
 | `Invoke-MaintenancePlan` | Execute plan steps. | `Invoke-MaintenancePlan -Plan $plan` |
+| `Show-MaintenancePlan` | Display a summary of a plan. | `Show-MaintenancePlan -Plan $plan` |
 | `Schedule-MaintenancePlan` | Register a task or generate cron. | `Schedule-MaintenancePlan -PlanPath plan.json -Cron '0 3 * * 0' -Name Weekly` |
 
 ### Scheduling

--- a/src/MaintenancePlan/MaintenancePlan.psd1
+++ b/src/MaintenancePlan/MaintenancePlan.psd1
@@ -6,5 +6,5 @@
     Description = 'Create and manage maintenance plans.'
     RequiredModules = @('Logging')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','Maintenance','Internal') } }
-    FunctionsToExport = @('New-MaintenancePlan','Export-MaintenancePlan','Import-MaintenancePlan','Invoke-MaintenancePlan','Schedule-MaintenancePlan')
+    FunctionsToExport = @('New-MaintenancePlan','Export-MaintenancePlan','Import-MaintenancePlan','Invoke-MaintenancePlan','Schedule-MaintenancePlan','Show-MaintenancePlan')
 }

--- a/src/MaintenancePlan/Public/Show-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/Show-MaintenancePlan.ps1
@@ -1,0 +1,30 @@
+function Show-MaintenancePlan {
+    <#
+    .SYNOPSIS
+        Display a formatted summary of a maintenance plan.
+    .PARAMETER Plan
+        Plan object created by New-MaintenancePlan or Import-MaintenancePlan.
+    #>
+    [CmdletBinding(PositionalBinding=$false)]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [ValidateNotNull()]
+        [object]$Plan
+    )
+    process {
+        Assert-ParameterNotNull $Plan 'Plan'
+        Write-STDivider -Title 'MAINTENANCE PLAN' -Style heavy
+        $summary = [ordered]@{
+            Name     = $Plan.Name
+            Steps    = ($Plan.Steps | Measure-Object).Count
+            Schedule = if ($Plan.PSObject.Properties.Match('Schedule')) { $Plan.Schedule } else { '' }
+        }
+        Write-STBlock -Data $summary
+        $index = 1
+        foreach ($step in $Plan.Steps) {
+            Write-STStatus -Message "$index. $step" -Level SUB
+            $index++
+        }
+        Write-STClosing
+    }
+}

--- a/tests/MaintenancePlan.Tests.ps1
+++ b/tests/MaintenancePlan.Tests.ps1
@@ -35,6 +35,11 @@ Describe 'MaintenancePlan Module' {
         }
     }
 
+    Safe-It 'shows plan summary' {
+        $plan = New-MaintenancePlan -Name Demo -Steps @('step1','step2') -Schedule 'Daily'
+        { Show-MaintenancePlan -Plan $plan } | Should -Not -Throw
+    }
+
     Safe-It 'builds scheduled task command on Windows' {
         InModuleScope MaintenancePlan {
             Set-Variable -Name IsWindows -Value $true -Scope Script -Force


### PR DESCRIPTION
### Summary
- implement `Show-MaintenancePlan` to display plan details
- export the command in the module manifest
- document the new cmdlet
- test that `Show-MaintenancePlan` does not throw

### File Citations
- `src/MaintenancePlan/Public/Show-MaintenancePlan.ps1`【F:src/MaintenancePlan/Public/Show-MaintenancePlan.ps1†L1-L30】
- `src/MaintenancePlan/MaintenancePlan.psd1`【F:src/MaintenancePlan/MaintenancePlan.psd1†L9-L10】
- `docs/MaintenancePlan.md`【F:docs/MaintenancePlan.md†L11-L18】
- `tests/MaintenancePlan.Tests.ps1`【F:tests/MaintenancePlan.Tests.ps1†L24-L41】

### Test Results
- ❌ `Invoke-Pester -Configuration (Import-PowerShellDataFile './PesterConfiguration.psd1')` (failed to run all tests; many failed due to missing dependencies)【069314†L1-L29】

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684638c0a8d4832c8596e987343e2aef