### PR TITLE
Add ErrorAction Stop to Invoke-STRequest

### DIFF
--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -131,9 +131,9 @@ function Invoke-STRequest {
     while ($true) {
         try {
             if ($json) {
-                $response = Invoke-RestMethod -Method $Method -Uri $Uri -Headers $Headers -Body $json -ContentType $ContentType
+                $response = Invoke-RestMethod -Method $Method -Uri $Uri -Headers $Headers -Body $json -ContentType $ContentType -ErrorAction Stop
             } else {
-                $response = Invoke-RestMethod -Method $Method -Uri $Uri -Headers $Headers
+                $response = Invoke-RestMethod -Method $Method -Uri $Uri -Headers $Headers -ErrorAction Stop
             }
             Write-STLog -Message "SUCCESS $Method $Uri" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
             return $response

--- a/tests/STCore.Helper.Tests.ps1
+++ b/tests/STCore.Helper.Tests.ps1
@@ -86,7 +86,7 @@ Describe 'STCore Helper Functions' {
                 Mock Invoke-RestMethod { @{ ok = 1 } }
                 $result = Invoke-STRequest -Method GET -Uri 'https://example.com'
                 $result.ok | Should -Be 1
-                Assert-MockCalled Invoke-RestMethod -Times 1 -ParameterFilter { $Method -eq 'GET' -and $Uri -eq 'https://example.com' }
+                Assert-MockCalled Invoke-RestMethod -Times 1 -ParameterFilter { $Method -eq 'GET' -and $Uri -eq 'https://example.com' -and $ErrorAction -eq 'Stop' }
             }
         }
 


### PR DESCRIPTION
### Summary
- ensure Invoke-RestMethod stops on HTTP errors
- verify calls use `-ErrorAction Stop` in tests

### File Citations
- `src/STCore/STCore.psm1`
- `tests/STCore.Helper.Tests.ps1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f0c09454832c9d8a58ad4566a82b