### PR TITLE
Suppress unapproved verb warnings

### DIFF
--- a/SupportToolsLoader.ps1
+++ b/SupportToolsLoader.ps1
@@ -15,7 +15,7 @@
 if (-not $script:SupportToolsLoaderLoaded) {
     $script:SupportToolsLoaderLoaded = $true
 
-    Import-Module (Join-Path $PSScriptRoot 'src/OutTools/OutTools.psd1') -Force -ErrorAction SilentlyContinue
+    Import-Module (Join-Path $PSScriptRoot 'src/OutTools/OutTools.psd1') -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
     function Write-LoaderLog {
         param([string]$Message)
@@ -40,7 +40,7 @@ if (-not $script:SupportToolsLoaderLoaded) {
         try {
             $name = Split-Path $moduleFile.FullName -LeafBase
             if (-not (Get-Module -Name $name)) {
-                Import-Module $moduleFile.FullName -Force -ErrorAction Stop
+                Import-Module $moduleFile.FullName -Force -ErrorAction Stop -DisableNameChecking
                 $loadedModules += $name
                 Write-LoaderLog "Loaded module $name"
                 $bannerFunc = "Show-$name`Banner"

--- a/build.ps1
+++ b/build.ps1
@@ -3,7 +3,7 @@ Param(
 )
 $ErrorActionPreference = 'Stop'
 $root = Split-Path -Parent $MyInvocation.MyCommand.Path
-Import-Module (Join-Path $root 'src/Logging/Logging.psd1') -Force
+Import-Module (Join-Path $root 'src/Logging/Logging.psd1') -Force -DisableNameChecking
 if (-not $Version) {
     $Version = (Import-PowerShellDataFile (Join-Path $root 'src/SupportTools/SupportTools.psd1')).ModuleVersion
 }

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -1,4 +1,4 @@
 function Import-SupportToolsLogging {
     $modulePath = Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1'
-    Import-Module $modulePath -Force -ErrorAction SilentlyContinue
+    Import-Module $modulePath -Force -ErrorAction SilentlyContinue -DisableNameChecking
 }

--- a/scripts/Install-ModuleDependencies.ps1
+++ b/scripts/Install-ModuleDependencies.ps1
@@ -6,7 +6,7 @@
     Prompts to install from the PowerShell Gallery when a module is missing.
 #>
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 $requiredModules = @{ 
     'PnP.PowerShell' = 'SharePoint cleanup functions';

--- a/scripts/Install-SupportTools.ps1
+++ b/scripts/Install-SupportTools.ps1
@@ -26,7 +26,7 @@ $modules = @(
     'SupportTools'
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 foreach ($module in $modules) {
     try {
@@ -39,7 +39,7 @@ foreach ($module in $modules) {
         Write-Warning "Failed to install $module from gallery: $($_.Exception.Message)"
         $localPath = Join-Path $PSScriptRoot '..' 'src' $module "$module.psd1"
         if (Test-Path $localPath) {
-            Import-Module $localPath -Force
+            Import-Module $localPath -Force -DisableNameChecking
             Write-Warning "Imported $module from $localPath"
         } else {
             Write-Warning "Could not find $module in src"

--- a/src/ChaosTools/ChaosTools.psm1
+++ b/src/ChaosTools/ChaosTools.psm1
@@ -1,7 +1,7 @@
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 $PublicDir = Join-Path $PSScriptRoot 'Public'
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }

--- a/src/ConfigManagementTools/ConfigManagementTools.psm1
+++ b/src/ConfigManagementTools/ConfigManagementTools.psm1
@@ -3,9 +3,9 @@ $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }

--- a/src/EntraIDTools/EntraIDTools.psm1
+++ b/src/EntraIDTools/EntraIDTools.psm1
@@ -2,8 +2,8 @@ $PublicDir = Join-Path $PSScriptRoot 'Public'
 $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }

--- a/src/IncidentResponseTools/IncidentResponseTools.psm1
+++ b/src/IncidentResponseTools/IncidentResponseTools.psm1
@@ -3,9 +3,9 @@ $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -1,6 +1,6 @@
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 $configFile = Join-Path $repoRoot 'config/supporttools.json'
 $SupportToolsConfig = Get-STConfig -Path $configFile
 if (-not $SupportToolsConfig.ContainsKey('maintenanceMode')) {

--- a/src/MaintenancePlan/MaintenancePlan.psm1
+++ b/src/MaintenancePlan/MaintenancePlan.psm1
@@ -1,8 +1,8 @@
 $PublicDir = Join-Path $PSScriptRoot 'Public'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 Get-ChildItem -Path "$PublicDir" -Filter *.ps1 -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
 Export-ModuleMember -Function (Get-ChildItem "$PublicDir/*.ps1" -ErrorAction SilentlyContinue).BaseName

--- a/src/MonitoringTools/MonitoringTools.psm1
+++ b/src/MonitoringTools/MonitoringTools.psm1
@@ -1,8 +1,8 @@
 $PublicDir = Join-Path $PSScriptRoot 'Public'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 

--- a/src/PerformanceTools/PerformanceTools.psm1
+++ b/src/PerformanceTools/PerformanceTools.psm1
@@ -1,7 +1,7 @@
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 function Measure-STCommand {
     <#

--- a/src/STPlatform/STPlatform.psm1
+++ b/src/STPlatform/STPlatform.psm1
@@ -2,9 +2,9 @@ $PublicDir = Join-Path $PSScriptRoot 'Public'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 Get-ChildItem -Path "$PublicDir" -Filter *.ps1 -ErrorAction SilentlyContinue |
     ForEach-Object { . $_.FullName }

--- a/src/ServiceDeskTools/ServiceDeskTools.psm1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psm1
@@ -4,9 +4,9 @@ $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue |
     ForEach-Object { . $_.FullName }

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -3,7 +3,7 @@
 # Load configuration values if available
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 $settingsFile = Join-Path $repoRoot 'config/SharePointToolsSettings.psd1'
 $SharePointToolsSettings = Get-STConfig -Path $settingsFile
 if (-not $SharePointToolsSettings) { $SharePointToolsSettings = @{} }
@@ -13,9 +13,9 @@ if (-not $SharePointToolsSettings.ContainsKey('CertPath')) { $SharePointToolsSet
 if (-not $SharePointToolsSettings.ContainsKey('Sites')) { $SharePointToolsSettings.Sites = @{} }
 
 $loggingModule = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath 'Logging/Logging.psd1'
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 $telemetryModule = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 # Load additional public commands
 $publicDir = Join-Path $PSScriptRoot 'Public'

--- a/src/SupportTools/SupportTools.psm1
+++ b/src/SupportTools/SupportTools.psm1
@@ -3,9 +3,9 @@ $PrivateDir = Join-Path $PSScriptRoot 'Private'
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
-Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 # Determine the version of the SupportTools module for logging purposes
 $manifestPath = Join-Path $PSScriptRoot 'SupportTools.psd1'

--- a/src/Telemetry/Telemetry.psm1
+++ b/src/Telemetry/Telemetry.psm1
@@ -1,7 +1,7 @@
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue
+Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue
+Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 function Send-STMetric {
     [CmdletBinding()]


### PR DESCRIPTION
### Summary
- add `-DisableNameChecking` to module import statements
- update SupportTools loader and build scripts

### File Citations
- `src/Logging/Logging.psm1`【F:src/Logging/Logging.psm1†L1-L5】
- `scripts/Install-SupportTools.ps1`【F:scripts/Install-SupportTools.ps1†L29-L43】
- `SupportToolsLoader.ps1`【F:SupportToolsLoader.ps1†L16-L23】
- `scripts/Common.ps1`【F:scripts/Common.ps1†L1-L4】
- `scripts/Install-ModuleDependencies.ps1`【F:scripts/Install-ModuleDependencies.ps1†L8-L9】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846e6c60aac832c9048aeb0b7c6bf47