### PR TITLE
Fix missing Invoke-ScriptFile dependency

### DIFF
--- a/src/IncidentResponseTools/IncidentResponseTools.psd1
+++ b/src/IncidentResponseTools/IncidentResponseTools.psd1
@@ -4,7 +4,7 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000101'
     Author = 'Contoso'
     Description = 'Incident response helper commands.'
-    RequiredModules = @('Logging','SharePointTools','ServiceDeskTools','Telemetry')
+    RequiredModules = @('Logging','SharePointTools','ServiceDeskTools','Telemetry','SupportTools')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','IncidentResponse','Internal') } }
     FunctionsToExport = @(
         'Get-CommonSystemInfo',


### PR DESCRIPTION
### Summary
- ensure `SupportTools` module is loaded by `IncidentResponseTools`

### File Citations
- `src/IncidentResponseTools/IncidentResponseTools.psd1`

### Test Results
```
bash: pwsh: command not found
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846ec823da4832c82e8526b35beba0b