### PR TITLE
Centralize constants in config

### DIFF
--- a/config/config.psd1
+++ b/config/config.psd1
@@ -1,0 +1,12 @@
+@{
+    SupportToolsConfig = 'config/supporttools.json'
+    SharePointSettings = 'config/SharePointToolsSettings.psd1'
+    TicketCache = 'config/ticketCache.json'
+    TerminatedState = 'config/terminated.json'
+    SysmonDir = 'C:\SYSV2'
+    FontsDir = 'C:\Windows\Fonts'
+    FontsRegPath = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Fonts'
+    PublicDesktop = 'C:\Users\Public\Desktop'
+    ReadmePattern = 'C:\*readme*.txt'
+    SystemDriveRoot = 'C:\'
+}

--- a/scripts/Configure-SharePointTools.ps1
+++ b/scripts/Configure-SharePointTools.ps1
@@ -9,7 +9,9 @@ Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -
 Import-Module (Join-Path $PSScriptRoot '..' 'src/STCore/STCore.psd1') -Force -ErrorAction SilentlyContinue
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
-$settingsPath = Join-Path $repoRoot 'config/SharePointToolsSettings.psd1'
+$defaultsFile = Join-Path $repoRoot 'config/config.psd1'
+$STDefaults = Get-STConfig -Path $defaultsFile
+$settingsPath = Join-Path $repoRoot (Get-STConfigValue -Config $STDefaults -Key 'SharePointSettings')
 
 $settings = Get-STConfig -Path $settingsPath
 if (-not $settings) { $settings = @{} }

--- a/scripts/Install-Fonts.ps1
+++ b/scripts/Install-Fonts.ps1
@@ -45,11 +45,17 @@ function Install-Fonts {
         $Fonts
     )
 
+    $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+    $defaultsFile = Join-Path $repoRoot 'config/config.psd1'
+    $STDefaults = Get-STConfig -Path $defaultsFile
+    $fontsDir = Get-STConfigValue -Config $STDefaults -Key 'FontsDir'
+    $fontsReg = Get-STConfigValue -Config $STDefaults -Key 'FontsRegPath'
+
     foreach ($font in $Fonts)
     {
         $fontName = $font.Name
-        Copy-Item -Path $font.FullName -Destination "C:\Windows\Fonts" -Force
-        New-ItemProperty -Name $font.BaseName -Path "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Fonts" -PropertyType string -Value $font.Name -Force
+        Copy-Item -Path $font.FullName -Destination $fontsDir -Force
+        New-ItemProperty -Name $font.BaseName -Path $fontsReg -PropertyType string -Value $font.Name -Force
     }
     
 }

--- a/scripts/PostInstallScript.ps1
+++ b/scripts/PostInstallScript.ps1
@@ -14,6 +14,10 @@
 # Functions listed here
 
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$defaultsFile = Join-Path $repoRoot 'config/config.psd1'
+$STDefaults = Get-STConfig -Path $defaultsFile
+$publicDesktop = Get-STConfigValue -Config $STDefaults -Key 'PublicDesktop'
 
 function MSStoreAppInstallerUpdate {
     <#
@@ -313,7 +317,7 @@ function Copy-Files {
 
     foreach ($shortcut in $AdminShortcuts)
     {
-        Copy-Item -Path $shortcut.Fullname -Destination "C:\Users\Public\Desktop\"
+        Copy-Item -Path $shortcut.Fullname -Destination $publicDesktop
     }
 
 
@@ -321,12 +325,12 @@ function Copy-Files {
     # Copy printer drivers to public desktop
     if ($USB)
     {
-        Copy-Item -Path "$($DriveLetter)assets\PrinterDrivers" -Destination "C:\Users\Public\Desktop" -Recurse
+        Copy-Item -Path "$($DriveLetter)assets\PrinterDrivers" -Destination $publicDesktop -Recurse
     }
 
     if ($Local)
     {
-        Copy-Item -Path ".\assets\PrinterDrivers" -Destination "C:\Users\Public\Desktop" -Recurse
+        Copy-Item -Path ".\assets\PrinterDrivers" -Destination $publicDesktop -Recurse
     }
 }
 

--- a/scripts/Process-TerminationTickets.ps1
+++ b/scripts/Process-TerminationTickets.ps1
@@ -16,9 +16,14 @@
 .PARAMETER ClientSecret
     Optional client secret for Graph authentication.
 #>
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$defaultsFile = Join-Path $repoRoot 'config/config.psd1'
+$STDefaults = Get-STConfig -Path $defaultsFile
+$defaultState = Join-Path $repoRoot (Get-STConfigValue -Config $STDefaults -Key 'TerminatedState')
+
 param(
     [int]$PollMinutes = 5,
-    [string]$StatePath = "$PSScriptRoot/../config/terminated.json",
+    [string]$StatePath = $defaultState,
     [string]$TenantId = $env:GRAPH_TENANT_ID,
     [string]$ClientId = $env:GRAPH_CLIENT_ID,
     [string]$ClientSecret = $env:GRAPH_CLIENT_SECRET

--- a/scripts/Search-Indicators.ps1
+++ b/scripts/Search-Indicators.ps1
@@ -1,4 +1,8 @@
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$defaultsFile = Join-Path $repoRoot 'config/config.psd1'
+$STDefaults = Get-STConfig -Path $defaultsFile
+$rootPath = Get-STConfigValue -Config $STDefaults -Key 'SystemDriveRoot'
 
 param(
     [Parameter(Mandatory=$true)]
@@ -28,7 +32,7 @@ function Search-Indicators {
             Where-Object { $_.Message -match [regex]::Escape($ind) }
         $regHits = Get-ChildItem -Path HKLM:\,HKCU:\ -Recurse -ErrorAction SilentlyContinue |
             Where-Object { $_.Name -match [regex]::Escape($ind) }
-        $fileHits = Get-ChildItem -Path C:\ -Recurse -ErrorAction SilentlyContinue -Force |
+        $fileHits = Get-ChildItem -Path $rootPath -Recurse -ErrorAction SilentlyContinue -Force |
             Where-Object { $_.FullName -match [regex]::Escape($ind) }
         [pscustomobject]@{
             Indicator      = $ind

--- a/scripts/Sync-SDTickets.ps1
+++ b/scripts/Sync-SDTickets.ps1
@@ -12,8 +12,13 @@
 .PARAMETER FullSyncHours
     Interval between full synchronizations in hours. Defaults to 24.
 #>
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$defaultsFile = Join-Path $repoRoot 'config/config.psd1'
+$STDefaults = Get-STConfig -Path $defaultsFile
+$defaultCache = Join-Path $repoRoot (Get-STConfigValue -Config $STDefaults -Key 'TicketCache')
+
 param(
-    [string]$CachePath = "$PSScriptRoot/../config/ticketCache.json",
+    [string]$CachePath = $defaultCache,
     [int]$PollMinutes = 5,
     [int]$FullSyncHours = 24
 )

--- a/scripts/Update-Sysmon.ps1
+++ b/scripts/Update-Sysmon.ps1
@@ -27,12 +27,17 @@ function Main {
     }
 
     # copy the updated sysmon dir to c drive
-    Copy-Item -Path $drivePath -Destination "C:\SYSV2"  -Recurse -Verbose
+    $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+    $defaultsFile = Join-Path $repoRoot 'config/config.psd1'
+    $STDefaults = Get-STConfig -Path $defaultsFile
+    $sysmonDir = Get-STConfigValue -Config $STDefaults -Key 'SysmonDir'
+
+    Copy-Item -Path $drivePath -Destination $sysmonDir  -Recurse -Verbose
 
     Start-Sleep -Seconds 2
 
     # change working dir to c drive
-    Set-Location -Path "C:\SYSV2\" -Verbose
+    Set-Location -Path $sysmonDir -Verbose
 
     # uninstall sysmon
     .\Sysmon64.exe -u force

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -1,7 +1,9 @@
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
-$configFile = Join-Path $repoRoot 'config/supporttools.json'
+$defaultsFile = Join-Path $repoRoot 'config/config.psd1'
+$STDefaults = Get-STConfig -Path $defaultsFile
+$configFile = Join-Path $repoRoot (Get-STConfigValue -Config $STDefaults -Key 'SupportToolsConfig')
 $SupportToolsConfig = Get-STConfig -Path $configFile
 if (-not $SupportToolsConfig.ContainsKey('maintenanceMode')) {
     $SupportToolsConfig.maintenanceMode = $false

--- a/src/STCore/STCore.psd1
+++ b/src/STCore/STCore.psd1
@@ -4,5 +4,5 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000000'
     Author = 'Contoso'
     Description = 'Core utility functions.'
-    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest')
+    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Get-STConfigValue','Invoke-STRequest')
 }

--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -95,6 +95,18 @@ function Get-STConfig {
     }
 }
 
+function Get-STConfigValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$Config,
+        [Parameter(Mandatory)][string]$Key,
+        $Default = $null
+    )
+    if (-not $Config) { return $Default }
+    if ($Config.ContainsKey($Key) -and $Config[$Key]) { return $Config[$Key] }
+    return $Default
+}
+
 function Invoke-STRequest {
     [CmdletBinding()]
     param(

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -4,7 +4,9 @@
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
 Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
-$settingsFile = Join-Path $repoRoot 'config/SharePointToolsSettings.psd1'
+$defaultsFile = Join-Path $repoRoot 'config/config.psd1'
+$STDefaults = Get-STConfig -Path $defaultsFile
+$settingsFile = Join-Path $repoRoot (Get-STConfigValue -Config $STDefaults -Key 'SharePointSettings')
 $SharePointToolsSettings = Get-STConfig -Path $settingsFile
 if (-not $SharePointToolsSettings) { $SharePointToolsSettings = @{} }
 if (-not $SharePointToolsSettings.ContainsKey('ClientId')) { $SharePointToolsSettings.ClientId = '' }

--- a/src/SupportTools/Public/Search-ReadMe.ps1
+++ b/src/SupportTools/Public/Search-ReadMe.ps1
@@ -13,10 +13,15 @@ function Search-ReadMe {
         [string]$TranscriptPath
     )
 
+    $repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
+    $defaultsFile = Join-Path $repoRoot 'config/config.psd1'
+    $STDefaults = Get-STConfig -Path $defaultsFile
+    $pattern = Get-STConfigValue -Config $STDefaults -Key 'ReadmePattern'
+
     if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
     try {
         Write-STStatus -Message 'Searching for readme files...' -Level INFO
-        $results = Get-ChildItem -Path C:\*readme*.txt -Recurse -File -ErrorAction SilentlyContinue
+        $results = Get-ChildItem -Path $pattern -Recurse -File -ErrorAction SilentlyContinue
         Write-STStatus "Found $($results.Count) file(s)." -Level SUCCESS
         return $results
     } catch {


### PR DESCRIPTION
### Summary
- add shared `config.psd1`
- load constants using new `Get-STConfigValue`
- update modules and scripts to read config values dynamically

### File Citations
- `config/config.psd1`
- `src/STCore/STCore.psm1`
- `src/Logging/Logging.psm1`
- `src/SharePointTools/SharePointTools.psm1`
- `scripts/Configure-SharePointTools.ps1`
- `scripts/Sync-SDTickets.ps1`
- `scripts/Process-TerminationTickets.ps1`
- `scripts/Install-Fonts.ps1`
- `scripts/Update-Sysmon.ps1`
- `scripts/PostInstallScript.ps1`
- `scripts/Search-Indicators.ps1`
- `src/SupportTools/Public/Search-ReadMe.ps1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f0130510832c8f70c898c02cbcd8