### PR TITLE
Add test stubs for missing functions

### DIFF
--- a/tests/MonitoringTools/Get-CPUUsage.Tests.ps1
+++ b/tests/MonitoringTools/Get-CPUUsage.Tests.ps1
@@ -1,0 +1,30 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Get-CPUUsage function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/MonitoringTools/MonitoringTools.psd1 -Force
+    }
+
+    Safe-It 'returns average percentage when Get-Counter is available' {
+        InModuleScope MonitoringTools {
+            Mock Get-Command { @{ Name = 'Get-Counter' } } -ParameterFilter { $Name -eq 'Get-Counter' }
+            $samples = 1..3 | ForEach-Object { [pscustomobject]@{ CookedValue = 10 } }
+            Mock Get-Counter { @{ CounterSamples = $samples } }
+            Mock Write-STRichLog {}
+            $result = Get-CPUUsage
+            $result | Should -Be 10
+        }
+    }
+
+    Safe-It 'logs warning when counter cmdlet missing' {
+        InModuleScope MonitoringTools {
+            Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Get-Counter' }
+            Mock Write-STStatus {}
+            Mock Write-STRichLog {}
+            $null = Get-CPUUsage
+            Assert-MockCalled Write-STStatus -Times 1
+        }
+    }
+}

--- a/tests/MonitoringTools/Get-DiskSpaceInfo.Tests.ps1
+++ b/tests/MonitoringTools/Get-DiskSpaceInfo.Tests.ps1
@@ -1,0 +1,39 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Get-DiskSpaceInfo function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/MonitoringTools/MonitoringTools.psd1 -Force
+    }
+
+    Safe-It 'returns disk information' {
+        InModuleScope MonitoringTools {
+            Mock Get-CimInstance { [pscustomobject]@{ DeviceID = 'C:'; Size = 1GB; FreeSpace = 512MB } }
+            Mock Write-STRichLog {}
+            $result = Get-DiskSpaceInfo
+            $result[0].Drive | Should -Be 'C:'
+        }
+    }
+
+    Safe-It 'writes transcript when TranscriptPath used' {
+        InModuleScope MonitoringTools {
+            Mock Get-CimInstance { @() }
+            Mock Start-Transcript {}
+            Mock Stop-Transcript {}
+            Mock Write-STRichLog {}
+            Get-DiskSpaceInfo -TranscriptPath 'log.txt'
+            Assert-MockCalled Start-Transcript -Times 1
+            Assert-MockCalled Stop-Transcript -Times 1
+        }
+    }
+
+    Safe-It 'returns error record on failure' {
+        InModuleScope MonitoringTools {
+            Mock Get-CimInstance { throw 'bad' }
+            Mock Write-STRichLog {}
+            $result = Get-DiskSpaceInfo
+            $result | Should -BeOfType 'System.Management.Automation.ErrorRecord'
+        }
+    }
+}

--- a/tests/MonitoringTools/Get-EventLogSummary.Tests.ps1
+++ b/tests/MonitoringTools/Get-EventLogSummary.Tests.ps1
@@ -1,0 +1,47 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Get-EventLogSummary function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/MonitoringTools/MonitoringTools.psd1 -Force
+    }
+
+    Safe-It 'summarises events using Get-WinEvent' {
+        InModuleScope MonitoringTools {
+            Mock Get-Command { @{ Name = 'Get-WinEvent' } } -ParameterFilter { $Name -eq 'Get-WinEvent' }
+            Mock Get-WinEvent { @([pscustomobject]@{ LevelDisplayName = 'Error' }) }
+            Mock Write-STRichLog {}
+            $result = Get-EventLogSummary -LogName 'System' -LastHours 1
+            $result[0].Name | Should -Be 'Error'
+            $result[0].Count | Should -Be 1
+        }
+    }
+
+    Safe-It 'falls back to Get-EventLog when Get-WinEvent missing' {
+        InModuleScope MonitoringTools {
+            Mock Get-Command {
+                if ($Name -eq 'Get-WinEvent') { $null } else { @{ Name = 'Get-EventLog' } }
+            }
+            Mock Get-EventLog { @([pscustomobject]@{ EntryType = 'Warning' }) }
+            Mock Write-STRichLog {}
+            $result = Get-EventLogSummary -LastHours 1
+            $result[0].Name | Should -Be 'Warning'
+            $result[0].Count | Should -Be 1
+        }
+    }
+
+    Safe-It 'logs warning when no event cmdlets found' {
+        InModuleScope MonitoringTools {
+            Mock Get-Command { $null }
+            Mock Write-Warning {}
+            Mock Write-STRichLog {}
+            $null = Get-EventLogSummary
+            Assert-MockCalled Write-Warning -Times 1
+        }
+    }
+
+    Safe-It 'validates LastHours range' {
+        { Get-EventLogSummary -LastHours 0 } | Should -Throw
+    }
+}

--- a/tests/MonitoringTools/Stop-HealthMonitor.Tests.ps1
+++ b/tests/MonitoringTools/Stop-HealthMonitor.Tests.ps1
@@ -1,0 +1,25 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Stop-HealthMonitor function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/MonitoringTools/MonitoringTools.psd1 -Force
+    }
+
+    Safe-It 'sets script flag to stop monitoring' {
+        InModuleScope MonitoringTools {
+            $script:StopHealthMonitor = $false
+            Stop-HealthMonitor
+            $script:StopHealthMonitor | Should -BeTrue
+        }
+    }
+
+    Safe-It 'does not set flag when -WhatIf specified' {
+        InModuleScope MonitoringTools {
+            $script:StopHealthMonitor = $false
+            Stop-HealthMonitor -WhatIf
+            $script:StopHealthMonitor | Should -BeFalse
+        }
+    }
+}

--- a/tests/SharePointTools/Test-SPToolsSiteAdmin.Tests.ps1
+++ b/tests/SharePointTools/Test-SPToolsSiteAdmin.Tests.ps1
@@ -1,0 +1,39 @@
+. $PSScriptRoot/../TestHelpers.ps1
+
+Describe 'Test-SPToolsSiteAdmin function' {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/SharePointTools/SharePointTools.psd1 -Force
+    }
+
+    Safe-It 'returns status object when site reachable and user is admin' {
+        InModuleScope SharePointTools {
+            Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 200 } }
+            Mock Connect-SPToolsOnline {}
+            Mock Invoke-PnPSPRestMethod { @{ IsSiteAdmin = $true } }
+            Mock Disconnect-PnPOnline {}
+            Mock Write-STTelemetryEvent {}
+            Mock Write-STLog {}
+            $r = Test-SPToolsSiteAdmin -SiteUrl 'https://contoso' -ClientId 'id' -TenantId 'tid' -CertPath 'cert'
+            $r.StatusCode | Should -Be 200
+            $r.IsAdmin | Should -BeTrue
+        }
+    }
+
+    Safe-It 'throws when site cannot be reached' {
+        InModuleScope SharePointTools {
+            Mock Invoke-WebRequest { throw 'fail' }
+            { Test-SPToolsSiteAdmin -SiteUrl 'https://bad' } | Should -Throw
+        }
+    }
+
+    Safe-It 'throws when admin rights check fails' {
+        InModuleScope SharePointTools {
+            Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 200 } }
+            Mock Connect-SPToolsOnline { throw 'err' }
+            Mock Disconnect-PnPOnline {}
+            { Test-SPToolsSiteAdmin -SiteUrl 'https://contoso' } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- add Pester tests for MonitoringTools functions
- add missing tests for Test-SPToolsSiteAdmin

### File Citations
- `tests/MonitoringTools/Get-CPUUsage.Tests.ps1`【F:tests/MonitoringTools/Get-CPUUsage.Tests.ps1†L1-L30】
- `tests/MonitoringTools/Get-DiskSpaceInfo.Tests.ps1`【F:tests/MonitoringTools/Get-DiskSpaceInfo.Tests.ps1†L1-L39】
- `tests/MonitoringTools/Get-EventLogSummary.Tests.ps1`【F:tests/MonitoringTools/Get-EventLogSummary.Tests.ps1†L1-L47】
- `tests/MonitoringTools/Stop-HealthMonitor.Tests.ps1`【F:tests/MonitoringTools/Stop-HealthMonitor.Tests.ps1†L1-L25】
- `tests/SharePointTools/Test-SPToolsSiteAdmin.Tests.ps1`【F:tests/SharePointTools/Test-SPToolsSiteAdmin.Tests.ps1†L1-L39】

### Test Results
- ❌ `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration ./PesterConfiguration.psd1"` (failed to run: `bash: pwsh: command not found`)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f0050c04832cb8efde1d54918bb7