### PR TITLE
Fix Write-STStatus calls

### DIFF
--- a/scripts/Get-NetworkShares.ps1
+++ b/scripts/Get-NetworkShares.ps1
@@ -24,7 +24,7 @@ function Get-NetworkShares {
     if ($ComputerName -eq $null) {
         $ComputerName = $env:COMPUTERNAME
     }
-    Write-STStatus "Gathering network shares on $ComputerName..." -Level INFO
+    Write-STStatus -Message "Gathering network shares on $ComputerName..." -Level INFO
 
     $shares = Get-CimInstance -ClassName Win32_Share -ComputerName $ComputerName
 
@@ -42,7 +42,7 @@ function Get-NetworkShares {
         Shares       = $shareObjects
     }
 
-    Write-STStatus "Found $($shareObjects.Count) shares." -Level SUCCESS
+    Write-STStatus -Message "Found $($shareObjects.Count) shares." -Level SUCCESS
     return $result
 }
 

--- a/scripts/Install-ModuleDependencies.ps1
+++ b/scripts/Install-ModuleDependencies.ps1
@@ -17,19 +17,19 @@ $requiredModules = @{
 
 foreach ($name in $requiredModules.Keys) {
     if (-not (Get-Module -ListAvailable -Name $name)) {
-        Write-STStatus "Module '$name' not found. Required for $($requiredModules[$name])." -Level WARN
+        Write-STStatus -Message "Module '$name' not found. Required for $($requiredModules[$name])." -Level WARN
         $install = Read-Host "Install $name from PSGallery? (Y/N)"
         if ($install -match '^[Yy]') {
             try {
                 Install-Module -Name $name -Scope CurrentUser -Force -ErrorAction Stop
-                Write-STStatus "Installed $name" -Level SUCCESS
+                Write-STStatus -Message "Installed $name" -Level SUCCESS
             } catch {
-                Write-STStatus "Failed to install ${name}: $($_.Exception.Message)" -Level ERROR
+                Write-STStatus -Message "Failed to install ${name}: $($_.Exception.Message)" -Level ERROR
             }
         } else {
-            Write-STStatus "$name was not installed. Some commands may not work." -Level WARN
+            Write-STStatus -Message "$name was not installed. Some commands may not work." -Level WARN
         }
     } else {
-        Write-STStatus "Module '$name' already installed." -Level SUCCESS
+        Write-STStatus -Message "Module '$name' already installed." -Level SUCCESS
     }
 }

--- a/scripts/Send-TelemetrySummary.ps1
+++ b/scripts/Send-TelemetrySummary.ps1
@@ -54,7 +54,7 @@ if ($LogPath) {
 }
 
 if (-not (Test-Path $path)) {
-    Write-STStatus "Telemetry log not found: $path" -Level ERROR
+    Write-STStatus -Message "Telemetry log not found: $path" -Level ERROR
     return
 }
 


### PR DESCRIPTION
### Summary
- fix parameter usage for Write-STStatus in multiple scripts

### File Citations
- `scripts/Install-ModuleDependencies.ps1` lines 18-33
- `scripts/Get-NetworkShares.ps1` lines 27-45
- `scripts/Send-TelemetrySummary.ps1` lines 56-57

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846e4385780832c8d5195402a0ffb27