### PR TITLE
Fix Create-NewHireUser dot-source behavior

### DIFF
--- a/scripts/Create-NewHireUser.ps1
+++ b/scripts/Create-NewHireUser.ps1
@@ -81,9 +81,11 @@ function Start-Main {
     }
 }
 
-try {
-    Start-Main -PollMinutes $PollMinutes -Once:$Once
-} finally {
-    if ($TranscriptPath) { Stop-Transcript | Out-Null }
+if ($MyInvocation.InvocationName -ne '.') {
+    try {
+        Start-Main -PollMinutes $PollMinutes -Once:$Once
+    } finally {
+        if ($TranscriptPath) { Stop-Transcript | Out-Null }
+    }
 }
 


### PR DESCRIPTION
### Summary
- avoid running the Create-NewHireUser script when dot-sourced

### File Citations
- `scripts/Create-NewHireUser.ps1`

### Test Results
- `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(fails: required module 'Logging' not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6846543e1ea8832c826d61a21ffd89c9