### PR TITLE
Stop installing modules from gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cd PowerShell
 ./scripts/Install-SupportTools.ps1
 ```
 
-`Install-SupportTools.ps1` pulls the latest module versions from your internal feed when available and falls back to importing them from the `src` folder. Next run the SharePoint configuration script if you plan to use those commands:
+`Install-SupportTools.ps1` imports the modules directly from the `src` folder. Next run the SharePoint configuration script if you plan to use those commands:
 
 ```powershell
 ./scripts/Test-SPToolsPrereqs.ps1 -Install

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -13,11 +13,11 @@ Publish the resulting `.nupkg` to your Chocolatey or PowerShell Gallery reposito
 Once published, install the entire suite on a fresh system using the helper script:
 
 ```powershell
-# Pin SupportTools to a specific version
-./scripts/Install-SupportTools.ps1 -SupportToolsVersion 1.3.0
+# Load the modules directly from source
+./scripts/Install-SupportTools.ps1
 ```
 
-The script downloads `Logging`, `Telemetry`, `SharePointTools`, `ServiceDeskTools` and the specified version of `SupportTools` from the gallery. If the gallery can't be reached it imports the local copies from `src` instead.
+The script imports `Logging`, `Telemetry`, `SharePointTools`, `ServiceDeskTools` and `SupportTools` from the `src` directory.
 
 ## Signing Scripts
 

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -21,12 +21,10 @@ This short guide shows the basic steps to start using the modules in this reposi
    ```
 5. **Install from internal repository (optional)**
    ```powershell
-   ./scripts/Install-SupportTools.ps1 -SupportToolsVersion 1.3.0
+   ./scripts/Install-SupportTools.ps1
    ```
-   The script attempts to download `Logging`, `Telemetry`, `SharePointTools`,
-   `ServiceDeskTools` and the specified version of `SupportTools` from the
-   gallery. If the gallery is unavailable it automatically imports the modules
-   from the `src` folder instead.
+   The script imports `Logging`, `Telemetry`, `SharePointTools`,
+   `ServiceDeskTools` and `SupportTools` from the `src` folder.
 6. **Import the modules**
    ```powershell
    Import-Module ./src/SupportTools/SupportTools.psd1

--- a/scripts/Install-SupportTools.ps1
+++ b/scripts/Install-SupportTools.ps1
@@ -1,16 +1,17 @@
 <#
 .SYNOPSIS
-    Installs the SupportTools suite from the PowerShell Gallery.
+    Imports the SupportTools suite from the repository source.
 .DESCRIPTION
-    Downloads SupportTools, SharePointTools, ServiceDeskTools and Logging from the gallery.
-    If a version is specified for SupportTools it will be pinned using -RequiredVersion.
-    If the gallery is unavailable the modules are imported from the local src folder.
+    Loads SupportTools, SharePointTools, ServiceDeskTools and Logging from the
+    local `src` folder. The script no longer attempts to download modules from
+    any gallery. `SupportToolsVersion` and `Scope` are retained for backward
+    compatibility but are ignored.
 .PARAMETER SupportToolsVersion
-    Version of SupportTools to install. Defaults to the latest available version.
+    Ignored parameter kept for compatibility with older automation.
 .PARAMETER Scope
-    Scope to install the modules. Defaults to CurrentUser.
+    Ignored parameter kept for compatibility with older automation.
 .EXAMPLE
-    ./Install-SupportTools.ps1 -SupportToolsVersion 1.3.0
+    ./Install-SupportTools.ps1
 #>
 param(
     [string]$SupportToolsVersion,
@@ -29,20 +30,11 @@ $modules = @(
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 foreach ($module in $modules) {
-    try {
-        if ($module -eq 'SupportTools' -and $SupportToolsVersion) {
-            Install-Module -Name $module -RequiredVersion $SupportToolsVersion -Scope $Scope -Force -AllowClobber -ErrorAction Stop
-        } else {
-            Install-Module -Name $module -Scope $Scope -Force -AllowClobber -ErrorAction Stop
-        }
-    } catch {
-        Write-Warning "Failed to install $module from gallery: $($_.Exception.Message)"
-        $localPath = Join-Path $PSScriptRoot '..' 'src' $module "$module.psd1"
-        if (Test-Path $localPath) {
-            Import-Module $localPath -Force -DisableNameChecking
-            Write-Warning "Imported $module from $localPath"
-        } else {
-            Write-Warning "Could not find $module in src"
-        }
+    $localPath = Join-Path $PSScriptRoot '..' 'src' $module "$module.psd1"
+    if (Test-Path $localPath) {
+        Import-Module $localPath -Force -DisableNameChecking
+        Write-Warning "Imported $module from $localPath"
+    } else {
+        Write-Warning "Could not find $module in src"
     }
 }

--- a/tests/Install-SupportTools.Tests.ps1
+++ b/tests/Install-SupportTools.Tests.ps1
@@ -2,15 +2,11 @@
 
 Describe 'Install-SupportTools script' {
     BeforeEach {
-        function Install-Module {}
         function Import-Module {}
-        Mock Install-Module {
-            if ($Name -eq 'SharePointTools') { throw 'gallery unavailable' }
-        }
         Mock Import-Module {}
     }
 
-    Safe-It 'imports from src when gallery install fails' {
+    Safe-It 'imports from src' {
         $warnings = @()
         & $PSScriptRoot/../scripts/Install-SupportTools.ps1 -WarningVariable +warnings -Scope CurrentUser
         $spPath = Join-Path $PSScriptRoot/../src/SharePointTools 'SharePointTools.psd1'


### PR DESCRIPTION
### Summary
- modify Install-SupportTools to only import modules from `src`
- adjust docs to describe local-only behavior
- update Pester test for new functionality

### File Citations
- `scripts/Install-SupportTools.ps1` lines 2-38
- `README.md` lines 46-52
- `docs/Quickstart.md` lines 22-27
- `docs/Packaging.md` lines 16-20
- `tests/Install-SupportTools.Tests.ps1` lines 1-15

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846eb04ff1c832c97b228d372cd57d5