### PR TITLE
Add Get-GraphRiskySignIns tests

### DIFF
--- a/tests/EntraIDTools/Get-GraphRiskySignIns.Tests.ps1
+++ b/tests/EntraIDTools/Get-GraphRiskySignIns.Tests.ps1
@@ -1,0 +1,32 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Get-GraphRiskySignIns function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/EntraIDTools/EntraIDTools.psd1 -Force
+        . $PSScriptRoot/../../src/EntraIDTools/Private/Get-GraphAccessToken.ps1
+    }
+
+    Safe-It 'returns risk events from Graph' {
+        $expected = @(
+            [pscustomobject]@{ id = '1'; userPrincipalName = 'user@test'; riskLevel = 'high' }
+        )
+        Mock Get-GraphAccessToken { 'tok' } -ModuleName EntraIDTools
+        Mock Invoke-STRequest { @{ value = $expected } } -ModuleName EntraIDTools -ParameterFilter { $Method -eq 'GET' }
+        Mock Write-STTelemetryEvent {} -ModuleName EntraIDTools
+
+        $result = Get-GraphRiskySignIns -TenantId 'tid' -ClientId 'cid'
+        $result | Should -Be $expected
+    }
+
+    Safe-It 'logs errors when Graph call fails' {
+        Mock Get-GraphAccessToken { 'tok' } -ModuleName EntraIDTools
+        Mock Invoke-STRequest { throw 'bad' } -ModuleName EntraIDTools -ParameterFilter { $Method -eq 'GET' }
+        Mock Write-STLog {} -ModuleName EntraIDTools
+        Mock Write-STTelemetryEvent {} -ModuleName EntraIDTools
+
+        { Get-GraphRiskySignIns -TenantId 'tid' -ClientId 'cid' } | Should -Throw
+        Assert-MockCalled Write-STLog -ModuleName EntraIDTools -Times 1 -ParameterFilter { $Level -eq 'ERROR' }
+    }
+}


### PR DESCRIPTION
### Summary
- add unit tests for Get-GraphRiskySignIns

### File Citations
- `tests/EntraIDTools/Get-GraphRiskySignIns.Tests.ps1`

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to run all tests)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463eb445e8832c85462cfe30bdeac5