### PR TITLE
Fix TestDrive handling in Pester tests

### DIFF
--- a/tests/ArchiveCleanup.Tests.ps1
+++ b/tests/ArchiveCleanup.Tests.ps1
@@ -1,6 +1,9 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'Invoke-ArchiveCleanup' {
     BeforeAll {
+        if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
+            Remove-PSDrive -Name TestDrive -Force
+        }
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/SharePointTools/SharePointTools.psd1 -Force
     }

--- a/tests/TestHelpers.ps1
+++ b/tests/TestHelpers.ps1
@@ -9,9 +9,6 @@ function Safe-It {
     It @itParams {
         param($case)
         try {
-            if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
-                Remove-PSDrive -Name TestDrive -Force -ErrorAction SilentlyContinue
-            }
             if ($PSBoundParameters.ContainsKey('ForEach')) { & $ScriptBlock $case } else { & $ScriptBlock }
         } catch {
             $err = $_
@@ -22,11 +19,3 @@ function Safe-It {
     }
 }
 
-if (-not $script:TestDriveCleanupAdded) {
-    AfterEach {
-        if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
-            Remove-PSDrive -Name TestDrive -Force -ErrorAction SilentlyContinue
-        }
-    }
-    $script:TestDriveCleanupAdded = $true
-}


### PR DESCRIPTION
### Summary
- prevent duplicate AfterEach registration in `Safe-It`
- ensure `Invoke-ArchiveCleanup` tests remove pre-existing `TestDrive`

### File Citations
- `tests/TestHelpers.ps1` lines 1-20
- `tests/ArchiveCleanup.Tests.ps1` lines 1-12

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to run all tests)
  - Output shows 392 failures due to missing dependencies


------
https://chatgpt.com/codex/tasks/task_e_6846622dea90832ca53d11fb78b01d26