### PR TITLE
Include IncidentResponseTools in Install-SupportTools

### DIFF
--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -17,7 +17,7 @@ Once published, install the entire suite on a fresh system using the helper scri
 ./scripts/Install-SupportTools.ps1
 ```
 
-The script imports `Logging`, `Telemetry`, `SharePointTools`, `ServiceDeskTools` and `SupportTools` from the `src` directory.
+The script imports `Logging`, `Telemetry`, `IncidentResponseTools`, `SharePointTools`, `ServiceDeskTools` and `SupportTools` from the `src` directory.
 
 ## Signing Scripts
 

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -23,8 +23,9 @@ This short guide shows the basic steps to start using the modules in this reposi
    ```powershell
    ./scripts/Install-SupportTools.ps1
    ```
-   The script imports `Logging`, `Telemetry`, `SharePointTools`,
-   `ServiceDeskTools` and `SupportTools` from the `src` folder.
+    The script imports `Logging`, `Telemetry`, `IncidentResponseTools`,
+    `SharePointTools`, `ServiceDeskTools` and `SupportTools` from the `src`
+    folder.
 6. **Import the modules**
    ```powershell
    Import-Module ./src/SupportTools/SupportTools.psd1

--- a/scripts/Install-SupportTools.ps1
+++ b/scripts/Install-SupportTools.ps1
@@ -2,10 +2,10 @@
 .SYNOPSIS
     Imports the SupportTools suite from the repository source.
 .DESCRIPTION
-    Loads SupportTools, SharePointTools, ServiceDeskTools and Logging from the
-    local `src` folder. The script no longer attempts to download modules from
-    any gallery. `SupportToolsVersion` and `Scope` are retained for backward
-    compatibility but are ignored.
+    Loads SupportTools, IncidentResponseTools, SharePointTools, ServiceDeskTools
+    and Logging from the local `src` folder. The script no longer attempts to
+    download modules from any gallery. `SupportToolsVersion` and `Scope` are
+    retained for backward compatibility but are ignored.
 .PARAMETER SupportToolsVersion
     Ignored parameter kept for compatibility with older automation.
 .PARAMETER Scope
@@ -22,6 +22,7 @@ param(
 $modules = @(
     'Logging',
     'Telemetry',
+    'IncidentResponseTools',
     'SharePointTools',
     'ServiceDeskTools',
     'SupportTools'


### PR DESCRIPTION
### Summary
- import IncidentResponseTools when running `Install-SupportTools.ps1`
- document the additional module in Quickstart and Packaging docs

### File Citations
- `scripts/Install-SupportTools.ps1` lines 4-28 show the updated description and module list
- `docs/Quickstart.md` lines 24-28 mention IncidentResponseTools in the install note
- `docs/Packaging.md` lines 17-20 mention IncidentResponseTools in packaging instructions

### Test Results
The Pester test run failed due to call depth overflow errors:
```
[-] Describe AddUsersToGroup Script failed
 [0] ScriptCallDepthException: The script failed due to call depth overflow.
```


------
https://chatgpt.com/codex/tasks/task_e_6846ec47645c832ca3790026e023aa9f