### PR TITLE
Add test for Install-SupportTools fallback

### DIFF
--- a/tests/Install-SupportTools.Tests.ps1
+++ b/tests/Install-SupportTools.Tests.ps1
@@ -1,0 +1,20 @@
+. $PSScriptRoot/TestHelpers.ps1
+
+Describe 'Install-SupportTools script' {
+    BeforeEach {
+        function Install-Module {}
+        function Import-Module {}
+        Mock Install-Module {
+            if ($Name -eq 'SharePointTools') { throw 'gallery unavailable' }
+        }
+        Mock Import-Module {}
+    }
+
+    Safe-It 'imports from src when gallery install fails' {
+        $warnings = @()
+        & $PSScriptRoot/../scripts/Install-SupportTools.ps1 -WarningVariable +warnings -Scope CurrentUser
+        $spPath = Join-Path $PSScriptRoot/../src/SharePointTools 'SharePointTools.psd1'
+        Assert-MockCalled Import-Module -ParameterFilter { $Name -eq $spPath } -Times 1
+        $warnings | Should -Contain "Imported SharePointTools from $spPath"
+    }
+}


### PR DESCRIPTION
### Summary
- add Install-SupportTools.Tests.ps1 to verify fallback to local modules

### File Citations
- `tests/Install-SupportTools.Tests.ps1`【F:tests/Install-SupportTools.Tests.ps1†L1-L20】

### Test Results
```
Invoke-Pester failed due to TestDrive errors
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463ec31a0c832c81f15da14aa0741e