### PR TITLE
Enable ST_HEALTH_INTERVAL

### DIFF
--- a/docs/MonitoringTools/Start-HealthMonitor.md
+++ b/docs/MonitoringTools/Start-HealthMonitor.md
@@ -27,7 +27,7 @@ Collects five health samples thirty seconds apart.
 
 ## PARAMETERS
 ### -IntervalSeconds
-Seconds between health checks. Default is 60.
+Seconds between health checks. Default is `60`. You can set `$env:ST_HEALTH_INTERVAL` to override the default when the parameter is omitted.
 ### -Count
 Number of samples to capture before exiting. Zero runs indefinitely.
 ### -LogPath

--- a/src/MonitoringTools/Public/Start-HealthMonitor.ps1
+++ b/src/MonitoringTools/Public/Start-HealthMonitor.ps1
@@ -21,6 +21,10 @@ function Start-HealthMonitor {
         [string]$LogPath
     )
 
+    if (-not $PSBoundParameters.ContainsKey('IntervalSeconds')) {
+        if ($env:ST_HEALTH_INTERVAL) { $IntervalSeconds = [int]$env:ST_HEALTH_INTERVAL }
+    }
+
     if (-not $PSCmdlet.ShouldProcess('system health monitoring')) { return }
 
     try {


### PR DESCRIPTION
### Summary
- allow Start-HealthMonitor to read the ST_HEALTH_INTERVAL env var
- document ST_HEALTH_INTERVAL in Start-HealthMonitor docs

### File Citations
- `src/MonitoringTools/Public/Start-HealthMonitor.ps1`
- `docs/MonitoringTools/Start-HealthMonitor.md`

### Test Results
```
Starting discovery in 48 files.
Discovery found 339 tests in 1.76s.
Starting code coverage.
Running tests.
Tests completed in 20.2s
Tests Passed: 0, Failed: 339, Skipped: 0, Inconclusive: 0, NotRun: 0
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463c14f9e4832cafd273422261f83b