### PR TITLE
Add ServiceDesk asset URI test

### DIFF
--- a/tests/ServiceDeskTools/Get-ServiceDeskAsset.Tests.ps1
+++ b/tests/ServiceDeskTools/Get-ServiceDeskAsset.Tests.ps1
@@ -1,0 +1,20 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Get-ServiceDeskAsset' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
+    }
+
+    Safe-It 'uses SD_ASSET_BASE_URI when set' {
+        InModuleScope ServiceDeskTools {
+            $env:SD_ASSET_BASE_URI = 'https://assets.example.com/api/'
+            Mock Invoke-SDRequest {}
+            Get-ServiceDeskAsset -Id 9
+            Assert-MockCalled Invoke-SDRequest -Times 1 -ParameterFilter {
+                $Method -eq 'GET' -and $Path -eq '/assets/9.json' -and $BaseUri -eq 'https://assets.example.com/api/'
+            }
+            Remove-Item env:SD_ASSET_BASE_URI
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- add a test for Get-ServiceDeskAsset to honor `SD_ASSET_BASE_URI`

### File Citations
- `tests/ServiceDeskTools/Get-ServiceDeskAsset.Tests.ps1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463ec0dc10832cb09079826595cb9a