### PR TITLE
Allow certificate selection via file dialog

### DIFF
--- a/scripts/Configure-SharePointTools.ps1
+++ b/scripts/Configure-SharePointTools.ps1
@@ -38,8 +38,25 @@ if ($PSBoundParameters.ContainsKey('TenantId')) {
 if ($PSBoundParameters.ContainsKey('CertPath')) {
     $settings.CertPath = $CertPath
 } else {
-    $certPath = Read-Host "Certificate Path (current: $($settings.CertPath))"
-    if ($certPath) { $settings.CertPath = $certPath }
+    if ($IsWindows) {
+        try {
+            Add-Type -AssemblyName System.Windows.Forms -ErrorAction Stop
+            $dialog = New-Object System.Windows.Forms.OpenFileDialog
+            $dialog.Title  = 'Select certificate file'
+            $dialog.Filter = 'PFX files (*.pfx)|*.pfx|All files (*.*)|*.*'
+            $dialog.FileName = $settings.CertPath
+            Write-STStatus -Message 'Select certificate file or press Cancel to keep the current value.' -Level INFO
+            if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
+                $settings.CertPath = $dialog.FileName
+            }
+        } catch {
+            $certPath = Read-Host "Certificate Path (current: $($settings.CertPath))"
+            if ($certPath) { $settings.CertPath = $certPath }
+        }
+    } else {
+        $certPath = Read-Host "Certificate Path (current: $($settings.CertPath))"
+        if ($certPath) { $settings.CertPath = $certPath }
+    }
 }
 
 # Configure SharePoint sites


### PR DESCRIPTION
### Summary
- add OpenFileDialog to select certificate if parameter isn't provided

### File Citations
- `scripts/Configure-SharePointTools.ps1` lines 38-60

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846e93de070832cb9e96e709a35ba05