### PR TITLE
Ensure Import-Module uses -Force

### DIFF
--- a/SupportToolsLoader.ps1
+++ b/SupportToolsLoader.ps1
@@ -15,7 +15,7 @@
 if (-not $script:SupportToolsLoaderLoaded) {
     $script:SupportToolsLoaderLoaded = $true
 
-    Import-Module (Join-Path $PSScriptRoot 'src/OutTools/OutTools.psd1') -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $PSScriptRoot 'src/OutTools/OutTools.psd1') -Force -ErrorAction SilentlyContinue
 
     function Write-LoaderLog {
         param([string]$Message)

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -1,4 +1,4 @@
 function Import-SupportToolsLogging {
     $modulePath = Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1'
-    Import-Module $modulePath -ErrorAction SilentlyContinue
+    Import-Module $modulePath -Force -ErrorAction SilentlyContinue
 }

--- a/scripts/Configure-SharePointTools.ps1
+++ b/scripts/Configure-SharePointTools.ps1
@@ -5,8 +5,8 @@ param(
     [hashtable]$Sites
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/STCore/STCore.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/STCore/STCore.psd1') -Force -ErrorAction SilentlyContinue
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 $settingsPath = Join-Path $repoRoot 'config/SharePointToolsSettings.psd1'

--- a/scripts/Create-NewHireUser.ps1
+++ b/scripts/Create-NewHireUser.ps1
@@ -19,8 +19,8 @@ param(
     [string]$TranscriptPath
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -Force -ErrorAction SilentlyContinue
 
 if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
 

--- a/scripts/Generate-SPUsageReport.ps1
+++ b/scripts/Generate-SPUsageReport.ps1
@@ -20,9 +20,9 @@ param(
     [string]$TranscriptPath
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/SharePointTools/SharePointTools.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/SharePointTools/SharePointTools.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -Force -ErrorAction SilentlyContinue
 
 if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
 

--- a/scripts/Get-CommonSystemInfo.ps1
+++ b/scripts/Get-CommonSystemInfo.ps1
@@ -1,4 +1,4 @@
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 function Get-CommonSystemInfo {
     <#

--- a/scripts/Get-FailedLogins.ps1
+++ b/scripts/Get-FailedLogins.ps1
@@ -1,4 +1,4 @@
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 function Get-FailedLogins {
     <#

--- a/scripts/Get-NetworkShares.ps1
+++ b/scripts/Get-NetworkShares.ps1
@@ -1,5 +1,5 @@
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 function Get-NetworkShares {
     <#

--- a/scripts/Install-Fonts.ps1
+++ b/scripts/Install-Fonts.ps1
@@ -9,7 +9,7 @@
 # fonts are available to all users. Administrator rights are required.
 # #>
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 function Main {
     param(

--- a/scripts/Install-ModuleDependencies.ps1
+++ b/scripts/Install-ModuleDependencies.ps1
@@ -6,7 +6,7 @@
     Prompts to install from the PowerShell Gallery when a module is missing.
 #>
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 $requiredModules = @{ 
     'PnP.PowerShell' = 'SharePoint cleanup functions';

--- a/scripts/Install-SupportTools.ps1
+++ b/scripts/Install-SupportTools.ps1
@@ -20,7 +20,7 @@ param(
 
 $modules = @('Logging','SharePointTools','ServiceDeskTools','SupportTools')
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 foreach ($module in $modules) {
     try {

--- a/scripts/Invoke-DailyAuditWorkflow.ps1
+++ b/scripts/Invoke-DailyAuditWorkflow.ps1
@@ -39,10 +39,10 @@ $scriptName = $MyInvocation.MyCommand.Name
 $ErrorActionPreference = 'Stop'
 
 # Import required modules from the repository
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction Stop
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Telemetry/Telemetry.psd1') -ErrorAction Stop
-Import-Module (Join-Path $PSScriptRoot '..' 'src/SharePointTools/SharePointTools.psd1') -ErrorAction Stop
-Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction Stop
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction Stop
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Telemetry/Telemetry.psd1') -Force -ErrorAction Stop
+Import-Module (Join-Path $PSScriptRoot '..' 'src/SharePointTools/SharePointTools.psd1') -Force -ErrorAction Stop
+Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -Force -ErrorAction Stop
 
 if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
 

--- a/scripts/Invoke-IncidentResponse.ps1
+++ b/scripts/Invoke-IncidentResponse.ps1
@@ -23,9 +23,9 @@ param(
 )
 
 if (-not (Get-Module -Name 'Logging')) {
-    Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 }
-Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -Force -ErrorAction SilentlyContinue
 
 if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
 

--- a/scripts/Invoke-PerformanceAudit.ps1
+++ b/scripts/Invoke-PerformanceAudit.ps1
@@ -6,8 +6,8 @@
 #>
 param()
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/PerformanceTools/PerformanceTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/PerformanceTools/PerformanceTools.psd1') -Force -ErrorAction SilentlyContinue
 
 Write-STStatus -Message 'Running performance audit...' -Level INFO -Log
 $metrics = Measure-STCommand { Get-Process | Out-Null } -Quiet

--- a/scripts/PostInstallScript.ps1
+++ b/scripts/PostInstallScript.ps1
@@ -13,7 +13,7 @@
 
 # Functions listed here
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 function MSStoreAppInstallerUpdate {
     <#

--- a/scripts/Process-TerminationTickets.ps1
+++ b/scripts/Process-TerminationTickets.ps1
@@ -24,9 +24,9 @@ param(
     [string]$ClientSecret = $env:GRAPH_CLIENT_SECRET
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/EntraIDTools/EntraIDTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/EntraIDTools/EntraIDTools.psd1') -Force -ErrorAction SilentlyContinue
 
 if (Test-Path $StatePath) { $processed = Get-Content $StatePath | ConvertFrom-Json } else { $processed = @() }
 

--- a/scripts/Run-JobBundle.ps1
+++ b/scripts/Run-JobBundle.ps1
@@ -17,8 +17,8 @@ param(
     [string]$BundlePath
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
 
 if (-not (Test-Path $BundlePath)) {
     throw "Bundle not found: $BundlePath"

--- a/scripts/ScriptLauncher.ps1
+++ b/scripts/ScriptLauncher.ps1
@@ -9,7 +9,7 @@
     ./ScriptLauncher.ps1
 #>
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 function Get-ScriptInfo {
     param([string]$Path)

--- a/scripts/Search-Indicators.ps1
+++ b/scripts/Search-Indicators.ps1
@@ -1,4 +1,4 @@
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 param(
     [Parameter(Mandatory=$true)]

--- a/scripts/Send-TelemetrySummary.ps1
+++ b/scripts/Send-TelemetrySummary.ps1
@@ -34,8 +34,8 @@ param(
     [string]$Subject = 'Telemetry Summary'
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
 
 Show-STPrompt './scripts/Send-TelemetrySummary.ps1'
 

--- a/scripts/Send-TelemetryToLogAnalytics.ps1
+++ b/scripts/Send-TelemetryToLogAnalytics.ps1
@@ -31,8 +31,8 @@ param(
     [string]$LogPath
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
 
 if ($env:ST_ENABLE_TELEMETRY -ne '1') {
     Write-STStatus -Message 'ST_ENABLE_TELEMETRY is not set. Telemetry will not be sent.' -Level WARN

--- a/scripts/Set-TimeZoneEasternStandardTime.ps1
+++ b/scripts/Set-TimeZoneEasternStandardTime.ps1
@@ -1,4 +1,4 @@
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 function Set-TimeZoneEasternStandardTime {
     <#

--- a/scripts/Setup-ScheduledMaintenance.ps1
+++ b/scripts/Setup-ScheduledMaintenance.ps1
@@ -14,7 +14,7 @@ param(
     [switch]$Register
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 function New-MaintenanceTaskXml {
     param(

--- a/scripts/Sign-RepositoryFiles.ps1
+++ b/scripts/Sign-RepositoryFiles.ps1
@@ -16,7 +16,7 @@ param(
 )
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
-Import-Module (Join-Path $repoRoot 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $repoRoot 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 Show-STPrompt './scripts/Sign-RepositoryFiles.ps1'
 

--- a/scripts/Start-MockApiServer.ps1
+++ b/scripts/Start-MockApiServer.ps1
@@ -2,7 +2,7 @@ param(
     [int]$Port = 8080
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 $listener = [System.Net.HttpListener]::new()
 $listener.Prefixes.Add("http://localhost:$Port/")

--- a/scripts/Submit-SystemInfoTicket.ps1
+++ b/scripts/Submit-SystemInfoTicket.ps1
@@ -35,10 +35,10 @@ param(
     [string]$SmtpServer
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/SupportTools/SupportTools.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/SharePointTools/SharePointTools.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/SupportTools/SupportTools.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/SharePointTools/SharePointTools.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -Force -ErrorAction SilentlyContinue
 
 if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
 

--- a/scripts/SupportToolsMenu.ps1
+++ b/scripts/SupportToolsMenu.ps1
@@ -9,8 +9,8 @@
     ./SupportToolsMenu.ps1
 #>
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/SupportTools/SupportTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/SupportTools/SupportTools.psd1') -Force -ErrorAction SilentlyContinue
 
 param(
     [ValidateSet('Helpdesk','Site Admin')]

--- a/scripts/Sync-SDTickets.ps1
+++ b/scripts/Sync-SDTickets.ps1
@@ -18,8 +18,8 @@ param(
     [int]$FullSyncHours = 24
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
-Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/ServiceDeskTools/ServiceDeskTools.psd1') -Force -ErrorAction SilentlyContinue
 
 function Get-AllTickets {
     Write-STStatus -Message 'Retrieving all tickets...' -Level INFO -Log

--- a/scripts/Test-SPToolsPrereqs.ps1
+++ b/scripts/Test-SPToolsPrereqs.ps1
@@ -16,6 +16,6 @@ param(
     [switch]$Install
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src' 'SharePointTools' 'SharePointTools.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src' 'SharePointTools' 'SharePointTools.psd1') -Force -ErrorAction SilentlyContinue
 
 Test-SPToolsPrereqs -Install:$Install

--- a/scripts/Update-ModuleDependencies.ps1
+++ b/scripts/Update-ModuleDependencies.ps1
@@ -10,7 +10,7 @@
     ./Update-ModuleDependencies.ps1
 #>
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 $nuspecPath = Join-Path $PSScriptRoot '..' 'SupportTools.nuspec'
 [xml]$nuspec = Get-Content $nuspecPath

--- a/scripts/Update-Sysmon.ps1
+++ b/scripts/Update-Sysmon.ps1
@@ -9,7 +9,7 @@
 # computer name is written to a log directory on the removable drive.
 # #>
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
 function Main {
 

--- a/src/ChaosTools/ChaosTools.psm1
+++ b/src/ChaosTools/ChaosTools.psm1
@@ -1,7 +1,7 @@
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
-Import-Module $coreModule -ErrorAction SilentlyContinue
-Import-Module $loggingModule -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
 
 $PublicDir = Join-Path $PSScriptRoot 'Public'
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }

--- a/src/ConfigManagementTools/ConfigManagementTools.psm1
+++ b/src/ConfigManagementTools/ConfigManagementTools.psm1
@@ -3,9 +3,9 @@ $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $coreModule -ErrorAction SilentlyContinue
-Import-Module $loggingModule -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
 
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }

--- a/src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1
@@ -62,17 +62,17 @@ function Invoke-CompanyPlaceManagement {
     $result = 'Success'
     try {
         if ($Logger) {
-            Import-Module $Logger -ErrorAction SilentlyContinue
+            Import-Module $Logger -Force -ErrorAction SilentlyContinue
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
         }
         if ($TelemetryClient) {
-            Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+            Import-Module $TelemetryClient -Force -ErrorAction SilentlyContinue
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
         }
         if ($Config) {
-            Import-Module $Config -ErrorAction SilentlyContinue
+            Import-Module $Config -Force -ErrorAction SilentlyContinue
         }
 
         if ($Explain) {

--- a/src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -27,17 +27,17 @@ function Invoke-ExchangeCalendarManager {
     $result = 'Success'
     try {
         if ($Logger) {
-            Import-Module $Logger -ErrorAction SilentlyContinue
+            Import-Module $Logger -Force -ErrorAction SilentlyContinue
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
         }
         if ($TelemetryClient) {
-            Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+            Import-Module $TelemetryClient -Force -ErrorAction SilentlyContinue
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
         }
         if ($Config) {
-            Import-Module $Config -ErrorAction SilentlyContinue
+            Import-Module $Config -Force -ErrorAction SilentlyContinue
         }
 
         if ($Explain) {

--- a/src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1
+++ b/src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1
@@ -49,17 +49,17 @@ function Set-SharedMailboxAutoReply {
 
     try {
         if ($Logger) {
-            Import-Module $Logger -ErrorAction SilentlyContinue
+            Import-Module $Logger -Force -ErrorAction SilentlyContinue
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
         }
         if ($TelemetryClient) {
-            Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+            Import-Module $TelemetryClient -Force -ErrorAction SilentlyContinue
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
         }
         if ($Config) {
-            Import-Module $Config -ErrorAction SilentlyContinue
+            Import-Module $Config -Force -ErrorAction SilentlyContinue
         }
 
         if ($Explain) {

--- a/src/EntraIDTools/EntraIDTools.psm1
+++ b/src/EntraIDTools/EntraIDTools.psm1
@@ -2,8 +2,8 @@ $PublicDir = Join-Path $PSScriptRoot 'Public'
 $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $loggingModule -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
 
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }

--- a/src/IncidentResponseTools/IncidentResponseTools.psm1
+++ b/src/IncidentResponseTools/IncidentResponseTools.psm1
@@ -3,9 +3,9 @@ $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $coreModule -ErrorAction SilentlyContinue
-Import-Module $loggingModule -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
 
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }

--- a/src/IncidentResponseTools/Public/Get-CommonSystemInfo.ps1
+++ b/src/IncidentResponseTools/Public/Get-CommonSystemInfo.ps1
@@ -24,17 +24,17 @@ function Get-CommonSystemInfo {
         $result = 'Success'
         try {
             if ($Logger) {
-                Import-Module $Logger -ErrorAction SilentlyContinue
+                Import-Module $Logger -Force -ErrorAction SilentlyContinue
             } else {
-                Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -ErrorAction SilentlyContinue
+                Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
             }
             if ($TelemetryClient) {
-                Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+                Import-Module $TelemetryClient -Force -ErrorAction SilentlyContinue
             } else {
-                Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+                Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
             }
             if ($Config) {
-                Import-Module $Config -ErrorAction SilentlyContinue
+                Import-Module $Config -Force -ErrorAction SilentlyContinue
             }
 
             Write-STStatus -Message 'Collecting system information...' -Level INFO

--- a/src/IncidentResponseTools/Public/Invoke-FullSystemAudit.ps1
+++ b/src/IncidentResponseTools/Public/Invoke-FullSystemAudit.ps1
@@ -29,13 +29,13 @@ function Invoke-FullSystemAudit {
     )
 
     process {
-        if ($Logger) { Import-Module $Logger -ErrorAction SilentlyContinue }
+        if ($Logger) { Import-Module $Logger -Force -ErrorAction SilentlyContinue }
         if ($TelemetryClient) {
-            Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+            Import-Module $TelemetryClient -Force -ErrorAction SilentlyContinue
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
         }
-        if ($Config) { Import-Module $Config -ErrorAction SilentlyContinue }
+        if ($Config) { Import-Module $Config -Force -ErrorAction SilentlyContinue }
         if (-not $OutputPath) {
             $ext = if ($Html) { 'html' } else { 'json' }
             $OutputPath = Join-Path (Get-Location) "SystemAudit_$((Get-Date).ToString('yyyyMMdd_HHmmss')).$ext"

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -1,6 +1,6 @@
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
-Import-Module $coreModule -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue
 $configFile = Join-Path $repoRoot 'config/supporttools.json'
 $SupportToolsConfig = Get-STConfig -Path $configFile
 if (-not $SupportToolsConfig.ContainsKey('maintenanceMode')) {

--- a/src/MaintenancePlan/MaintenancePlan.psm1
+++ b/src/MaintenancePlan/MaintenancePlan.psm1
@@ -1,8 +1,8 @@
 $PublicDir = Join-Path $PSScriptRoot 'Public'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
-Import-Module $coreModule -ErrorAction SilentlyContinue
-Import-Module $loggingModule -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
 Get-ChildItem -Path "$PublicDir" -Filter *.ps1 -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
 Export-ModuleMember -Function (Get-ChildItem "$PublicDir/*.ps1" -ErrorAction SilentlyContinue).BaseName

--- a/src/MonitoringTools/MonitoringTools.psm1
+++ b/src/MonitoringTools/MonitoringTools.psm1
@@ -1,8 +1,8 @@
 $PublicDir = Join-Path $PSScriptRoot 'Public'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $loggingModule -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
 
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 

--- a/src/PerformanceTools/Invoke-PerformanceAudit.ps1
+++ b/src/PerformanceTools/Invoke-PerformanceAudit.ps1
@@ -33,15 +33,15 @@ param(
 )
 
 $moduleRoot = Join-Path $PSScriptRoot '..'
-Import-Module (Join-Path $moduleRoot 'STCore/STCore.psd1') -ErrorAction SilentlyContinue
+Import-Module (Join-Path $moduleRoot 'STCore/STCore.psd1') -Force -ErrorAction SilentlyContinue
 if (-not (Get-Module -Name 'Logging')) {
-    Import-Module (Join-Path $moduleRoot 'Logging/Logging.psd1') -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $moduleRoot 'Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 }
 if (-not (Get-Module -Name 'Telemetry')) {
-    Import-Module (Join-Path $moduleRoot 'Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $moduleRoot 'Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
 }
 if ($CreateTicket) {
-    Import-Module (Join-Path $moduleRoot 'ServiceDeskTools/ServiceDeskTools.psd1') -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $moduleRoot 'ServiceDeskTools/ServiceDeskTools.psd1') -Force -ErrorAction SilentlyContinue
 }
 
 if ($TranscriptPath) {

--- a/src/PerformanceTools/PerformanceTools.psm1
+++ b/src/PerformanceTools/PerformanceTools.psm1
@@ -1,7 +1,7 @@
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
-Import-Module $coreModule -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
-Import-Module $loggingModule -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
 
 function Measure-STCommand {
     <#

--- a/src/STPlatform/Public/Connect-STPlatform.ps1
+++ b/src/STPlatform/Public/Connect-STPlatform.ps1
@@ -64,7 +64,7 @@ function Connect-STPlatform {
                     Write-STStatus "$m module missing." -Level WARN -Log
                 }
             }
-            Import-Module $m -ErrorAction SilentlyContinue
+            Import-Module $m -Force -ErrorAction SilentlyContinue
         }
 
         switch ($Mode) {

--- a/src/STPlatform/STPlatform.psm1
+++ b/src/STPlatform/STPlatform.psm1
@@ -2,9 +2,9 @@ $PublicDir = Join-Path $PSScriptRoot 'Public'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $coreModule -ErrorAction SilentlyContinue
-Import-Module $loggingModule -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
 
 Get-ChildItem -Path "$PublicDir" -Filter *.ps1 -ErrorAction SilentlyContinue |
     ForEach-Object { . $_.FullName }

--- a/src/ServiceDeskTools/ServiceDeskTools.psm1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psm1
@@ -4,9 +4,9 @@ $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $coreModule -ErrorAction SilentlyContinue
-Import-Module $loggingModule -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
 
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue |
     ForEach-Object { . $_.FullName }

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -3,7 +3,7 @@
 # Load configuration values if available
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
-Import-Module $coreModule -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue
 $settingsFile = Join-Path $repoRoot 'config/SharePointToolsSettings.psd1'
 $SharePointToolsSettings = Get-STConfig -Path $settingsFile
 if (-not $SharePointToolsSettings) { $SharePointToolsSettings = @{} }
@@ -13,9 +13,9 @@ if (-not $SharePointToolsSettings.ContainsKey('CertPath')) { $SharePointToolsSet
 if (-not $SharePointToolsSettings.ContainsKey('Sites')) { $SharePointToolsSettings.Sites = @{} }
 
 $loggingModule = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath 'Logging/Logging.psd1'
-Import-Module $loggingModule -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
 $telemetryModule = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $telemetryModule -ErrorAction SilentlyContinue
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
 
 # Load additional public commands
 $publicDir = Join-Path $PSScriptRoot 'Public'

--- a/src/SupportTools/Private/Invoke-ScriptFile.ps1
+++ b/src/SupportTools/Private/Invoke-ScriptFile.ps1
@@ -30,19 +30,19 @@ function Invoke-ScriptFile {
     }
 
     if ($Logger) {
-        Import-Module $Logger -ErrorAction SilentlyContinue
+        Import-Module $Logger -Force -ErrorAction SilentlyContinue
     } elseif ($loggingModule) {
-        Import-Module $loggingModule -ErrorAction SilentlyContinue
+        Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
     }
 
     if ($TelemetryClient) {
-        Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+        Import-Module $TelemetryClient -Force -ErrorAction SilentlyContinue
     } elseif ($telemetryModule) {
-        Import-Module $telemetryModule -ErrorAction SilentlyContinue
+        Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
     }
 
     if ($Config) {
-        Import-Module $Config -ErrorAction SilentlyContinue
+        Import-Module $Config -Force -ErrorAction SilentlyContinue
     }
     $Path = Join-Path $PSScriptRoot '..' |
             Join-Path -ChildPath '..' |

--- a/src/SupportTools/Public/Sync-SupportTools.ps1
+++ b/src/SupportTools/Public/Sync-SupportTools.ps1
@@ -34,17 +34,17 @@ function Sync-SupportTools {
     try {
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
         if ($Logger) {
-            Import-Module $Logger -ErrorAction SilentlyContinue
+            Import-Module $Logger -Force -ErrorAction SilentlyContinue
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
         }
         if ($TelemetryClient) {
-            Import-Module $TelemetryClient -ErrorAction SilentlyContinue
+            Import-Module $TelemetryClient -Force -ErrorAction SilentlyContinue
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
         }
         if ($Config) {
-            Import-Module $Config -ErrorAction SilentlyContinue
+            Import-Module $Config -Force -ErrorAction SilentlyContinue
         }
 
         if ($Explain) {
@@ -63,9 +63,9 @@ function Sync-SupportTools {
 
         Import-Module (Join-Path $InstallPath 'src/SupportTools/SupportTools.psd1') -Force
         $sp = Join-Path $InstallPath 'src/SharePointTools/SharePointTools.psd1'
-        if (Test-Path $sp) { Import-Module $sp -ErrorAction SilentlyContinue }
+        if (Test-Path $sp) { Import-Module $sp -Force -ErrorAction SilentlyContinue }
         $sd = Join-Path $InstallPath 'src/ServiceDeskTools/ServiceDeskTools.psd1'
-        if (Test-Path $sd) { Import-Module $sd -ErrorAction SilentlyContinue }
+        if (Test-Path $sd) { Import-Module $sd -Force -ErrorAction SilentlyContinue }
 
         Write-STStatus -Message 'SupportTools synchronized' -Level FINAL
         return [pscustomobject]@{

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -3,9 +3,9 @@ $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $coreModule -ErrorAction SilentlyContinue
-Import-Module $loggingModule -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
 
 # Determine the version of the SupportTools module for logging purposes
 $manifestPath = Join-Path $PSScriptRoot 'SupportTools.psd1'

--- a/src/Telemetry/Telemetry.psm1
+++ b/src/Telemetry/Telemetry.psm1
@@ -1,7 +1,7 @@
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
-Import-Module $coreModule -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
-Import-Module $loggingModule -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
 
 function Send-STMetric {
     [CmdletBinding()]


### PR DESCRIPTION
### Summary
- enforce `-Force` for all internal module imports

### File Citations
- `src/Logging/Logging.psm1`【F:src/Logging/Logging.psm1†L1-L4】
- `src/SupportTools/SupportTools.psm1`【F:src/SupportTools/SupportTools.psm1†L3-L9】
- `scripts/Create-NewHireUser.ps1`【F:scripts/Create-NewHireUser.ps1†L20-L24】
- `SupportToolsLoader.ps1`【F:SupportToolsLoader.ps1†L16-L20】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684647de2090832ca10521ecb0858051