### PR TITLE
Fix logging module parse error

### DIFF
--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -135,7 +135,7 @@ function Write-STLog {
             try {
                 Invoke-RestMethod -Uri $ForwardUri -Method Post -Body $json -ContentType 'application/json' | Out-Null
             } catch {
-                Write-STDebug "Failed to forward log to $ForwardUri: $_"
+                Write-STDebug "Failed to forward log to ${ForwardUri}: $_"
             }
         }
     } else {

--- a/tests/STPlatform.Tests.ps1
+++ b/tests/STPlatform.Tests.ps1
@@ -306,7 +306,9 @@ Describe 'STPlatform Module' {
             InModuleScope STPlatform {
                 Mock Connect-MgGraph { throw 'boom' }
                 Mock Write-STLog {}
-                foreach ($n in 'GRAPH_TENANT_ID','GRAPH_CLIENT_ID','GRAPH_CLIENT_SECRET') { $env:$n = $n.ToLower() }
+                foreach ($n in 'GRAPH_TENANT_ID','GRAPH_CLIENT_ID','GRAPH_CLIENT_SECRET') {
+                    Set-Item -Path "env:$n" -Value $n.ToLower()
+                }
                 $log = Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName())
                 try {
                     $env:ST_ENABLE_TELEMETRY = '1'


### PR DESCRIPTION
### Summary
- fix bad variable expansion in `Write-STDebug`
- fix env var assignment in STPlatform tests

### File Citations
- `src/Logging/Logging.psm1` lines 132-140
- `tests/STPlatform.Tests.ps1` lines 304-314

### Test Results
```
Starting discovery in 67 files.
Discovery found 392 tests in 2.92s.
Running tests.
New-PSDrive: A drive with the name 'TestDrive' already exists.
[-] AddUsersToGroup Script.connects and disconnects from Graph 838ms (380ms|459ms)
 RuntimeException: Test failed in : [Framework failed:
 Result 1 - Error 1:MethodInvocationException: Exception calling "Add" with "2" argument(s): "Item has already been added. Key
 in dictionary: 'TestDrive'  Key being added: 'TestDrive'"
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684644875db4832c93d84b8f293dd8ed