### PR TITLE
Add sanitization test for random strings

### DIFF
--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -197,4 +197,17 @@ Describe 'Logging Module' {
             Remove-Item $temp -ErrorAction SilentlyContinue
         }
     }
+
+    Safe-It 'sanitizes long random strings in logs' {
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            $value = -join ((48..57)+(65..90)+(97..122) | Get-Random -Count 25 | ForEach-Object { [char]$_ })
+            Write-STLog -Message $value -Path $temp
+            $content = Get-Content $temp
+            $content | Should -Not -Match $value
+            $content | Should -Match '\[REDACTED\]'
+        } finally {
+            Remove-Item $temp -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
### Summary
- extend Logging.Tests with scenario for long random strings

### File Citations
- `tests/Logging.Tests.ps1`

### Test Results
```text
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.
```

------
https://chatgpt.com/codex/tasks/task_e_68463eaf4044832c84a243e9c7dbf7e2