### PR TITLE
Add Import-STCsv helper and refactor scripts

### DIFF
--- a/scripts/AddUsersToGroup.ps1
+++ b/scripts/AddUsersToGroup.ps1
@@ -199,7 +199,7 @@ function Start-Main {
     # Import the CSV file with UPN header
     if (-not $CsvPath) { $CsvPath = Get-CSVFilePath }
     $filePath = $CsvPath
-    $file = Import-Csv $filePath
+    $file = Import-STCsv -Path $filePath
     $users = $file.UPN
 
     $addedUsers = [System.Collections.Generic.List[object]]::new()

--- a/scripts/CleanupGroupMembership.ps1
+++ b/scripts/CleanupGroupMembership.ps1
@@ -24,7 +24,7 @@ if ($Cloud -eq 'Entra') {
     $group = Get-MgGroup -Filter "displayName eq '$GroupName'" | Select-Object -First 1
     if (-not $group) { throw "Group '$GroupName' not found." }
 
-    $users = Import-Csv $CsvPath
+    $users = Import-STCsv -Path $CsvPath
     foreach ($user in $users.UPN) {
         $obj = Get-MgUser -UserId $user -ErrorAction SilentlyContinue
         if (-not $obj) { Write-STStatus "User not found: $user" -Level WARN; continue }
@@ -41,7 +41,7 @@ if ($Cloud -eq 'Entra') {
     Import-Module ActiveDirectory -ErrorAction Stop
     $group = Get-ADGroup -Identity $GroupName -ErrorAction Stop
 
-    $users = Import-Csv $CsvPath
+    $users = Import-STCsv -Path $CsvPath
     foreach ($user in $users.UPN) {
         $obj = Get-ADUser -Filter "UserPrincipalName -eq '$user'" -ErrorAction SilentlyContinue
         if (-not $obj) { $obj = Get-ADUser -Identity $user -ErrorAction SilentlyContinue }

--- a/scripts/Search-Indicators.ps1
+++ b/scripts/Search-Indicators.ps1
@@ -21,7 +21,7 @@ function Search-Indicators {
 
     if (-not (Test-Path $IndicatorList)) { throw "Indicator list '$IndicatorList' not found." }
     Write-STStatus "Loading indicators from $IndicatorList" -Level INFO
-    $indicators = Import-Csv -Path $IndicatorList | Select-Object -ExpandProperty Indicator
+    $indicators = Import-STCsv -Path $IndicatorList | Select-Object -ExpandProperty Indicator
     $results = foreach ($ind in $indicators) {
         Write-STStatus "Searching for '$ind'" -Level SUB
         $eventHits = Get-WinEvent -LogName Security,Application,System -ErrorAction SilentlyContinue |

--- a/scripts/Set-ComputerIPAddress.ps1
+++ b/scripts/Set-ComputerIPAddress.ps1
@@ -27,7 +27,7 @@ function Set-ComputerIPAddress {
         $CSVPath
     )
 
-    $CSV = Import-Csv -Path $CSVPath
+    $CSV = Import-STCsv -Path $CSVPath
 
     if ($csv)
     {

--- a/src/STCore/STCore.psd1
+++ b/src/STCore/STCore.psd1
@@ -4,5 +4,5 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000000'
     Author = 'Contoso'
     Description = 'Core utility functions.'
-    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest')
+    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest','Import-STCsv')
 }

--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -161,7 +161,25 @@ function Invoke-STRequest {
     }
 }
 
-Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest'
+function Import-STCsv {
+    <#
+    .SYNOPSIS
+        Imports a CSV file after validating the path.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    Assert-ParameterNotNull $Path 'Path'
+    if (-not (Test-Path -Path $Path)) {
+        throw "CSV path '$Path' not found."
+    }
+
+    return Import-Csv -Path $Path
+}
+
+Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest','Import-STCsv'
 
 function Show-STCoreBanner {
     <#

--- a/tests/AddUsersToGroup.Tests.ps1
+++ b/tests/AddUsersToGroup.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'AddUsersToGroup Script' {
         function Get-Group { param([string]$GroupName) }
         function Get-GroupExistingMembers { param($Group) }
         function Get-CSVFilePath {}
-        function Import-Csv { param([string]$Path) }
+        function Import-STCsv { param([string]$Path) }
         function Get-UserID { param([string]$UserPrincipalName) }
         function Write-STStatus { param([string]$Message, [string]$Level) }
         # Stub Add-Type so the script can be dot-sourced without loading GUI assemblies
@@ -29,7 +29,7 @@ Describe 'AddUsersToGroup Script' {
         Mock Get-Group { [pscustomobject]@{ Id='1'; DisplayName='Group' } }
         Mock Get-GroupExistingMembers { @('existing@contoso.com') }
         Mock Get-CSVFilePath { 'dummy.csv' }
-        Mock Import-Csv { @([pscustomobject]@{ UPN='user1@contoso.com' }, [pscustomobject]@{ UPN='existing@contoso.com' }) }
+        Mock Import-STCsv { @([pscustomobject]@{ UPN='user1@contoso.com' }, [pscustomobject]@{ UPN='existing@contoso.com' }) }
         Mock Get-UserID { param($UserPrincipalName) [pscustomobject]@{ UserPrincipalName=$UserPrincipalName; DisplayName='User'; Id='id' } }
         Mock New-MgGroupMember {}
         Mock Add-ADGroupMember {}
@@ -44,7 +44,7 @@ Describe 'AddUsersToGroup Script' {
     }
     Safe-It 'imports the CSV' {
         Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' | Out-Null
-        Assert-MockCalled Import-Csv -ParameterFilter { $Path -eq 'dummy.csv' } -Times 1
+        Assert-MockCalled Import-STCsv -ParameterFilter { $Path -eq 'dummy.csv' } -Times 1
     }
     Safe-It 'adds only missing users' {
         Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' | Out-Null

--- a/tests/STCore.Helper.Tests.ps1
+++ b/tests/STCore.Helper.Tests.ps1
@@ -79,6 +79,23 @@ Describe 'STCore Helper Functions' {
         }
     }
 
+    Context 'Import-STCsv' {
+        Safe-It 'throws when file missing' {
+            $path = Join-Path $TestDrive 'missing.csv'
+            { Import-STCsv -Path $path } | Should -Throw
+        }
+        Safe-It 'returns imported objects' {
+            $path = Join-Path $TestDrive 'good.csv'
+            "UPN`nuser@contoso.com" | Set-Content -Path $path
+            try {
+                $res = Import-STCsv -Path $path
+                $res[0].UPN | Should -Be 'user@contoso.com'
+            } finally {
+                Remove-Item $path -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
     Context 'Invoke-STRequest' {
         Safe-It 'invokes once on success' {
             InModuleScope STCore {

--- a/tests/STCore.Tests.ps1
+++ b/tests/STCore.Tests.ps1
@@ -7,4 +7,7 @@ Describe 'STCore Module' {
     Safe-It 'exports Invoke-STRequest' {
         (Get-Command -Module STCore).Name | Should -Contain 'Invoke-STRequest'
     }
+    Safe-It 'exports Import-STCsv' {
+        (Get-Command -Module STCore).Name | Should -Contain 'Import-STCsv'
+    }
 }


### PR DESCRIPTION
### Summary
- add `Import-STCsv` helper for safe CSV import
- export `Import-STCsv` from STCore
- use `Import-STCsv` in cleanup and user management scripts
- update tests for new helper

### File Citations
- `src/STCore/STCore.psm1`【F:src/STCore/STCore.psm1†L170-L182】
- `src/STCore/STCore.psd1`【F:src/STCore/STCore.psd1†L1-L8】
- `scripts/CleanupGroupMembership.ps1`【F:scripts/CleanupGroupMembership.ps1†L27-L45】
- `scripts/AddUsersToGroup.ps1`【F:scripts/AddUsersToGroup.ps1†L199-L207】
- `tests/STCore.Helper.Tests.ps1`【F:tests/STCore.Helper.Tests.ps1†L82-L97】

### Test Results
```
Invoke-Pester: Cannot process argument transformation on parameter 'Configuration'. Cannot convert the "./PesterConfiguration.psd1" value of type "System.String" to type "PesterConfiguration".
RuntimeException: The script failed due to call depth overflow.
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f128b910832ca44f04d0790f6011