### PR TITLE
Add STCore error helper tests

### DIFF
--- a/tests/STCore.ErrorHelpers.Tests.ps1
+++ b/tests/STCore.ErrorHelpers.Tests.ps1
@@ -1,0 +1,20 @@
+. $PSScriptRoot/TestHelpers.ps1
+Describe 'STCore Error Helpers' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/STCore/STCore.psd1 -Force
+    }
+
+    Safe-It 'New-STErrorRecord returns an ErrorRecord with the provided message' {
+        $err = New-STErrorRecord -Message 'oops'
+        $err | Should -BeOfType 'System.Management.Automation.ErrorRecord'
+        $err.Exception.Message | Should -Be 'oops'
+    }
+
+    Safe-It 'New-STErrorObject returns PSCustomObject with Timestamp, Category and Message' {
+        $obj = New-STErrorObject -Message 'fail' -Category 'Test'
+        $obj | Should -BeOfType 'pscustomobject'
+        @('Timestamp','Category','Message') | ForEach-Object { $obj.PSObject.Properties.Name | Should -Contain $_ }
+        $obj.Category | Should -Be 'Test'
+        $obj.Message | Should -Be 'fail'
+    }
+}


### PR DESCRIPTION
### Summary
- add tests for `New-STErrorRecord` and `New-STErrorObject`

### File Citations
- `tests/STCore.ErrorHelpers.Tests.ps1`
- `docs/TestingGuidelines.md`

### Test Results
```
Starting discovery in 50 files.
Discovery found 349 tests in 1.62s.
Starting code coverage.
Running tests.
New-PSDrive: A drive with the name 'TestDrive' already exists.
[-] AddUsersToGroup Script.connects and disconnects from Graph 732ms (383ms|350ms)
RuntimeException: Test failed in : [Framework failed:
 Result 1 - Error 1:MethodInvocationException: Exception calling "Add" with "2" argument(s): "Item has already been added. Key
 in dictionary: 'TestDrive'  Key being added: 'TestDrive'"
...
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463eae8638832cac64755ec8f6b451