### PR TITLE
Add Watch-GraphSignIns tests

### DIFF
--- a/tests/EntraIDTools/Watch-GraphSignIns.Tests.ps1
+++ b/tests/EntraIDTools/Watch-GraphSignIns.Tests.ps1
@@ -1,0 +1,28 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Watch-GraphSignIns batch output' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/EntraIDTools/EntraIDTools.psd1 -Force
+    }
+
+    Safe-It 'emits all sign-ins and stops after count' {
+        InModuleScope EntraIDTools {
+            $batch1 = 1..5 | ForEach-Object { [pscustomobject]@{ id = $_ } }
+            $batch2 = 6..10 | ForEach-Object { [pscustomobject]@{ id = $_ } }
+            $calls = 0
+            Mock Get-GraphSignInLogs {
+                $script:calls++
+                if ($script:calls -eq 1) { $batch1 }
+                elseif ($script:calls -eq 2) { $batch2 }
+                else { @() }
+            } -ModuleName EntraIDTools
+
+            $result = Watch-GraphSignIns -TenantId 'tid' -ClientId 'cid' -RequesterEmail 'r@test' -Count 2 -IntervalSeconds 0
+
+            $result.Count | Should -Be 10
+            $script:calls | Should -Be 2
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- add missing test for Watch-GraphSignIns

### File Citations
- `tests/EntraIDTools/Watch-GraphSignIns.Tests.ps1`

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to run: `pwsh: command not found`)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463eb5e4d8832c8e1e4375fde6e9f5