### PR TITLE
Add invalid mode test for Connect-STPlatform

### DIFF
--- a/tests/STPlatform.Tests.ps1
+++ b/tests/STPlatform.Tests.ps1
@@ -258,6 +258,15 @@ Describe 'STPlatform Module' {
                 }
             }
         }
+
+        Safe-It 'throws on invalid Mode and does not import modules' {
+            InModuleScope STPlatform {
+                function Import-Module {}
+                Mock Import-Module {}
+                { Connect-STPlatform -Mode Invalid } | Should -Throw
+                Assert-MockCalled Import-Module -Times 0
+            }
+        }
     }
 
     Context 'Connect-EntraID' {


### PR DESCRIPTION
### Summary
- ensure invalid Mode throws and doesn't import modules

### File Citations
- `tests/STPlatform.Tests.ps1` lines 262-269

### Test Results
```text
Tests Passed: 0, Failed: 348, Skipped: 0, Inconclusive: 0, NotRun: 0
BeforeAll \ AfterAll failed: 3
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68463ebdfefc832c89d1ac652922930d