### PR TITLE
Add Get-GraphSignInLogs test

### DIFF
--- a/tests/EntraIDTools/Get-GraphSignInLogs.Tests.ps1
+++ b/tests/EntraIDTools/Get-GraphSignInLogs.Tests.ps1
@@ -1,0 +1,21 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Get-GraphSignInLogs request' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/EntraIDTools/EntraIDTools.psd1 -Force
+        . $PSScriptRoot/../../src/EntraIDTools/Private/Get-GraphAccessToken.ps1
+    }
+
+    Safe-It 'targets auditLogs/signIns and records telemetry' {
+        Mock Get-GraphAccessToken { 'token' } -ModuleName EntraIDTools
+        Mock Invoke-STRequest { @{ value=@() } } -ModuleName EntraIDTools -ParameterFilter { $Method -eq 'GET' }
+        Mock Write-STTelemetryEvent {} -ModuleName EntraIDTools
+
+        Get-GraphSignInLogs -TenantId 'tid' -ClientId 'cid'
+
+        Assert-MockCalled Invoke-STRequest -ModuleName EntraIDTools -Times 1 -ParameterFilter { $Uri -match '/auditLogs/signIns' }
+        Assert-MockCalled Write-STTelemetryEvent -ModuleName EntraIDTools -Times 1
+    }
+}


### PR DESCRIPTION
### Summary
- add unit test for Get-GraphSignInLogs to check request URI and telemetry

### File Citations
- `tests/EntraIDTools/Get-GraphSignInLogs.Tests.ps1`

### Test Results
```
Invoke-Pester failed due to missing modules and existing TestDrive conflicts.
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.
```

------
https://chatgpt.com/codex/tasks/task_e_68463eb5011c832c81999dbe69a85d80