### PR TITLE
Add ErrorAction Stop to EntraIDTools REST calls

### DIFF
--- a/src/EntraIDTools/Public/Disable-GraphUser.ps1
+++ b/src/EntraIDTools/Public/Disable-GraphUser.ps1
@@ -44,7 +44,7 @@ function Disable-GraphUser {
             $url = "https://graph.microsoft.com/v1.0/users/$UserPrincipalName"
             $body = @{ accountEnabled = $false } | ConvertTo-Json
             if ($PSCmdlet.ShouldProcess($UserPrincipalName, 'Disable user')) {
-                Invoke-RestMethod -Uri $url -Headers $headers -Method Patch -Body $body -ContentType 'application/json'
+                Invoke-RestMethod -Uri $url -Headers $headers -Method Patch -Body $body -ContentType 'application/json' -ErrorAction Stop
             }
         } else {
             Import-Module ActiveDirectory -ErrorAction Stop

--- a/src/EntraIDTools/Public/Get-GraphSignInLogs.ps1
+++ b/src/EntraIDTools/Public/Get-GraphSignInLogs.ps1
@@ -56,7 +56,7 @@ function Get-GraphSignInLogs {
             $filter = [string]::Join(' and ', $filterParts)
             $uri += "?`$filter=" + [System.Web.HttpUtility]::UrlEncode($filter)
         }
-        $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get
+        $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get -ErrorAction Stop
         return $response.value
     } catch {
         $result = 'Failure'


### PR DESCRIPTION
### Summary
- ensure REST requests fail fast by adding `-ErrorAction Stop`

### File Citations
- `src/EntraIDTools/Public/Get-GraphSignInLogs.ps1` lines 54-60
- `src/EntraIDTools/Public/Disable-GraphUser.ps1` lines 42-48

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f0bea2d8832c886c40cc8ba02dd4