### PR TITLE
Improve error handling in scripts

### DIFF
--- a/src/SupportTools/Public/Clear-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Clear-ArchiveFolder.ps1
@@ -25,7 +25,12 @@ function Clear-ArchiveFolder {
         [object]$Config
     )
     process {
-        $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        try {
+            $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
+        }
         return [pscustomobject]@{
             Script = 'CleanupArchive.ps1'
             Result = $output

--- a/src/SupportTools/Public/Clear-TempFile.ps1
+++ b/src/SupportTools/Public/Clear-TempFile.ps1
@@ -18,10 +18,22 @@ function Clear-TempFile {
 
         $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '../../..')
         Write-STStatus -Message 'Cleaning temporary files...' -Level INFO
-        $tmpFiles  = Get-ChildItem -Path $repoRoot -Recurse -Include '*.tmp' -File -ErrorAction SilentlyContinue
-        $logFiles  = Get-ChildItem -Path $repoRoot -Recurse -Include '*.log' -File -ErrorAction SilentlyContinue | Where-Object { $_.Length -eq 0 }
-        $tmpFiles | Remove-Item -Force -ErrorAction SilentlyContinue
-        $logFiles | Remove-Item -Force -ErrorAction SilentlyContinue
+        try {
+            $tmpFiles  = Get-ChildItem -Path $repoRoot -Recurse -Include '*.tmp' -File -ErrorAction Stop
+            $logFiles  = Get-ChildItem -Path $repoRoot -Recurse -Include '*.log' -File -ErrorAction Stop | Where-Object { $_.Length -eq 0 }
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
+        }
+
+        try {
+            $tmpFiles | Remove-Item -Force -ErrorAction Stop
+            $logFiles | Remove-Item -Force -ErrorAction Stop
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
+        }
+
         Write-STStatus -Message 'Cleanup complete.' -Level SUCCESS
         return [pscustomobject]@{
             RemovedTmpFileCount = $tmpFiles.Count

--- a/src/SupportTools/Public/Export-ITReport.ps1
+++ b/src/SupportTools/Public/Export-ITReport.ps1
@@ -65,6 +65,9 @@ function Export-ITReport {
                 OutputPath = $OutputPath
                 Format     = $Format
             }
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
         } finally {
             if ($TranscriptPath) { Stop-Transcript | Out-Null }
         }

--- a/src/SupportTools/Public/Export-ProductKey.ps1
+++ b/src/SupportTools/Public/Export-ProductKey.ps1
@@ -21,13 +21,25 @@ function Export-ProductKey {
     try {
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
 
-        $key = (Get-CimInstance -ClassName SoftwareLicensingService | Select-Object -ExpandProperty OA3xOriginalProductKey)
+        try {
+            $key = Get-CimInstance -ClassName SoftwareLicensingService -ErrorAction Stop | Select-Object -ExpandProperty OA3xOriginalProductKey
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
+        }
+
         if (-not $key) {
             Write-STStatus -Message 'Product key not found.' -Level WARN
             return
         }
 
-        Set-Content -Path $OutputPath -Value $key
+        try {
+            Set-Content -Path $OutputPath -Value $key -ErrorAction Stop
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
+        }
+
         Write-STStatus "Product key exported to $OutputPath" -Level SUCCESS
         return [pscustomobject]@{
             ProductKey = $key

--- a/src/SupportTools/Public/Get-UniquePermission.ps1
+++ b/src/SupportTools/Public/Get-UniquePermission.ps1
@@ -25,7 +25,12 @@ function Get-UniquePermission {
         [object]$Config
     )
     process {
-        $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Get-UniquePermissions.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        try {
+            $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Get-UniquePermissions.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
+        }
         return [pscustomobject]@{
             Script = 'Get-UniquePermissions.ps1'
             Result = $output

--- a/src/SupportTools/Public/Invoke-JobBundle.ps1
+++ b/src/SupportTools/Public/Invoke-JobBundle.ps1
@@ -39,8 +39,13 @@ function Invoke-JobBundle {
 
         $files = @($transcript)
         if (Test-Path $logFile) { $files += $logFile }
-        Compress-Archive -Path $files -DestinationPath $LogArchivePath -Force
-        Remove-Item $transcript -Force
+        try {
+            Compress-Archive -Path $files -DestinationPath $LogArchivePath -Force -ErrorAction Stop
+            Remove-Item $transcript -Force -ErrorAction Stop
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
+        }
         Write-STStatus "Logs archived to $LogArchivePath" -Level SUCCESS
         return [pscustomobject]@{
             LogArchivePath = $LogArchivePath

--- a/src/SupportTools/Public/Invoke-PerformanceAudit.ps1
+++ b/src/SupportTools/Public/Invoke-PerformanceAudit.ps1
@@ -24,7 +24,12 @@ function Invoke-PerformanceAudit {
         [object]$Config
     )
     process {
-        $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Invoke-PerformanceAudit.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        try {
+            $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Invoke-PerformanceAudit.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
+        }
         return [pscustomobject]@{
             Script = 'Invoke-PerformanceAudit.ps1'
             Result = $output

--- a/src/SupportTools/Public/New-SPUsageReport.ps1
+++ b/src/SupportTools/Public/New-SPUsageReport.ps1
@@ -24,7 +24,12 @@ function New-SPUsageReport {
         [object]$Config
     )
     process {
-        $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Generate-SPUsageReport.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        try {
+            $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Generate-SPUsageReport.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
+        }
         return [pscustomobject]@{
             Script = 'Generate-SPUsageReport.ps1'
             Result = $output

--- a/src/SupportTools/Public/Restore-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Restore-ArchiveFolder.ps1
@@ -25,7 +25,12 @@ function Restore-ArchiveFolder {
         [object]$Config
     )
     process {
-        $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "RollbackArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        try {
+            $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "RollbackArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        } catch {
+            Write-Error $_.Exception.Message
+            throw
+        }
         return [pscustomobject]@{
             Script = 'RollbackArchive.ps1'
             Result = $output


### PR DESCRIPTION
### Summary
- wrap WMI queries and file writes in `Export-ProductKey` with try/catch
- add catch blocks to `Clear-TempFile` clean-up routines
- propagate script errors in `Export-ITReport`
- guard archive and wrapper scripts with try/catch blocks

### File Citations
- `src/SupportTools/Public/Export-ProductKey.ps1`【F:src/SupportTools/Public/Export-ProductKey.ps1†L21-L51】
- `src/SupportTools/Public/Clear-TempFile.ps1`【F:src/SupportTools/Public/Clear-TempFile.ps1†L16-L45】
- `src/SupportTools/Public/Export-ITReport.ps1`【F:src/SupportTools/Public/Export-ITReport.ps1†L60-L73】
- `src/SupportTools/Public/Invoke-JobBundle.ps1`【F:src/SupportTools/Public/Invoke-JobBundle.ps1†L28-L53】
- `src/SupportTools/Public/Clear-ArchiveFolder.ps1`【F:src/SupportTools/Public/Clear-ArchiveFolder.ps1†L26-L38】
- `src/SupportTools/Public/Get-UniquePermission.ps1`【F:src/SupportTools/Public/Get-UniquePermission.ps1†L26-L38】
- `src/SupportTools/Public/Invoke-PerformanceAudit.ps1`【F:src/SupportTools/Public/Invoke-PerformanceAudit.ps1†L26-L37】
- `src/SupportTools/Public/New-SPUsageReport.ps1`【F:src/SupportTools/Public/New-SPUsageReport.ps1†L26-L37】
- `src/SupportTools/Public/Restore-ArchiveFolder.ps1`【F:src/SupportTools/Public/Restore-ArchiveFolder.ps1†L26-L38】

### Test Results
Tests failed to run due to a call depth overflow error:
```
RuntimeException: The script failed due to call depth overflow.
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f0b84dbc832c8eed1209610953e6