### PR TITLE
Add ST_HEALTH_INTERVAL support

### DIFF
--- a/docs/MonitoringTools/Start-HealthMonitor.md
+++ b/docs/MonitoringTools/Start-HealthMonitor.md
@@ -27,7 +27,8 @@ Collects five health samples thirty seconds apart.
 
 ## PARAMETERS
 ### -IntervalSeconds
-Seconds between health checks. Default is 60.
+Seconds between health checks. Default is 60. Set `$env:ST_HEALTH_INTERVAL` to
+define the interval when the parameter is not provided.
 ### -Count
 Number of samples to capture before exiting. Zero runs indefinitely.
 

--- a/src/MonitoringTools/Public/Start-HealthMonitor.ps1
+++ b/src/MonitoringTools/Public/Start-HealthMonitor.ps1
@@ -17,6 +17,10 @@ function Start-HealthMonitor {
         [int]$Count = 0
     )
 
+    if (-not $PSBoundParameters.ContainsKey('IntervalSeconds') -and $env:ST_HEALTH_INTERVAL) {
+        $IntervalSeconds = [int]$env:ST_HEALTH_INTERVAL
+    }
+
     if (-not $PSCmdlet.ShouldProcess('system health monitoring')) { return }
 
     try {

--- a/tests/MonitoringTools.Tests.ps1
+++ b/tests/MonitoringTools.Tests.ps1
@@ -33,4 +33,19 @@ Describe 'MonitoringTools Module' {
         Start-HealthMonitor -IntervalSeconds 0 -Count 2
         Assert-MockCalled Write-STRichLog -ModuleName MonitoringTools -Times 10
     }
+
+    Safe-It 'honors ST_HEALTH_INTERVAL environment variable' {
+        InModuleScope MonitoringTools {
+            Mock Get-SystemHealth { @{ CpuPercent=1; DiskInfo=@(); EventLogSummary=@() } }
+            Mock Write-STRichLog {}
+            Mock Start-Sleep {}
+            try {
+                $env:ST_HEALTH_INTERVAL = '2'
+                Start-HealthMonitor -Count 1
+            } finally {
+                Remove-Item env:ST_HEALTH_INTERVAL -ErrorAction SilentlyContinue
+            }
+            Assert-MockCalled Start-Sleep -ParameterFilter { $Seconds -eq 2 } -Times 1
+        }
+    }
 }


### PR DESCRIPTION
### Summary
- read the `ST_HEALTH_INTERVAL` variable in **Start-HealthMonitor.ps1**
- document the variable in the command help
- test that Start-HealthMonitor honors the environment variable

### File Citations
- `src/MonitoringTools/Public/Start-HealthMonitor.ps1`【F:src/MonitoringTools/Public/Start-HealthMonitor.ps1†L16-L22】
- `docs/MonitoringTools/Start-HealthMonitor.md`【F:docs/MonitoringTools/Start-HealthMonitor.md†L28-L33】
- `tests/MonitoringTools.Tests.ps1`【F:tests/MonitoringTools.Tests.ps1†L30-L50】

### Test Results
```text
See log for Pester output. Tests failed to run: Invoke-Pester reported 310 failures due to environment setup issues.
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.
```

------
https://chatgpt.com/codex/tasks/task_e_684638cabd70832c822e61877a692157