### PR TITLE
Fix TestDrive conflicts in Pester tests

### DIFF
--- a/tests/TestHelpers.ps1
+++ b/tests/TestHelpers.ps1
@@ -9,6 +9,9 @@ function Safe-It {
     It @itParams {
         param($case)
         try {
+            if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
+                Remove-PSDrive -Name TestDrive -Force -ErrorAction SilentlyContinue
+            }
             if ($PSBoundParameters.ContainsKey('ForEach')) { & $ScriptBlock $case } else { & $ScriptBlock }
         } catch {
             $err = $_


### PR DESCRIPTION
### Summary
- remove stale TestDrive drives before Safe-It runs

### File Citations
- `tests/TestHelpers.ps1`【F:tests/TestHelpers.ps1†L9-L15】

### Test Results
Tests failed due to missing dependencies and TestDrive errors.
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68465f0f10d4832ca1e9769c60d003e7