### PR TITLE
Fix log level mapping for Write-SPToolsHacker

### DIFF
--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -61,7 +61,13 @@ function Write-SPToolsHacker {
         if ($Level -in @('SUCCESS','ERROR','WARN','FATAL')) {
             $meta = @{ tool = 'SharePointTools'; level = $Level }
             if ($Metadata) { foreach ($k in $Metadata.Keys) { $meta[$k] = $Metadata[$k] } }
-            Write-STLog -Message $Message -Level $Level -Structured -Metadata $meta
+            switch ($Level) {
+                'ERROR' { $logLevel = 'ERROR' }
+                'FATAL' { $logLevel = 'ERROR' }
+                'WARN'  { $logLevel = 'WARN'  }
+                default { $logLevel = 'INFO'  }
+            }
+            Write-STLog -Message $Message -Level $logLevel -Structured -Metadata $meta
         }
 
     }


### PR DESCRIPTION
### Summary
- map custom SharePointTools log levels to Write-STLog's supported values

### File Citations
- `src/SharePointTools/SharePointTools.psm1`【F:src/SharePointTools/SharePointTools.psm1†L55-L71】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846e6f09010832c96a07e99acf6352f