### PR TITLE
Disable Pester TestDrive

### DIFF
--- a/PesterConfiguration.psd1
+++ b/PesterConfiguration.psd1
@@ -8,4 +8,5 @@
         OutputFormat = 'JaCoCo'
         OutputPath = 'coverage.xml'
     }
+    TestDrive = @{ Enabled = $false }
 }


### PR DESCRIPTION
### Summary
- disable the TestDrive feature in the Pester config to avoid name collisions

### File Citations
- `PesterConfiguration.psd1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68465f1d1abc832ca1e75130ce4a4324