### PR TITLE
Add banner color support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - SupportTools cmdlets can inject custom logging and telemetry modules
 - Detailed scenario documentation for the SharePointTools module
 - SharePointTools module graduated from Beta to Stable with version 1.2.0
+- `Out-STBanner` now accepts `-Color` to output ANSI colored titles
 ### Breaking Changes
 - None in this release
 

--- a/docs/ModuleStyleGuide.md
+++ b/docs/ModuleStyleGuide.md
@@ -21,6 +21,15 @@ Write-STBlock -Data @{ 'User'='svc-backend'; 'Domain'='corp.local'; 'IP'='10.10.
 Write-STClosing
 ```
 
+## Banners with Color
+
+`Out-STBanner` accepts a `-Color` parameter to emit the banner title using ANSI
+color codes. Pass any standard console color name.
+
+```powershell
+Out-STBanner -Info (Show-LoggingBanner) -Color Red
+```
+
 All messages can also be logged to `%USERPROFILE%\SupportToolsLogs\supporttools.log` or `$env:ST_LOG_PATH`.
 Use the `-Log` switch or `-Path` parameter of `Write-STLog` to override the location.
 Use the `-Structured` parameter or set `ST_LOG_STRUCTURED=1` to output JSON lines with extra metadata.

--- a/src/OutTools/OutTools.psm1
+++ b/src/OutTools/OutTools.psm1
@@ -11,10 +11,21 @@ function Out-STStatus {
 function Out-STBanner {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][pscustomobject]$Info
+        [Parameter(Mandatory)][pscustomobject]$Info,
+        [ValidateSet('Black','DarkBlue','DarkGreen','DarkCyan','DarkRed','DarkMagenta','DarkYellow','Gray','DarkGray','Blue','Green','Cyan','Red','Magenta','Yellow','White')]
+        [string]$Color
     )
     if (-not $Info.Module) { throw 'Module property required' }
     $title = "$($Info.Module.ToUpper()) MODULE LOADED"
+    if ($PSBoundParameters.ContainsKey('Color')) {
+        $ansiMap = @{
+            Black='30'; DarkBlue='34'; DarkGreen='32'; DarkCyan='36'; DarkRed='31';
+            DarkMagenta='35'; DarkYellow='33'; Gray='37'; DarkGray='90'; Blue='94';
+            Green='92'; Cyan='96'; Red='91'; Magenta='95'; Yellow='93'; White='97'
+        }
+        $code = $ansiMap[$Color]
+        if ($code) { $title = "`e[${code}m$title`e[0m" }
+    }
     Write-STDivider -Title $title -Style heavy
     Write-STStatus "Run 'Get-Command -Module $($Info.Module)' to view available tools." -Level SUB
     Write-STLog -Message "$($Info.Module) module loaded" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')

--- a/tests/OutTools.Tests.ps1
+++ b/tests/OutTools.Tests.ps1
@@ -9,4 +9,20 @@ Describe 'OutTools Module' {
         $obj = [pscustomobject]@{ Module='TestMod'; Version='1.0' }
         { $obj | Out-STBanner } | Should -Not -Throw
     }
+
+    Safe-It 'adds ANSI color when -Color used' {
+        Mock Write-STDivider {} -ModuleName Logging
+        Mock Write-STStatus {} -ModuleName OutTools
+        Mock Write-STLog {} -ModuleName Logging
+        Out-STBanner -Info @{ Module='TestMod' } -Color Red
+        Assert-MockCalled Write-STDivider -ModuleName Logging -ParameterFilter { $Title.Contains([char]27) } -Times 1
+    }
+
+    Safe-It 'prints plain banner by default' {
+        Mock Write-STDivider {} -ModuleName Logging
+        Mock Write-STStatus {} -ModuleName OutTools
+        Mock Write-STLog {} -ModuleName Logging
+        Out-STBanner -Info @{ Module='TestMod' }
+        Assert-MockCalled Write-STDivider -ModuleName Logging -ParameterFilter { -not $Title.Contains([char]27) } -Times 1
+    }
 }


### PR DESCRIPTION
### Summary
- allow banners to output ANSI-colored titles
- describe banner colors in style guide
- test new banner color parameter

### File Citations
- `src/OutTools/OutTools.psm1`
- `docs/ModuleStyleGuide.md`
- `CHANGELOG.md`
- `tests/OutTools.Tests.ps1`

### Test Results
- ❌ `Invoke-Pester` (failed to run due to module errors)


------
https://chatgpt.com/codex/tasks/task_e_684638c87d78832cb1812bc2fb4513bd