### PR TITLE
Add log forwarding env var test

### DIFF
--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -197,4 +197,17 @@ Describe 'Logging Module' {
             Remove-Item $temp -ErrorAction SilentlyContinue
         }
     }
+
+    Safe-It 'forwards logs using ST_LOG_FORWARD_URI' {
+        $temp = [System.IO.Path]::GetTempFileName()
+        try {
+            $env:ST_LOG_FORWARD_URI = 'https://example.com/forward'
+            Mock Invoke-RestMethod {}
+            Write-STLog -Message 'test' -Structured -Path $temp
+            Assert-MockCalled Invoke-RestMethod -Times 1 -ParameterFilter { $Uri -eq $env:ST_LOG_FORWARD_URI }
+        } finally {
+            Remove-Item env:ST_LOG_FORWARD_URI -ErrorAction SilentlyContinue
+            Remove-Item $temp -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
### Summary
- add unit test ensuring logs forward to the URI in `ST_LOG_FORWARD_URI`

### File Citations
- `tests/Logging.Tests.ps1` lines 201-212 add the new test verifying `Invoke-RestMethod` is called with the forwarded URI.

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to run successfully)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463eb06228832cac8155f7187a9f76