### PR TITLE
Fix AddUsersToGroup tests

### DIFF
--- a/tests/AddUsersToGroup.Tests.ps1
+++ b/tests/AddUsersToGroup.Tests.ps1
@@ -1,6 +1,9 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'AddUsersToGroup Script' {
     BeforeAll {
+        if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
+            Remove-PSDrive -Name TestDrive -Force
+        }
         function Install-Module {}
         function Import-Module {}
         function Connect-MgGraph {}


### PR DESCRIPTION
### Summary
- remove any existing TestDrive PSDrive before AddUsersToGroup tests run

### File Citations
- `tests/AddUsersToGroup.Tests.ps1`【F:tests/AddUsersToGroup.Tests.ps1†L3-L6】

### Test Results
- `Invoke-Pester` *(fails: New-PSDrive conflicts and missing modules)*【172fe2†L1-L33】

------
https://chatgpt.com/codex/tasks/task_e_68465f32dc0c832c93843d6329d6222f