### PR TITLE
Add ShouldProcess capability to Start-Main

### DIFF
--- a/scripts/AddUsersToGroup.ps1
+++ b/scripts/AddUsersToGroup.ps1
@@ -171,6 +171,7 @@ function Get-UserID {
 }
 
 function Start-Main {
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [string]$CsvPath,
         [string]$GroupName,


### PR DESCRIPTION
### Summary
- enable `SupportsShouldProcess` on Start-Main so callers can use `-WhatIf`

### File Citations
- `scripts/AddUsersToGroup.ps1`

### Test Results
- `Invoke-Pester` *(failed: Cannot convert PesterConfiguration.psd1)*


------
https://chatgpt.com/codex/tasks/task_e_684647d4e8b8832c9c82268664e84ae1