### PR TITLE
Fix Install-SupportTools Telemetry install

### DIFF
--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -17,7 +17,7 @@ Once published, install the entire suite on a fresh system using the helper scri
 ./scripts/Install-SupportTools.ps1 -SupportToolsVersion 1.3.0
 ```
 
-The script downloads `Logging`, `SharePointTools`, `ServiceDeskTools` and the specified version of `SupportTools` from the gallery. If the gallery can't be reached it imports the local copies from `src` instead.
+The script downloads `Logging`, `Telemetry`, `SharePointTools`, `ServiceDeskTools` and the specified version of `SupportTools` from the gallery. If the gallery can't be reached it imports the local copies from `src` instead.
 
 ## Signing Scripts
 

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -23,7 +23,9 @@ This short guide shows the basic steps to start using the modules in this reposi
    ```powershell
    ./scripts/Install-SupportTools.ps1 -SupportToolsVersion 1.3.0
    ```
-   If the gallery is unavailable the script automatically imports the modules
+   The script attempts to download `Logging`, `Telemetry`, `SharePointTools`,
+   `ServiceDeskTools` and the specified version of `SupportTools` from the
+   gallery. If the gallery is unavailable it automatically imports the modules
    from the `src` folder instead.
 6. **Import the modules**
    ```powershell

--- a/scripts/Install-SupportTools.ps1
+++ b/scripts/Install-SupportTools.ps1
@@ -18,7 +18,13 @@ param(
     [string]$Scope = 'CurrentUser'
 )
 
-$modules = @('Logging','SharePointTools','ServiceDeskTools','SupportTools')
+$modules = @(
+    'Logging',
+    'Telemetry',
+    'SharePointTools',
+    'ServiceDeskTools',
+    'SupportTools'
+)
 
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
### Summary
- import Telemetry module when installing SupportTools suite
- document Telemetry installation in quickstart and packaging guides

### File Citations
- `scripts/Install-SupportTools.ps1` lines 18-27
- `docs/Quickstart.md` lines 22-29
- `docs/Packaging.md` lines 14-21

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846e13e5234832cbd7bd123dd574c1c