### PR TITLE
Add Disable-GraphUser test

### DIFF
--- a/tests/EntraIDTools/Disable-GraphUser.Tests.ps1
+++ b/tests/EntraIDTools/Disable-GraphUser.Tests.ps1
@@ -1,0 +1,23 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Disable-GraphUser' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/EntraIDTools/EntraIDTools.psd1 -Force
+        . $PSScriptRoot/../../src/EntraIDTools/Private/Get-GraphAccessToken.ps1
+    }
+
+    It 'sends PATCH /users/<id> with accountEnabled=false' {
+        Mock Get-GraphAccessToken { 'token' } -ModuleName EntraIDTools
+        Mock Invoke-STRequest {} -ModuleName EntraIDTools
+
+        Disable-GraphUser -UserPrincipalName 'user@test' -TenantId 'tid' -ClientId 'cid' -ClientSecret 'sec'
+
+        Assert-MockCalled Invoke-STRequest -ModuleName EntraIDTools -Times 1 -ParameterFilter {
+            $Method -eq 'PATCH' -and
+            $Uri -eq 'https://graph.microsoft.com/v1.0/users/user@test' -and
+            $Body.accountEnabled -eq $false
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- test Disable-GraphUser sends PATCH with accountEnabled=false

### File Citations
- `tests/EntraIDTools/Disable-GraphUser.Tests.ps1`

### Test Results
```bash
Starting discovery in 49 files.
Discovery found 347 tests in 1.09s.
Starting code coverage.
Running tests.
Tests completed in 22.32s
Tests Passed: 0, Failed: 347, Skipped: 0, Inconclusive: 0, NotRun: 0
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463eb9902c832cb55f06d53d9f8458