### PR TITLE
Fix psscriptanalyzer action

### DIFF
--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -36,7 +36,7 @@ jobs:
           name: PSScriptAnalyzerResults
           path: PSScriptAnalyzerResults.sarif
       - name: Fail if lint issues
-        if: steps.analyze.outputs.count -gt '0'
+        if: ${{ steps.analyze.outputs.count > '0' }}
         run: |
           echo "::error ::PSScriptAnalyzer found issues."
           exit 1


### PR DESCRIPTION
### Summary
- fix expression syntax in psscriptanalyzer workflow

### File Citations
- `.github/workflows/psscriptanalyzer.yml`【F:.github/workflows/psscriptanalyzer.yml†L34-L42】

### Test Results
- ❌ `Invoke-Pester` (failed)【e45030†L1-L31】


------
https://chatgpt.com/codex/tasks/task_e_684656e6c760832cbaf1eade956cf682