### PR TITLE
Add test for Install-ModuleDependencies nuspec modules

### DIFF
--- a/tests/Install-ModuleDependencies.Tests.ps1
+++ b/tests/Install-ModuleDependencies.Tests.ps1
@@ -1,0 +1,21 @@
+Describe 'Install-ModuleDependencies script' {
+    BeforeEach {
+        function Get-Module {}
+        function Install-Module {}
+        function Read-Host {}
+        Mock Get-Module { $null } -Verifiable
+        Mock Install-Module {} -Verifiable
+        Mock Read-Host { 'Y' }
+    }
+
+    It 'installs all modules from the nuspec when missing' {
+        & $PSScriptRoot/../scripts/Install-ModuleDependencies.ps1
+        $nuspec = [xml](Get-Content "$PSScriptRoot/../SupportTools.nuspec")
+        $modules = $nuspec.package.metadata.dependencies.dependency | ForEach-Object { $_.id }
+        foreach ($name in $modules) {
+            Assert-MockCalled Install-Module -ParameterFilter { $Name -eq $name } -Times 1
+        }
+        Assert-MockCalled Get-Module -Times $modules.Count
+        Assert-VerifiableMocks
+    }
+}


### PR DESCRIPTION
### Summary
- add test file for Install-ModuleDependencies script

### File Citations
- `tests/Install-ModuleDependencies.Tests.ps1`

### Test Results
- `Invoke-Pester` failed because `pwsh` was not found
  ```
  bash: pwsh: command not found
  ```
  Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684640fc36f0832cbe7e4befe01d64e9