### PR TITLE
Add bad signature test

### DIFF
--- a/tests/UpdateModuleDependencies.Tests.ps1
+++ b/tests/UpdateModuleDependencies.Tests.ps1
@@ -5,7 +5,10 @@ Describe 'Update-ModuleDependencies script' {
         function Get-AuthenticodeSignature {}
         function Write-STLog {}
         Mock Update-Module {} -Verifiable
-        Mock Get-Module { [pscustomobject]@{ Path = 'module.psd1' } } -Verifiable
+        Mock Get-Module {
+            param($Name)
+            [pscustomobject]@{ Path = "$Name.psd1" }
+        } -Verifiable
         Mock Get-AuthenticodeSignature { [pscustomobject]@{ Status = 'Valid'; StatusMessage = 'Valid' } } -Verifiable
         Mock Write-STLog {} -Verifiable
     }
@@ -18,6 +21,27 @@ Describe 'Update-ModuleDependencies script' {
             Assert-MockCalled Update-Module -ParameterFilter { $Name -eq $name } -Times 1
         }
         Assert-MockCalled Get-AuthenticodeSignature -Times $modules.Count
+        Assert-VerifiableMocks
+    }
+
+    It 'logs an error when a module signature is invalid' {
+        $nuspec = [xml](Get-Content "$PSScriptRoot/../SupportTools.nuspec")
+        $modules = $nuspec.package.metadata.dependencies.dependency | ForEach-Object { $_.id }
+        $badModule = $modules[0]
+
+        Mock Get-AuthenticodeSignature {
+            param($FilePath)
+            if ($FilePath -like "$badModule.psd1") {
+                [pscustomobject]@{ Status = 'BadSignature'; StatusMessage = 'Bad signature' }
+            } else {
+                [pscustomobject]@{ Status = 'Valid'; StatusMessage = 'Valid' }
+            }
+        } -Verifiable -Force
+
+        & $PSScriptRoot/../scripts/Update-ModuleDependencies.ps1
+
+        Assert-MockCalled Get-AuthenticodeSignature -Times $modules.Count
+        Assert-MockCalled Write-STLog -ParameterFilter { $Level -eq 'ERROR' -and $Message -like "$badModule signature invalid*" } -Times 1
         Assert-VerifiableMocks
     }
 }


### PR DESCRIPTION
### Summary
- enhance module dependency tests with failing signature scenario

### File Citations
- `tests/UpdateModuleDependencies.Tests.ps1`

### Test Results
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.
```


------
https://chatgpt.com/codex/tasks/task_e_684640fe1218832cabc8529f3721f422