### PR TITLE
Fix PSScriptAnalyzer artifact step

### DIFF
--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -20,18 +20,23 @@ jobs:
         with:
           modules-to-cache: PSScriptAnalyzer, ConvertToSARIF
       - name: Run PSScriptAnalyzer
+        id: analyze
+        continue-on-error: true
         shell: pwsh
         run: |
           Import-Module PSScriptAnalyzer
           Import-Module ConvertToSARIF
           $results = Invoke-ScriptAnalyzer -Path . -Recurse -Severity Warning,Error
           $results | ConvertTo-SARIF -FilePath PSScriptAnalyzerResults.sarif
-          if ($results.Count -gt 0) {
-            Write-Error 'PSScriptAnalyzer found issues.'
-            exit 1
-          }
+          echo "count=$($results.Count)" >> $env:GITHUB_OUTPUT
       - name: Upload lint results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: PSScriptAnalyzerResults
           path: PSScriptAnalyzerResults.sarif
+      - name: Fail if lint issues
+        if: steps.analyze.outputs.count -gt '0'
+        run: |
+          echo "::error ::PSScriptAnalyzer found issues."
+          exit 1


### PR DESCRIPTION
### Summary
- adjust lint workflow so artifact uploads even when lint fails

### File Citations
- `.github/workflows/psscriptanalyzer.yml` lines 16-42

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.


------
https://chatgpt.com/codex/tasks/task_e_684654abd374832ca75bb4f1fdc24441