### PR TITLE
Implement ticket ID completers

### DIFF
--- a/src/ServiceDeskTools/Public/Add-SDTicketComment.ps1
+++ b/src/ServiceDeskTools/Public/Add-SDTicketComment.ps1
@@ -32,3 +32,18 @@ function Add-SDTicketComment {
         Invoke-SDRequest -Method 'POST' -Path "/incidents/$Id/comments.json" -Body $body -ChaosMode:$ChaosMode
     }
 }
+
+# Register argument completer for open ticket IDs
+Register-ArgumentCompleter -CommandName Add-SDTicketComment -ParameterName Id -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete)
+    try {
+        Invoke-SDRequest -Method 'GET' -Path '/incidents.json?state=open' |
+            ForEach-Object id |
+            Where-Object { $_ -like "$wordToComplete*" } |
+            ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+            }
+    } catch {
+        # ignore completion errors
+    }
+}

--- a/src/ServiceDeskTools/Public/Get-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDTicket.ps1
@@ -29,3 +29,18 @@ function Get-SDTicket {
         return [TicketObject]::FromApiResponse($result)
     }
 }
+
+# Register argument completer for open ticket IDs
+Register-ArgumentCompleter -CommandName Get-SDTicket -ParameterName Id -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete)
+    try {
+        Invoke-SDRequest -Method 'GET' -Path '/incidents.json?state=open' |
+            ForEach-Object id |
+            Where-Object { $_ -like "$wordToComplete*" } |
+            ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+            }
+    } catch {
+        # ignore completion errors
+    }
+}

--- a/src/ServiceDeskTools/Public/Get-SDTicketHistory.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDTicketHistory.ps1
@@ -27,3 +27,18 @@ function Get-SDTicketHistory {
         return $result
     }
 }
+
+# Register argument completer for open ticket IDs
+Register-ArgumentCompleter -CommandName Get-SDTicketHistory -ParameterName Id -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete)
+    try {
+        Invoke-SDRequest -Method 'GET' -Path '/incidents.json?state=open' |
+            ForEach-Object id |
+            Where-Object { $_ -like "$wordToComplete*" } |
+            ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+            }
+    } catch {
+        # ignore completion errors
+    }
+}

--- a/src/ServiceDeskTools/Public/Set-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicket.ps1
@@ -32,3 +32,18 @@ function Set-SDTicket {
         Invoke-SDRequest -Method 'PUT' -Path "/incidents/$Id.json" -Body $body -ChaosMode:$ChaosMode
     }
 }
+
+# Register argument completer for open ticket IDs
+Register-ArgumentCompleter -CommandName Set-SDTicket -ParameterName Id -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete)
+    try {
+        Invoke-SDRequest -Method 'GET' -Path '/incidents.json?state=open' |
+            ForEach-Object id |
+            Where-Object { $_ -like "$wordToComplete*" } |
+            ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+            }
+    } catch {
+        # ignore completion errors
+    }
+}

--- a/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
@@ -33,3 +33,18 @@ function Set-SDTicketBulk {
         }
     }
 }
+
+# Register argument completer for open ticket IDs
+Register-ArgumentCompleter -CommandName Set-SDTicketBulk -ParameterName Id -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete)
+    try {
+        Invoke-SDRequest -Method 'GET' -Path '/incidents.json?state=open' |
+            ForEach-Object id |
+            Where-Object { $_ -like "$wordToComplete*" } |
+            ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+            }
+    } catch {
+        # ignore completion errors
+    }
+}

--- a/tests/ServiceDeskTools/TicketObject.Tests.ps1
+++ b/tests/ServiceDeskTools/TicketObject.Tests.ps1
@@ -42,3 +42,14 @@ Describe 'TicketObject class' {
         [TicketObject]::FromApiResponse($null) | Should -Be $null
     }
 }
+
+Describe 'Ticket ID argument completer' {
+    Safe-It 'registers completer for Id parameters' {
+        Mock Register-ArgumentCompleter {}
+        Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
+        $cmds = 'Get-SDTicket','Set-SDTicket','Add-SDTicketComment','Get-SDTicketHistory','Set-SDTicketBulk'
+        foreach ($c in $cmds) {
+            Assert-MockCalled Register-ArgumentCompleter -ParameterFilter { $CommandName -eq $c -and $ParameterName -eq 'Id' } -Times 1
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- register open ticket ID tab completion
- test registration of completer

### File Citations
- `src/ServiceDeskTools/Public/Get-SDTicket.ps1` lines 33-46
- `tests/ServiceDeskTools/TicketObject.Tests.ps1` lines 46-55

### Test Results
See executed test run with failures due to environment restrictions.


------
https://chatgpt.com/codex/tasks/task_e_684638a143fc832c82857b33fa7bdf3b