### PR TITLE
Fix catch blocks and enforce ErrorAction

### DIFF
--- a/src/ConfigManagementTools/Public/Add-UserToGroup.ps1
+++ b/src/ConfigManagementTools/Public/Add-UserToGroup.ps1
@@ -61,7 +61,8 @@ function Add-UserToGroup {
 
             Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
         } catch {
-            return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
+            Write-STLog -Message $_.Exception.Message -Level ERROR
+            throw
         }
     }
 }

--- a/src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1
@@ -62,17 +62,17 @@ function Invoke-CompanyPlaceManagement {
     $result = 'Success'
     try {
         if ($Logger) {
-            Import-Module $Logger -Force -ErrorAction SilentlyContinue
+            Import-Module $Logger -Force -ErrorAction Stop
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction Stop
         }
         if ($TelemetryClient) {
-            Import-Module $TelemetryClient -Force -ErrorAction SilentlyContinue
+            Import-Module $TelemetryClient -Force -ErrorAction Stop
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction Stop
         }
         if ($Config) {
-            Import-Module $Config -Force -ErrorAction SilentlyContinue
+            Import-Module $Config -Force -ErrorAction Stop
         }
 
         if ($Explain) {
@@ -80,7 +80,7 @@ function Invoke-CompanyPlaceManagement {
             return
         }
 
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append -ErrorAction Stop | Out-Null }
         Write-STStatus "Invoke-CompanyPlaceManagement -Action $Action" -Level SUCCESS -Log
         if ($Simulate) {
             Write-STStatus -Message 'Simulation mode active - no Microsoft Places changes will be made.' -Level WARN -Log
@@ -153,7 +153,7 @@ function Invoke-CompanyPlaceManagement {
         Write-STStatus "Invoke-CompanyPlaceManagement failed: $_" -Level ERROR -Log
         Write-STLog -Message "Invoke-CompanyPlaceManagement failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
         $result = 'Failure'
-        return New-STErrorObject -Message $_.Exception.Message -Category 'SharePoint'
+        throw
     } finally {
         if ($TranscriptPath) { Stop-Transcript | Out-Null }
         $sw.Stop()

--- a/src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -27,17 +27,17 @@ function Invoke-ExchangeCalendarManager {
     $result = 'Success'
     try {
         if ($Logger) {
-            Import-Module $Logger -Force -ErrorAction SilentlyContinue
+            Import-Module $Logger -Force -ErrorAction Stop
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction Stop
         }
         if ($TelemetryClient) {
-            Import-Module $TelemetryClient -Force -ErrorAction SilentlyContinue
+            Import-Module $TelemetryClient -Force -ErrorAction Stop
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction Stop
         }
         if ($Config) {
-            Import-Module $Config -Force -ErrorAction SilentlyContinue
+            Import-Module $Config -Force -ErrorAction Stop
         }
 
         if ($Explain) {
@@ -45,7 +45,7 @@ function Invoke-ExchangeCalendarManager {
             return
         }
 
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append -ErrorAction Stop | Out-Null }
         Write-STStatus -Message 'ExchangeCalendarManager launched' -Level SUCCESS -Log
         if ($Simulate) {
             Write-STStatus -Message 'Simulation mode active - no Exchange operations will occur.' -Level WARN -Log
@@ -61,18 +61,18 @@ function Invoke-ExchangeCalendarManager {
     }
 
     Write-STStatus -Message 'Checking ExchangeOnlineManagement module...' -Level SUB
-    $module = Get-InstalledModule ExchangeOnlineManagement -ErrorAction SilentlyContinue
-    $updateVersion = Find-Module -Name ExchangeOnlineManagement -ErrorAction SilentlyContinue
+    $module = Get-InstalledModule ExchangeOnlineManagement -ErrorAction Stop
+    $updateVersion = Find-Module -Name ExchangeOnlineManagement -ErrorAction Stop
 
     if (-not $module) {
         Write-STStatus -Message 'Installing Exchange Online module...' -Level INFO -Log
-        Install-Module -Name ExchangeOnlineManagement -Force
+        Install-Module -Name ExchangeOnlineManagement -Force -ErrorAction Stop
     } elseif ($updateVersion -and $module.Version -lt $updateVersion.Version) {
         Write-STStatus -Message 'Updating Exchange Online module...' -Level INFO -Log
-        Update-Module -Name ExchangeOnlineManagement -Force
+        Update-Module -Name ExchangeOnlineManagement -Force -ErrorAction Stop
     }
 
-    Import-Module ExchangeOnlineManagement
+    Import-Module ExchangeOnlineManagement -ErrorAction Stop
 
     try {
         Connect-ExchangeOnline -ErrorAction Stop
@@ -124,7 +124,7 @@ function Invoke-ExchangeCalendarManager {
         Write-STStatus "Invoke-ExchangeCalendarManager failed: $_" -Level ERROR -Log
         Write-STLog -Message "Invoke-ExchangeCalendarManager failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
         $result = 'Failure'
-        return New-STErrorObject -Message $_.Exception.Message -Category 'Exchange'
+        throw
     } finally {
         if ($TranscriptPath) { Stop-Transcript | Out-Null }
         Disconnect-ExchangeOnline -Confirm:$false | Out-Null

--- a/src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1
+++ b/src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1
@@ -49,17 +49,17 @@ function Set-SharedMailboxAutoReply {
 
     try {
         if ($Logger) {
-            Import-Module $Logger -Force -ErrorAction SilentlyContinue
+            Import-Module $Logger -Force -ErrorAction Stop
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction Stop
         }
         if ($TelemetryClient) {
-            Import-Module $TelemetryClient -Force -ErrorAction SilentlyContinue
+            Import-Module $TelemetryClient -Force -ErrorAction Stop
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction Stop
         }
         if ($Config) {
-            Import-Module $Config -Force -ErrorAction SilentlyContinue
+            Import-Module $Config -Force -ErrorAction Stop
         }
 
         if ($Explain) {
@@ -67,7 +67,7 @@ function Set-SharedMailboxAutoReply {
             return
         }
 
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append -ErrorAction Stop | Out-Null }
         $sw = [System.Diagnostics.Stopwatch]::StartNew()
         $result = 'Success'
         Write-STStatus -Message 'Running Set-SharedMailboxAutoReply' -Level SUCCESS -Log
@@ -86,18 +86,18 @@ function Set-SharedMailboxAutoReply {
     }
 
     Write-STStatus -Message 'Checking ExchangeOnlineManagement module...' -Level SUB
-    $module = Get-InstalledModule ExchangeOnlineManagement -ErrorAction SilentlyContinue
-    $updateVersion = Find-Module -Name ExchangeOnlineManagement -ErrorAction SilentlyContinue
+    $module = Get-InstalledModule ExchangeOnlineManagement -ErrorAction Stop
+    $updateVersion = Find-Module -Name ExchangeOnlineManagement -ErrorAction Stop
 
     if (-not $module) {
         Write-STStatus -Message 'Installing Exchange Online module...' -Level INFO -Log
-        Install-Module -Name ExchangeOnlineManagement -Force
+        Install-Module -Name ExchangeOnlineManagement -Force -ErrorAction Stop
     } elseif ($updateVersion -and $module.Version -lt $updateVersion.Version) {
         Write-STStatus -Message 'Updating Exchange Online module...' -Level INFO -Log
-        Update-Module -Name ExchangeOnlineManagement -Force
+        Update-Module -Name ExchangeOnlineManagement -Force -ErrorAction Stop
     }
 
-    Import-Module ExchangeOnlineManagement
+    Import-Module ExchangeOnlineManagement -ErrorAction Stop
 
     try {
         if ($UseWebLogin) {
@@ -127,7 +127,7 @@ function Set-SharedMailboxAutoReply {
         Write-STStatus "Set-SharedMailboxAutoReply failed: $_" -Level ERROR -Log
         Write-STLog -Message "Set-SharedMailboxAutoReply failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
         $result = 'Failure'
-        return New-STErrorObject -Message $_.Exception.Message -Category 'Exchange'
+        throw
     } finally {
         if ($TranscriptPath) { Stop-Transcript | Out-Null }
         Disconnect-ExchangeOnline -Confirm:$false | Out-Null

--- a/src/MonitoringTools/Public/Start-HealthMonitor.ps1
+++ b/src/MonitoringTools/Public/Start-HealthMonitor.ps1
@@ -31,7 +31,7 @@ function Start-HealthMonitor {
         $collected = 0
         while (-not $script:StopHealthMonitor -and ($Count -eq 0 -or $collected -lt $Count)) {
             $start = Get-Date
-            $health = Get-SystemHealth
+            $health = Get-SystemHealth -ErrorAction Stop
             $json = $health | ConvertTo-Json -Compress
             if ($PSBoundParameters.ContainsKey('LogPath')) {
                 Write-STRichLog -Tool 'HealthMonitor' -Status 'sample' -Details $json -Path $LogPath
@@ -46,6 +46,7 @@ function Start-HealthMonitor {
             if ($sleep -gt 0) { Start-Sleep -Seconds $sleep }
         }
     } catch {
-        return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
+        Write-STLog -Message $_.Exception.Message -Level ERROR
+        throw
     }
 }

--- a/src/SupportTools/Public/Convert-ExcelToCsv.ps1
+++ b/src/SupportTools/Public/Convert-ExcelToCsv.ps1
@@ -18,13 +18,13 @@ function Convert-ExcelToCsv {
     )
 
     try {
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append -ErrorAction Stop | Out-Null }
 
         Write-STStatus "Converting $XlsxFilePath to CSV..." -Level INFO
         $excel = New-Object -ComObject Excel.Application
         $workbook = $excel.Workbooks.Open($XlsxFilePath)
 
-        $xlsxFile = Get-ChildItem $XlsxFilePath
+        $xlsxFile = Get-ChildItem $XlsxFilePath -ErrorAction Stop
         $directory = $xlsxFile.DirectoryName
         $basename = $xlsxFile.BaseName
         $csvFilePath = Join-Path $directory "$basename.csv"
@@ -41,9 +41,10 @@ function Convert-ExcelToCsv {
         [GC]::WaitForPendingFinalizers()
 
         Write-STStatus "CSV saved to $csvFilePath" -Level SUCCESS
-        return (Import-Csv $csvFilePath)
+        return (Import-Csv $csvFilePath -ErrorAction Stop)
     } catch {
-        return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
+        Write-STLog -Message $_.Exception.Message -Level ERROR
+        throw
     } finally {
         if ($TranscriptPath) { Stop-Transcript | Out-Null }
     }

--- a/src/SupportTools/Public/Invoke-NewHireUserAutomation.ps1
+++ b/src/SupportTools/Public/Invoke-NewHireUserAutomation.ps1
@@ -36,7 +36,8 @@ function Invoke-NewHireUserAutomation {
             if ($PSBoundParameters.ContainsKey('TranscriptPath')) { $args += '-TranscriptPath'; $args += $TranscriptPath }
             Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Create-NewHireUser.ps1' -Args $args -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
         } catch {
-            return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
+            Write-STLog -Message $_.Exception.Message -Level ERROR
+            throw
         }
     }
 }

--- a/src/SupportTools/Public/New-STDashboard.ps1
+++ b/src/SupportTools/Public/New-STDashboard.ps1
@@ -39,8 +39,8 @@ function New-STDashboard {
             else { $TelemetryLogPath = Join-Path $HOME 'SupportToolsTelemetry/telemetry.jsonl' }
         }
 
-        $logLines = if (Test-Path $LogPath) { Get-Content $LogPath -Tail $LogLines } else { @() }
-        $metrics  = if (Test-Path $TelemetryLogPath) { Get-STTelemetryMetrics -LogPath $TelemetryLogPath } else { @() }
+        $logLines = if (Test-Path $LogPath) { Get-Content $LogPath -Tail $LogLines -ErrorAction Stop } else { @() }
+        $metrics  = if (Test-Path $TelemetryLogPath) { Get-STTelemetryMetrics -LogPath $TelemetryLogPath -ErrorAction Stop } else { @() }
 
         $html = @()
         $html += '<html><head><title>Support Tools Dashboard</title></head><body>'
@@ -65,10 +65,11 @@ function New-STDashboard {
         }
         $html += '</body></html>'
 
-        $html -join "`n" | Out-File -FilePath $OutputPath -Encoding utf8
+        $html -join "`n" | Out-File -FilePath $OutputPath -Encoding utf8 -ErrorAction Stop
         Write-STStatus "Dashboard saved to $OutputPath" -Level SUCCESS
         return $OutputPath
     } catch {
-        return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
+        Write-STLog -Message $_.Exception.Message -Level ERROR
+        throw
     }
 }

--- a/src/SupportTools/Public/Search-ReadMe.ps1
+++ b/src/SupportTools/Public/Search-ReadMe.ps1
@@ -13,14 +13,15 @@ function Search-ReadMe {
         [string]$TranscriptPath
     )
 
-    if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+    if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append -ErrorAction Stop | Out-Null }
     try {
         Write-STStatus -Message 'Searching for readme files...' -Level INFO
-        $results = Get-ChildItem -Path C:\*readme*.txt -Recurse -File -ErrorAction SilentlyContinue
+        $results = Get-ChildItem -Path C:\*readme*.txt -Recurse -File -ErrorAction Stop
         Write-STStatus "Found $($results.Count) file(s)." -Level SUCCESS
         return $results
     } catch {
-        return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
+        Write-STLog -Message $_.Exception.Message -Level ERROR
+        throw
     } finally {
         if ($TranscriptPath) { Stop-Transcript | Out-Null }
     }

--- a/src/SupportTools/Public/Start-Countdown.ps1
+++ b/src/SupportTools/Public/Start-Countdown.ps1
@@ -14,7 +14,7 @@ function Start-Countdown {
     )
 
     try {
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append -ErrorAction Stop | Out-Null }
 
         foreach ($num in 10..1) {
             Write-STStatus $num -Level INFO
@@ -25,7 +25,8 @@ function Start-Countdown {
             Completed     = $true
         }
     } catch {
-        return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
+        Write-STLog -Message $_.Exception.Message -Level ERROR
+        throw
     } finally {
         if ($TranscriptPath) { Stop-Transcript | Out-Null }
     }

--- a/src/SupportTools/Public/Sync-SupportTools.ps1
+++ b/src/SupportTools/Public/Sync-SupportTools.ps1
@@ -32,19 +32,19 @@ function Sync-SupportTools {
     )
 
     try {
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append -ErrorAction Stop | Out-Null }
         if ($Logger) {
-            Import-Module $Logger -Force -ErrorAction SilentlyContinue
+            Import-Module $Logger -Force -ErrorAction Stop
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Logging/Logging.psd1') -Force -ErrorAction Stop
         }
         if ($TelemetryClient) {
-            Import-Module $TelemetryClient -Force -ErrorAction SilentlyContinue
+            Import-Module $TelemetryClient -Force -ErrorAction Stop
         } else {
-            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
+            Import-Module (Join-Path $PSScriptRoot '../../Telemetry/Telemetry.psd1') -Force -ErrorAction Stop
         }
         if ($Config) {
-            Import-Module $Config -Force -ErrorAction SilentlyContinue
+            Import-Module $Config -Force -ErrorAction Stop
         }
 
         if ($Explain) {
@@ -61,11 +61,11 @@ function Sync-SupportTools {
             git clone $RepositoryUrl $InstallPath
         }
 
-        Import-Module (Join-Path $InstallPath 'src/SupportTools/SupportTools.psd1') -Force
+        Import-Module (Join-Path $InstallPath 'src/SupportTools/SupportTools.psd1') -Force -ErrorAction Stop
         $sp = Join-Path $InstallPath 'src/SharePointTools/SharePointTools.psd1'
-        if (Test-Path $sp) { Import-Module $sp -Force -ErrorAction SilentlyContinue }
+        if (Test-Path $sp) { Import-Module $sp -Force -ErrorAction Stop }
         $sd = Join-Path $InstallPath 'src/ServiceDeskTools/ServiceDeskTools.psd1'
-        if (Test-Path $sd) { Import-Module $sd -Force -ErrorAction SilentlyContinue }
+        if (Test-Path $sd) { Import-Module $sd -Force -ErrorAction Stop }
 
         Write-STStatus -Message 'SupportTools synchronized' -Level FINAL
         return [pscustomobject]@{
@@ -77,7 +77,7 @@ function Sync-SupportTools {
         Write-STStatus "Sync-SupportTools failed: $_" -Level ERROR -Log
         Write-STLog -Message "Sync-SupportTools failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
         $result = 'Failure'
-        return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
+        throw
     } finally {
         if ($TranscriptPath) { Stop-Transcript | Out-Null }
         $sw.Stop()


### PR DESCRIPTION
### Summary
- update several public cmdlets to throw instead of returning `New-STErrorRecord`
- use `Write-STLog -Level ERROR` before rethrowing
- ensure cmdlets in try blocks use `-ErrorAction Stop`

### File Citations
- `src/SupportTools/Public/Convert-ExcelToCsv.ps1`【F:src/SupportTools/Public/Convert-ExcelToCsv.ps1†L20-L47】
- `src/SupportTools/Public/Sync-SupportTools.ps1`【F:src/SupportTools/Public/Sync-SupportTools.ps1†L34-L80】
- `src/SupportTools/Public/New-STDashboard.ps1`【F:src/SupportTools/Public/New-STDashboard.ps1†L42-L74】
- `src/SupportTools/Public/Search-ReadMe.ps1`【F:src/SupportTools/Public/Search-ReadMe.ps1†L14-L26】
- `src/SupportTools/Public/Start-Countdown.ps1`【F:src/SupportTools/Public/Start-Countdown.ps1†L16-L32】
- `src/SupportTools/Public/Invoke-NewHireUserAutomation.ps1`【F:src/SupportTools/Public/Invoke-NewHireUserAutomation.ps1†L30-L41】
- `src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1`【F:src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1†L18-L45】
- `src/MonitoringTools/Public/Start-HealthMonitor.ps1`【F:src/MonitoringTools/Public/Start-HealthMonitor.ps1†L30-L50】
- `src/ConfigManagementTools/Public/Add-UserToGroup.ps1`【F:src/ConfigManagementTools/Public/Add-UserToGroup.ps1†L60-L66】
- `src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1`【F:src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1†L60-L156】
- `src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1`【F:src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1†L52-L130】
- `src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1`【F:src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1†L28-L127】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f0b74b28832c9b7abbb716af84a5