### PR TITLE
Add Export-SDConfig test

### DIFF
--- a/tests/ServiceDeskTools/Export-SDConfig.Tests.ps1
+++ b/tests/ServiceDeskTools/Export-SDConfig.Tests.ps1
@@ -1,0 +1,34 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Export-SDConfig' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
+    }
+
+    Safe-It 'exports env settings without API token' {
+        InModuleScope ServiceDeskTools {
+            $temp = [System.IO.Path]::GetTempFileName()
+            try {
+                $env:SD_BASE_URI = 'https://desk.example.com/api'
+                $env:SD_ASSET_BASE_URI = 'https://assets.example.com/api'
+                $env:SD_RATE_LIMIT_PER_MINUTE = '17'
+                $env:SD_API_TOKEN = 'secret'
+
+                Export-SDConfig -Path $temp
+                $json = Get-Content $temp | ConvertFrom-Json
+                $json.BaseUri | Should -Be 'https://desk.example.com/api'
+                $json.AssetBaseUri | Should -Be 'https://assets.example.com/api'
+                $json.RateLimitPerMinute | Should -Be 17
+                $json.PSObject.Properties.Name | Should -Not -Contain 'ApiToken'
+            }
+            finally {
+                Remove-Item $temp -ErrorAction SilentlyContinue
+                Remove-Item env:SD_BASE_URI -ErrorAction SilentlyContinue
+                Remove-Item env:SD_ASSET_BASE_URI -ErrorAction SilentlyContinue
+                Remove-Item env:SD_RATE_LIMIT_PER_MINUTE -ErrorAction SilentlyContinue
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- test Export-SDConfig respects environment variables

### File Citations
- `tests/ServiceDeskTools/Export-SDConfig.Tests.ps1`

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to run)

------
https://chatgpt.com/codex/tasks/task_e_68463ebe77bc832c9ffd764dee986644