### PR TITLE
Add Show-STHelpWhenExplain helper

### DIFF
--- a/src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1
@@ -75,10 +75,7 @@ function Invoke-CompanyPlaceManagement {
             Import-Module $Config -Force -ErrorAction SilentlyContinue
         }
 
-        if ($Explain) {
-            Get-Help $MyInvocation.PSCommandPath -Full
-            return
-        }
+        if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
         Write-STStatus "Invoke-CompanyPlaceManagement -Action $Action" -Level SUCCESS -Log

--- a/src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -40,10 +40,7 @@ function Invoke-ExchangeCalendarManager {
             Import-Module $Config -Force -ErrorAction SilentlyContinue
         }
 
-        if ($Explain) {
-            Get-Help $MyInvocation.PSCommandPath -Full
-            return
-        }
+        if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
         Write-STStatus -Message 'ExchangeCalendarManager launched' -Level SUCCESS -Log

--- a/src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1
+++ b/src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1
@@ -62,10 +62,7 @@ function Set-SharedMailboxAutoReply {
             Import-Module $Config -Force -ErrorAction SilentlyContinue
         }
 
-        if ($Explain) {
-            Get-Help $MyInvocation.PSCommandPath -Full
-            return
-        }
+        if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
         $sw = [System.Diagnostics.Stopwatch]::StartNew()

--- a/src/STCore/STCore.psd1
+++ b/src/STCore/STCore.psd1
@@ -4,5 +4,5 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000000'
     Author = 'Contoso'
     Description = 'Core utility functions.'
-    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest')
+    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest','Show-STHelpWhenExplain')
 }

--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -161,7 +161,20 @@ function Invoke-STRequest {
     }
 }
 
-Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest'
+function Show-STHelpWhenExplain {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [switch]$Explain
+    )
+    if ($Explain) {
+        Get-Help $MyInvocation.PSCommandPath -Full
+        return $true
+    }
+    return $false
+}
+
+Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest','Show-STHelpWhenExplain'
 
 function Show-STCoreBanner {
     <#

--- a/src/ServiceDeskTools/Public/Add-SDTicketComment.ps1
+++ b/src/ServiceDeskTools/Public/Add-SDTicketComment.ps1
@@ -21,10 +21,7 @@ function Add-SDTicketComment {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     Write-STLog -Message "Add-SDTicketComment $Id"
     $body = @{ comment = @{ body = $Comment } }

--- a/src/ServiceDeskTools/Public/Get-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDTicket.ps1
@@ -18,10 +18,7 @@ function Get-SDTicket {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     Write-STLog -Message "Get-SDTicket $Id" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
     if ($PSCmdlet.ShouldProcess("ticket $Id", 'Get')) {

--- a/src/ServiceDeskTools/Public/Get-SDTicketHistory.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDTicketHistory.ps1
@@ -16,10 +16,7 @@ function Get-SDTicketHistory {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     Write-STLog -Message "Get-SDTicketHistory $Id" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
     if ($PSCmdlet.ShouldProcess("ticket $Id", 'Get history')) {

--- a/src/ServiceDeskTools/Public/Get-SDUser.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDUser.ps1
@@ -14,10 +14,7 @@ function Get-SDUser {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     Write-STLog -Message "Get-SDUser $Id" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
     if ($PSCmdlet.ShouldProcess("user $Id", 'Get')) {

--- a/src/ServiceDeskTools/Public/Get-ServiceDeskAsset.ps1
+++ b/src/ServiceDeskTools/Public/Get-ServiceDeskAsset.ps1
@@ -16,10 +16,7 @@ function Get-ServiceDeskAsset {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     Write-STLog -Message "Get-ServiceDeskAsset $Id"
     if ($PSCmdlet.ShouldProcess("asset $Id", 'Get')) {

--- a/src/ServiceDeskTools/Public/Get-ServiceDeskRelationship.ps1
+++ b/src/ServiceDeskTools/Public/Get-ServiceDeskRelationship.ps1
@@ -18,10 +18,7 @@ function Get-ServiceDeskRelationship {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     Write-STLog -Message "Get-ServiceDeskRelationship $AssetId $Type" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
 

--- a/src/ServiceDeskTools/Public/Get-ServiceDeskStats.ps1
+++ b/src/ServiceDeskTools/Public/Get-ServiceDeskStats.ps1
@@ -29,10 +29,7 @@ function Get-ServiceDeskStats {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $result = 'Success'

--- a/src/ServiceDeskTools/Public/Link-SDTicketToSPTask.ps1
+++ b/src/ServiceDeskTools/Public/Link-SDTicketToSPTask.ps1
@@ -26,10 +26,7 @@ function Link-SDTicketToSPTask {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     Write-STLog -Message "Link-SDTicketToSPTask $TicketId $TaskUrl" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
     $fields = @{ $FieldName = $TaskUrl }

--- a/src/ServiceDeskTools/Public/New-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/New-SDTicket.ps1
@@ -26,10 +26,7 @@ function New-SDTicket {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     Write-STLog -Message "New-SDTicket $Subject" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
     $body = @{ incident = @{ name = $Subject; description = $Description; requester_email = $RequesterEmail } }

--- a/src/ServiceDeskTools/Public/Remove-SDTicketAttachment.ps1
+++ b/src/ServiceDeskTools/Public/Remove-SDTicketAttachment.ps1
@@ -16,10 +16,7 @@ function Remove-SDTicketAttachment {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     Write-STLog -Message "Remove-SDTicketAttachment $Id" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
     if ($PSCmdlet.ShouldProcess("attachment $Id", 'Remove')) {

--- a/src/ServiceDeskTools/Public/Search-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Search-SDTicket.ps1
@@ -18,10 +18,7 @@ function Search-SDTicket {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     Write-STLog -Message "Search-SDTicket $Query" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
     $encoded = [uri]::EscapeDataString($Query)

--- a/src/ServiceDeskTools/Public/Set-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicket.ps1
@@ -21,10 +21,7 @@ function Set-SDTicket {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     Write-STLog -Message "Set-SDTicket $Id" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
     $body = @{ incident = $Fields }

--- a/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
@@ -21,10 +21,7 @@ function Set-SDTicketBulk {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     foreach ($ticketId in $Id) {
         Write-STLog -Message "Set-SDTicketBulk $ticketId" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')

--- a/src/ServiceDeskTools/Public/Submit-Ticket.ps1
+++ b/src/ServiceDeskTools/Public/Submit-Ticket.ps1
@@ -22,10 +22,7 @@ function Submit-Ticket {
         [switch]$Explain
     )
 
-    if ($Explain) {
-        Get-Help $MyInvocation.PSCommandPath -Full
-        return
-    }
+    if (Show-STHelpWhenExplain -Explain:$Explain) { return }
 
     Write-STLog -Message "Submit-Ticket $Subject" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
     if ($PSCmdlet.ShouldProcess("ticket $Subject", 'Create')) {


### PR DESCRIPTION
### Summary
- add `Show-STHelpWhenExplain` helper to STCore
- export new helper in manifest
- replace manual `-Explain` checks with `Show-STHelpWhenExplain` in ServiceDeskTools
- update ConfigManagementTools functions to use the new helper

### File Citations
- `src/STCore/STCore.psm1`
- `src/STCore/STCore.psd1`
- `src/ServiceDeskTools/Public/Add-SDTicketComment.ps1`
- `src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f12b1290832c99954e9317138f4a