### PR TITLE
Add test for Send-TelemetryToLogAnalytics

### DIFF
--- a/scripts/Send-TelemetryToLogAnalytics.ps1
+++ b/scripts/Send-TelemetryToLogAnalytics.ps1
@@ -11,6 +11,8 @@
 .PARAMETER Vault
     Secret vault name to pull WorkspaceId and WorkspaceKey from when they are
     not provided.
+.PARAMETER LogPath
+    Optional path to the telemetry log file.
 .EXAMPLE
     ./Send-TelemetryToLogAnalytics.ps1 -WorkspaceId "<id>" -WorkspaceKey "<key>"
 .EXAMPLE
@@ -24,7 +26,9 @@ param(
 
     [string]$WorkspaceKey,
 
-    [string]$Vault
+    [string]$Vault,
+
+    [string]$LogPath
 )
 
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
@@ -65,7 +69,9 @@ if (-not $WorkspaceId -or -not $WorkspaceKey) {
 }
 
 # Determine telemetry log path
-if ($env:ST_TELEMETRY_PATH) {
+if ($PSBoundParameters.ContainsKey('LogPath')) {
+    $logPath = $LogPath
+} elseif ($env:ST_TELEMETRY_PATH) {
     $logPath = $env:ST_TELEMETRY_PATH
 } else {
     $profile = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }

--- a/tests/Send-TelemetryToLogAnalytics.Tests.ps1
+++ b/tests/Send-TelemetryToLogAnalytics.Tests.ps1
@@ -1,0 +1,21 @@
+. $PSScriptRoot/TestHelpers.ps1
+Describe 'Send-TelemetryToLogAnalytics.ps1' {
+    Safe-It 'posts JSON telemetry to workspace URI' {
+        $log = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+        $event = @{Timestamp='2024-01-01T00:00:00Z'; Script='Test.ps1'; Result='Success'; Duration=1} | ConvertTo-Json -Compress
+        Set-Content -Path $log -Value $event
+        Mock Invoke-RestMethod {} -Verifiable
+        try {
+            $env:ST_ENABLE_TELEMETRY = '1'
+            & $PSScriptRoot/../scripts/Send-TelemetryToLogAnalytics.ps1 -WorkspaceId 'ws123' -WorkspaceKey 'Zg==' -LogPath $log
+            Assert-MockCalled Invoke-RestMethod -ParameterFilter {
+                $Method -eq 'Post' -and
+                $Uri -eq 'https://ws123.ods.opinsights.azure.com/api/logs?api-version=2016-04-01' -and
+                $Body -is [string] -and (($Body | ConvertFrom-Json)[0].Script -eq 'Test.ps1')
+            } -Times 1
+        } finally {
+            Remove-Item $log -ErrorAction SilentlyContinue
+            Remove-Item env:ST_ENABLE_TELEMETRY -ErrorAction SilentlyContinue
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- allow Send-TelemetryToLogAnalytics.ps1 to take `-LogPath`
- test that telemetry is posted to Log Analytics

### File Citations
- `scripts/Send-TelemetryToLogAnalytics.ps1`
- `tests/Send-TelemetryToLogAnalytics.Tests.ps1`

### Test Results


------
https://chatgpt.com/codex/tasks/task_e_684640fd537c832c860e938ebba2abab