### PR TITLE
Add test for DailyAudit workflow

### DIFF
--- a/tests/Invoke-DailyAuditWorkflow.Tests.ps1
+++ b/tests/Invoke-DailyAuditWorkflow.Tests.ps1
@@ -1,0 +1,39 @@
+. $PSScriptRoot/TestHelpers.ps1
+
+Describe 'Invoke-DailyAuditWorkflow.ps1 script' {
+    BeforeAll {
+        $ScriptPath = Join-Path $PSScriptRoot/.. 'scripts/Invoke-DailyAuditWorkflow.ps1'
+        Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../src/SharePointTools/SharePointTools.psd1 -Force
+        Import-Module $PSScriptRoot/../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force
+    }
+
+    BeforeEach {
+        $script:order = @()
+        Mock Write-STStatus {}
+        Mock Get-SPPermissionsReport {
+            $script:order += 'Get-SPPermissionsReport'
+            @([pscustomobject]@{ User='U' })
+        }
+        Mock Export-Csv {
+            $script:order += 'Export-Csv'
+        }
+        Mock New-SDTicket {
+            $script:order += 'New-SDTicket'
+            @{ id = 1 }
+        }
+        Mock Write-STTelemetryEvent {
+            $script:order += 'Write-STTelemetryEvent'
+        }
+        # Mock internal scripts if called
+        function Invoke-IncidentResponse {}
+        function Invoke-PerformanceAudit {}
+    }
+
+    Safe-It 'runs the workflow and records telemetry' {
+        & $ScriptPath -SiteUrl 'https://contoso.sharepoint.com' -RequesterEmail 'admin@contoso.com' | Out-Null
+        $script:order | Should -Be @('Get-SPPermissionsReport','Export-Csv','New-SDTicket','Write-STTelemetryEvent')
+        Assert-MockCalled Write-STTelemetryEvent -Times 1
+    }
+}


### PR DESCRIPTION
### Summary
- add Pester test for `Invoke-DailyAuditWorkflow.ps1`

### File Citations
- `tests/Invoke-DailyAuditWorkflow.Tests.ps1`【F:tests/Invoke-DailyAuditWorkflow.Tests.ps1†L1-L39】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed: `Cannot process argument transformation on parameter 'Configuration'`)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846410072a4832c948192b0011caf50