### PR TITLE
Add Get-SDUser command

### DIFF
--- a/docs/ServiceDeskTools/Get-SDUser.md
+++ b/docs/ServiceDeskTools/Get-SDUser.md
@@ -1,0 +1,40 @@
+---
+external help file: ServiceDeskTools-help.xml
+Module Name: ServiceDeskTools
+online version:
+schema: 2.0.0
+---
+
+# Get-SDUser
+
+## SYNOPSIS
+Retrieves details for a Service Desk user.
+
+## SYNTAX
+
+```
+Get-SDUser [-Id] <Int32> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Queries the Service Desk API for a single user and returns the full user object.
+
+## PARAMETERS
+
+### -Id
+Unique numeric identifier of the user to retrieve.
+
+### -ProgressAction
+Specifies how progress is displayed.
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### PSObject
+User returned from the Service Desk API.
+
+## NOTES

--- a/src/ServiceDeskTools/Public/Get-SDUser.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDUser.ps1
@@ -1,0 +1,26 @@
+function Get-SDUser {
+    <#
+    .SYNOPSIS
+        Retrieves details for a Service Desk user.
+    .PARAMETER Id
+        User ID to retrieve.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [int]$Id,
+        [switch]$ChaosMode,
+        [switch]$Explain
+    )
+
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return
+    }
+
+    Write-STLog -Message "Get-SDUser $Id" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    if ($PSCmdlet.ShouldProcess("user $Id", 'Get')) {
+        Invoke-SDRequest -Method 'GET' -Path "/users/$Id.json" -ChaosMode:$ChaosMode
+    }
+}

--- a/src/ServiceDeskTools/ServiceDeskTools.psd1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psd1
@@ -6,5 +6,5 @@
     Description = 'Commands for interacting with the Service Desk ticketing system.'
     RequiredModules = @('Logging','Telemetry')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','ServiceDesk','Internal') } }
-    FunctionsToExport = @('Add-SDTicketComment','Export-SDConfig','Get-SDTicket','Get-SDTicketHistory','Get-ServiceDeskAsset','Get-ServiceDeskRelationship','Get-ServiceDeskStats','Link-SDTicketToSPTask','New-SDTicket','Remove-SDTicketAttachment','Search-SDTicket','Set-SDTicket','Set-SDTicketBulk','Submit-Ticket')
+    FunctionsToExport = @('Add-SDTicketComment','Export-SDConfig','Get-SDTicket','Get-SDTicketHistory','Get-ServiceDeskAsset','Get-ServiceDeskRelationship','Get-ServiceDeskStats','Get-SDUser','Link-SDTicketToSPTask','New-SDTicket','Remove-SDTicketAttachment','Search-SDTicket','Set-SDTicket','Set-SDTicketBulk','Submit-Ticket')
 }

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'ServiceDeskTools Module' {
         $expected = @(
             'Get-SDTicket','Get-SDTicketHistory','New-SDTicket','Set-SDTicket',
             'Add-SDTicketComment','Search-SDTicket','Get-ServiceDeskAsset',
-            'Set-SDTicketBulk','Link-SDTicketToSPTask','Export-SDConfig'
+            'Get-SDUser','Set-SDTicketBulk','Link-SDTicketToSPTask','Export-SDConfig'
         )
         $exported = (Get-Command -Module ServiceDeskTools).Name
         foreach ($cmd in $expected) {
@@ -97,6 +97,20 @@ Describe 'ServiceDeskTools Module' {
                 $ChaosMode -eq $true -and $Method -eq 'GET' -and $Path -eq '/assets/4.json'
             } -Times 1
         }
+        Safe-It 'Get-SDUser calls Invoke-SDRequest' {
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
+            Get-SDUser -Id 3
+            Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter {
+                $Method -eq 'GET' -and $Path -eq '/users/3.json'
+            } -Times 1
+        }
+        Safe-It 'Get-SDUser passes ChaosMode' {
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
+            Get-SDUser -Id 3 -ChaosMode
+            Assert-MockCalled Invoke-SDRequest -ModuleName ServiceDeskTools -ParameterFilter {
+                $ChaosMode -eq $true -and $Method -eq 'GET' -and $Path -eq '/users/3.json'
+            } -Times 1
+        }
         Safe-It 'Set-SDTicketBulk calls Set-SDTicket for each id' {
             Mock Set-SDTicket {} -ModuleName ServiceDeskTools
             Set-SDTicketBulk -Id 10,11 -Fields @{status='Closed'}
@@ -142,6 +156,12 @@ Describe 'ServiceDeskTools Module' {
             Mock Write-STLog {} -ModuleName ServiceDeskTools
             Get-ServiceDeskAsset -Id 6
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Get-ServiceDeskAsset 6' } -Times 1
+        }
+        Safe-It 'Get-SDUser logs the request' {
+            Mock Invoke-SDRequest {} -ModuleName ServiceDeskTools
+            Mock Write-STLog {} -ModuleName ServiceDeskTools
+            Get-SDUser -Id 6
+            Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Get-SDUser 6' } -Times 1
         }
         Safe-It 'Set-SDTicketBulk logs each id' {
             Mock Set-SDTicket {} -ModuleName ServiceDeskTools

--- a/tests/ServiceDeskTools/Get-SDUser.Tests.ps1
+++ b/tests/ServiceDeskTools/Get-SDUser.Tests.ps1
@@ -1,0 +1,26 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Get-SDUser' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
+    }
+
+    Safe-It 'returns API response on success' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { @{ ok = $true } }
+            $res = Get-SDUser -Id 1
+            Assert-MockCalled Invoke-SDRequest -Times 1 -ParameterFilter {
+                $Method -eq 'GET' -and $Path -eq '/users/1.json'
+            }
+            $res.ok | Should -Be $true
+        }
+    }
+
+    Safe-It 'throws when Invoke-SDRequest fails' {
+        InModuleScope ServiceDeskTools {
+            Mock Invoke-SDRequest { throw 'bad' }
+            { Get-SDUser -Id 2 } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- add Get-SDUser command to query `/users` API
- export new function via module manifest
- document Get-SDUser
- test new command

### File Citations
- `src/ServiceDeskTools/Public/Get-SDUser.ps1`【F:src/ServiceDeskTools/Public/Get-SDUser.ps1†L1-L26】
- `src/ServiceDeskTools/ServiceDeskTools.psd1` update exports【F:src/ServiceDeskTools/ServiceDeskTools.psd1†L6-L10】
- `docs/ServiceDeskTools/Get-SDUser.md`【F:docs/ServiceDeskTools/Get-SDUser.md†L1-L40】
- `tests/ServiceDeskTools/Get-SDUser.Tests.ps1`【F:tests/ServiceDeskTools/Get-SDUser.Tests.ps1†L1-L26】
- integration tests in `tests/ServiceDeskTools.Tests.ps1` add cases【F:tests/ServiceDeskTools.Tests.ps1†L96-L112】【F:tests/ServiceDeskTools.Tests.ps1†L156-L165】

### Test Results
```
Tests completed in 17.19s
Tests Passed: 0, Failed: 345, Skipped: 0, Inconclusive: 0, NotRun: 0
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463c04c90c832c8492e6e5a21b341f