### PR TITLE
Fix debug logging recursion

### DIFF
--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -80,7 +80,11 @@ function Write-STLog {
         $logFile = Join-Path $logDir 'supporttools.log'
     }
     if (-not $ForwardUri -and $env:ST_LOG_FORWARD_URI) { $ForwardUri = $env:ST_LOG_FORWARD_URI }
-    Write-STDebug "Logging to $logFile"
+    if ($env:ST_DEBUG -ne '1') {
+        Write-STDebug "Logging to $logFile"
+    } else {
+        Write-Host "[DEBUG] Logging to $logFile" -ForegroundColor DarkCyan
+    }
     $dir = Split-Path -Path $logFile -Parent
     if (-not (Test-Path $dir)) {
         New-Item -Path $dir -ItemType Directory -Force | Out-Null


### PR DESCRIPTION
### Summary
- prevent infinite recursion in `Write-STLog` when `ST_DEBUG=1`

### File Citations
- `src/Logging/Logging.psm1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846d499ad94832c879fed4f76aed10f