### PR TITLE
Remove manual structured log parameter

### DIFF
--- a/src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1
@@ -151,7 +151,7 @@ function Invoke-CompanyPlaceManagement {
         Write-STStatus -Message 'Invoke-CompanyPlaceManagement completed' -Level FINAL -Log
     } catch {
         Write-STStatus "Invoke-CompanyPlaceManagement failed: $_" -Level ERROR -Log
-        Write-STLog -Message "Invoke-CompanyPlaceManagement failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Invoke-CompanyPlaceManagement failed: $_" -Level ERROR
         $result = 'Failure'
         return New-STErrorObject -Message $_.Exception.Message -Category 'SharePoint'
     } finally {

--- a/src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -122,7 +122,7 @@ function Invoke-ExchangeCalendarManager {
         Write-STStatus -Message 'ExchangeCalendarManager finished' -Level FINAL -Log
     } catch {
         Write-STStatus "Invoke-ExchangeCalendarManager failed: $_" -Level ERROR -Log
-        Write-STLog -Message "Invoke-ExchangeCalendarManager failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Invoke-ExchangeCalendarManager failed: $_" -Level ERROR
         $result = 'Failure'
         return New-STErrorObject -Message $_.Exception.Message -Category 'Exchange'
     } finally {

--- a/src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1
+++ b/src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1
@@ -125,7 +125,7 @@ function Set-SharedMailboxAutoReply {
         return $result
     } catch {
         Write-STStatus "Set-SharedMailboxAutoReply failed: $_" -Level ERROR -Log
-        Write-STLog -Message "Set-SharedMailboxAutoReply failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Set-SharedMailboxAutoReply failed: $_" -Level ERROR
         $result = 'Failure'
         return New-STErrorObject -Message $_.Exception.Message -Category 'Exchange'
     } finally {

--- a/src/EntraIDTools/Public/Disable-GraphUser.ps1
+++ b/src/EntraIDTools/Public/Disable-GraphUser.ps1
@@ -56,7 +56,7 @@ function Disable-GraphUser {
     } catch {
         $result = 'Failure'
         Write-STStatus "Failed to disable $UserPrincipalName: $_" -Level ERROR -Log
-        Write-STLog -Message "Disable-GraphUser failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Disable-GraphUser failed: $_" -Level ERROR
         throw
     } finally {
         $sw.Stop()

--- a/src/EntraIDTools/Public/Get-GraphGroupDetails.ps1
+++ b/src/EntraIDTools/Public/Get-GraphGroupDetails.ps1
@@ -58,7 +58,7 @@ function Get-GraphGroupDetails {
         }
     } catch {
         $result = 'Failure'
-        Write-STLog -Message "Get-GraphGroupDetails failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Get-GraphGroupDetails failed: $_" -Level ERROR
         throw
     } finally {
         $sw.Stop()

--- a/src/EntraIDTools/Public/Get-GraphRiskySignIns.ps1
+++ b/src/EntraIDTools/Public/Get-GraphRiskySignIns.ps1
@@ -40,7 +40,7 @@ function Get-GraphRiskySignIns {
         return $response.value
     } catch {
         $result = 'Failure'
-        Write-STLog -Message "Get-GraphRiskySignIns failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Get-GraphRiskySignIns failed: $_" -Level ERROR
         throw
     } finally {
         $sw.Stop()

--- a/src/EntraIDTools/Public/Get-GraphUserDetails.ps1
+++ b/src/EntraIDTools/Public/Get-GraphUserDetails.ps1
@@ -116,7 +116,7 @@ function Get-GraphUserDetails {
         return $details
     } catch {
         $result = 'Failure'
-        Write-STLog -Message "Get-GraphUserDetails failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Get-GraphUserDetails failed: $_" -Level ERROR
         throw
     } finally {
         $sw.Stop()

--- a/src/EntraIDTools/Public/Get-UserInfoHybrid.ps1
+++ b/src/EntraIDTools/Public/Get-UserInfoHybrid.ps1
@@ -58,7 +58,7 @@ function Get-UserInfoHybrid {
         return [pscustomobject]$combined
     } catch {
         $result = 'Failure'
-        Write-STLog -Message "Get-UserInfoHybrid failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Get-UserInfoHybrid failed: $_" -Level ERROR
         throw
     } finally {
         $sw.Stop()

--- a/src/IncidentResponseTools/Public/Get-CommonSystemInfo.ps1
+++ b/src/IncidentResponseTools/Public/Get-CommonSystemInfo.ps1
@@ -67,7 +67,7 @@ function Get-CommonSystemInfo {
             return $commonSystemInfoObj
         } catch {
             Write-STStatus "Get-CommonSystemInfo failed: $_" -Level ERROR -Log
-            Write-STLog -Message "Get-CommonSystemInfo failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+            Write-STLog -Message "Get-CommonSystemInfo failed: $_" -Level ERROR
             $result = 'Failure'
             return New-STErrorObject -Message $_.Exception.Message -Category 'WMI'
         } finally {

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -232,7 +232,7 @@ function Write-STStatus {
     }
 
     Write-Host "$prefix $Message" -ForegroundColor $color
-    if ($Log) { Write-STLog -Message "$prefix $Message" -Structured:$($env:ST_LOG_STRUCTURED -eq '1') }
+    if ($Log) { Write-STLog -Message "$prefix $Message" }
 }
 
 function Show-STPrompt {

--- a/src/OutTools/OutTools.psm1
+++ b/src/OutTools/OutTools.psm1
@@ -28,7 +28,7 @@ function Out-STBanner {
     }
     Write-STDivider -Title $title -Style heavy
     Write-STStatus "Run 'Get-Command -Module $($Info.Module)' to view available tools." -Level SUB
-    Write-STLog -Message "$($Info.Module) module loaded" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "$($Info.Module) module loaded"
 }
 
 Export-ModuleMember -Function 'Out-STStatus','Out-STBanner'

--- a/src/PerformanceTools/PerformanceTools.psm1
+++ b/src/PerformanceTools/PerformanceTools.psm1
@@ -31,7 +31,7 @@ function Measure-STCommand {
         & $ScriptBlock
     } catch {
         Write-STStatus "Measure-STCommand failed: $_" -Level ERROR -Log
-        Write-STLog -Message "Measure-STCommand failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Measure-STCommand failed: $_" -Level ERROR
         $errorObj = New-STErrorObject -Message $_.Exception.Message -Category 'Performance'
     } finally {
         $sw.Stop()

--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -58,7 +58,7 @@ function Write-STDebug {
     )
     if ($env:ST_DEBUG -eq '1') {
         Write-STStatus "[DEBUG] $Message" -Level SUB
-        Write-STLog "[DEBUG] $Message" -Level INFO -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog "[DEBUG] $Message" -Level INFO
     }
 }
 
@@ -112,14 +112,14 @@ function Invoke-STRequest {
     if (-not $ChaosMode) { $ChaosMode = [bool]$env:ST_CHAOS_MODE }
     if ($ChaosMode) {
         $delay = Get-Random -Minimum 500 -Maximum 1500
-        Write-STLog -Message "CHAOS MODE delay $delay ms" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "CHAOS MODE delay $delay ms"
         Start-Sleep -Milliseconds $delay
         $roll = Get-Random -Minimum 1 -Maximum 100
         if ($roll -le 10) { throw 'ChaosMode: simulated throttling (429 Too Many Requests)' }
         elseif ($roll -le 20) { throw 'ChaosMode: simulated server error (500 Internal Server Error)' }
     }
 
-    Write-STLog -Message "STRequest $Method $Uri" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "STRequest $Method $Uri"
     Write-Verbose "Invoking $Method $Uri"
 
     $json = if ($PSBoundParameters.ContainsKey('Body')) {
@@ -135,17 +135,17 @@ function Invoke-STRequest {
             } else {
                 $response = Invoke-RestMethod -Method $Method -Uri $Uri -Headers $Headers
             }
-            Write-STLog -Message "SUCCESS $Method $Uri" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+            Write-STLog -Message "SUCCESS $Method $Uri"
             return $response
         } catch [System.Net.WebException],[Microsoft.PowerShell.Commands.HttpResponseException] {
             $status = $_.Exception.Response.StatusCode.value__
             $msg    = $_.Exception.Message
-            Write-STLog -Message "HTTP $status $msg" -Level 'ERROR' -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+            Write-STLog -Message "HTTP $status $msg" -Level 'ERROR'
             if ($status -eq 429 -or ($status -ge 500 -and $status -lt 600)) {
                 if ($attempt -lt $maxRetries) {
                     $retryAfter = $_.Exception.Response.Headers['Retry-After']
                     if ($retryAfter) { $delay = [int]$retryAfter } else { $delay = [math]::Pow(2, $attempt) }
-                    Write-STLog -Message "Retry $attempt in $delay sec" -Level WARN -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+                    Write-STLog -Message "Retry $attempt in $delay sec" -Level WARN
                     Write-Verbose "Retrying in $delay seconds"
                     Start-Sleep -Seconds $delay
                     $attempt++
@@ -155,7 +155,7 @@ function Invoke-STRequest {
             $errorObj = New-STErrorObject -Message "HTTP $status $msg" -Category 'HTTP'
             throw $errorObj
         } catch {
-            Write-STLog -Message "ERROR $Method $Uri :: $_" -Level 'ERROR' -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+            Write-STLog -Message "ERROR $Method $Uri :: $_" -Level 'ERROR'
             throw
         }
     }

--- a/src/STPlatform/Public/Connect-EntraID.ps1
+++ b/src/STPlatform/Public/Connect-EntraID.ps1
@@ -60,7 +60,7 @@ function Connect-EntraID {
     } catch {
         $result = 'Failure'
         Write-STStatus "Connect-EntraID failed: $_" -Level ERROR -Log
-        Write-STLog -Message "Connect-EntraID failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Connect-EntraID failed: $_" -Level ERROR
         throw
     } finally {
         $sw.Stop()

--- a/src/STPlatform/Public/Connect-STPlatform.ps1
+++ b/src/STPlatform/Public/Connect-STPlatform.ps1
@@ -117,7 +117,7 @@ function Connect-STPlatform {
     } catch {
         $result = 'Failure'
         Write-STStatus "Connect-STPlatform failed: $_" -Level ERROR -Log
-        Write-STLog -Message "Connect-STPlatform failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Connect-STPlatform failed: $_" -Level ERROR
         throw
     } finally {
         $sw.Stop()

--- a/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
+++ b/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
@@ -25,7 +25,7 @@ function Invoke-SDRequest {
     if (-not $ChaosMode) { $ChaosMode = [bool]$env:ST_CHAOS_MODE }
     if ($ChaosMode) {
         $delay = Get-Random -Minimum 500 -Maximum 1500
-        Write-STLog -Message "CHAOS MODE delay $delay ms" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "CHAOS MODE delay $delay ms"
         Start-Sleep -Milliseconds $delay
         $roll = Get-Random -Minimum 1 -Maximum 100
         if ($roll -le 10) { throw 'ChaosMode: simulated throttling (429 Too Many Requests)' }
@@ -37,7 +37,7 @@ function Invoke-SDRequest {
 
     $headers = @{ 'X-Samanage-Authorization' = "Bearer $token"; Accept = 'application/json' }
     $uri = $baseUri.TrimEnd('/') + $Path
-    Write-STLog -Message "SDRequest $Method $uri" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "SDRequest $Method $uri"
     Write-Verbose "Invoking $Method $uri"
     $json = if ($Body) { $Body | ConvertTo-Json -Depth 10 } else { $null }
     Invoke-SDRestWithRetry -Method $Method -Uri $uri -Headers $headers -Body $json

--- a/src/ServiceDeskTools/Private/Invoke-SDRestWithRetry.ps1
+++ b/src/ServiceDeskTools/Private/Invoke-SDRestWithRetry.ps1
@@ -15,17 +15,17 @@ function Invoke-SDRestWithRetry {
             } else {
                 $response = Invoke-RestMethod -Method $Method -Uri $Uri -Headers $Headers
             }
-            Write-STLog -Message "SUCCESS $Method $Uri" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+            Write-STLog -Message "SUCCESS $Method $Uri"
             return $response
         } catch [System.Net.WebException],[Microsoft.PowerShell.Commands.HttpResponseException] {
             $status = $_.Exception.Response.StatusCode.value__
             $msg    = $_.Exception.Message
-            Write-STLog -Message "HTTP $status $msg" -Level 'ERROR' -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+            Write-STLog -Message "HTTP $status $msg" -Level 'ERROR'
             if ($status -eq 429 -or ($status -ge 500 -and $status -lt 600)) {
                 if ($attempt -lt $maxRetries) {
                     $retryAfter = $_.Exception.Response.Headers['Retry-After']
                     if ($retryAfter) { $delay = [int]$retryAfter } else { $delay = [math]::Pow(2, $attempt) }
-                    Write-STLog -Message "Retry $attempt in $delay sec" -Level WARN -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+                    Write-STLog -Message "Retry $attempt in $delay sec" -Level WARN
                     Write-Verbose "Retrying in $delay seconds"
                     Start-Sleep -Seconds $delay
                     $attempt++
@@ -35,7 +35,7 @@ function Invoke-SDRestWithRetry {
             $errorObj = New-STErrorObject -Message "HTTP $status $msg" -Category 'HTTP'
             throw $errorObj
         } catch {
-            Write-STLog -Message "ERROR $Method $Uri :: $_" -Level 'ERROR' -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+            Write-STLog -Message "ERROR $Method $Uri :: $_" -Level 'ERROR'
             throw
         }
     }

--- a/src/ServiceDeskTools/Public/Get-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDTicket.ps1
@@ -23,7 +23,7 @@ function Get-SDTicket {
         return
     }
 
-    Write-STLog -Message "Get-SDTicket $Id" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "Get-SDTicket $Id"
     if ($PSCmdlet.ShouldProcess("ticket $Id", 'Get')) {
         $result = Invoke-SDRequest -Method 'GET' -Path "/incidents/$Id.json" -ChaosMode:$ChaosMode
         return [TicketObject]::FromApiResponse($result)

--- a/src/ServiceDeskTools/Public/Get-SDTicketHistory.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDTicketHistory.ps1
@@ -21,7 +21,7 @@ function Get-SDTicketHistory {
         return
     }
 
-    Write-STLog -Message "Get-SDTicketHistory $Id" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "Get-SDTicketHistory $Id"
     if ($PSCmdlet.ShouldProcess("ticket $Id", 'Get history')) {
         $result = Invoke-SDRequest -Method 'GET' -Path "/incidents/$Id/audits.json" -ChaosMode:$ChaosMode
         return $result

--- a/src/ServiceDeskTools/Public/Get-SDUser.ps1
+++ b/src/ServiceDeskTools/Public/Get-SDUser.ps1
@@ -19,7 +19,7 @@ function Get-SDUser {
         return
     }
 
-    Write-STLog -Message "Get-SDUser $Id" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "Get-SDUser $Id"
     if ($PSCmdlet.ShouldProcess("user $Id", 'Get')) {
         Invoke-SDRequest -Method 'GET' -Path "/users/$Id.json" -ChaosMode:$ChaosMode
     }

--- a/src/ServiceDeskTools/Public/Get-ServiceDeskRelationship.ps1
+++ b/src/ServiceDeskTools/Public/Get-ServiceDeskRelationship.ps1
@@ -23,7 +23,7 @@ function Get-ServiceDeskRelationship {
         return
     }
 
-    Write-STLog -Message "Get-ServiceDeskRelationship $AssetId $Type" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "Get-ServiceDeskRelationship $AssetId $Type"
 
     $path = '/asset_relationships.json'
     $query = @()

--- a/src/ServiceDeskTools/Public/Get-ServiceDeskStats.ps1
+++ b/src/ServiceDeskTools/Public/Get-ServiceDeskStats.ps1
@@ -36,7 +36,7 @@ function Get-ServiceDeskStats {
 
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $result = 'Success'
-    Write-STLog -Message "Get-ServiceDeskStats" -Structured:$($env:ST_LOG_STRUCTURED -eq '1') -Metadata @{ start=$StartDate; end=$EndDate }
+    Write-STLog -Message "Get-ServiceDeskStats" -Metadata @{ start=$StartDate; end=$EndDate }
     try {
         $after  = [uri]::EscapeDataString($StartDate.ToString('yyyy-MM-dd'))
         $before = [uri]::EscapeDataString($EndDate.ToString('yyyy-MM-dd'))
@@ -50,7 +50,7 @@ function Get-ServiceDeskStats {
     }
     catch {
         $result = 'Failure'
-        Write-STLog -Message "Get-ServiceDeskStats failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Get-ServiceDeskStats failed: $_" -Level ERROR
         throw
     }
     finally {

--- a/src/ServiceDeskTools/Public/Link-SDTicketToSPTask.ps1
+++ b/src/ServiceDeskTools/Public/Link-SDTicketToSPTask.ps1
@@ -31,7 +31,7 @@ function Link-SDTicketToSPTask {
         return
     }
 
-    Write-STLog -Message "Link-SDTicketToSPTask $TicketId $TaskUrl" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "Link-SDTicketToSPTask $TicketId $TaskUrl"
     $fields = @{ $FieldName = $TaskUrl }
     if ($PSCmdlet.ShouldProcess("ticket $TicketId", 'Link to SP task')) {
         Set-SDTicket -Id $TicketId -Fields $fields -ChaosMode:$ChaosMode

--- a/src/ServiceDeskTools/Public/New-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/New-SDTicket.ps1
@@ -31,7 +31,7 @@ function New-SDTicket {
         return
     }
 
-    Write-STLog -Message "New-SDTicket $Subject" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "New-SDTicket $Subject"
     $body = @{ incident = @{ name = $Subject; description = $Description; requester_email = $RequesterEmail } }
     if ($PSCmdlet.ShouldProcess("ticket $Subject", 'Create')) {
         Invoke-SDRequest -Method 'POST' -Path '/incidents.json' -Body $body -ChaosMode:$ChaosMode

--- a/src/ServiceDeskTools/Public/Remove-SDTicketAttachment.ps1
+++ b/src/ServiceDeskTools/Public/Remove-SDTicketAttachment.ps1
@@ -21,7 +21,7 @@ function Remove-SDTicketAttachment {
         return
     }
 
-    Write-STLog -Message "Remove-SDTicketAttachment $Id" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "Remove-SDTicketAttachment $Id"
     if ($PSCmdlet.ShouldProcess("attachment $Id", 'Remove')) {
         Invoke-SDRequest -Method 'DELETE' -Path "/attachments/$Id.json" -ChaosMode:$ChaosMode
     }

--- a/src/ServiceDeskTools/Public/Search-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Search-SDTicket.ps1
@@ -23,7 +23,7 @@ function Search-SDTicket {
         return
     }
 
-    Write-STLog -Message "Search-SDTicket $Query" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "Search-SDTicket $Query"
     $encoded = [uri]::EscapeDataString($Query)
     if ($PSCmdlet.ShouldProcess('incidents', "Search for $Query")) {
         $result = Invoke-SDRequest -Method 'GET' -Path "/incidents.json?search=$encoded" -ChaosMode:$ChaosMode

--- a/src/ServiceDeskTools/Public/Set-SDTicket.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicket.ps1
@@ -26,7 +26,7 @@ function Set-SDTicket {
         return
     }
 
-    Write-STLog -Message "Set-SDTicket $Id" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "Set-SDTicket $Id"
     $body = @{ incident = $Fields }
     if ($PSCmdlet.ShouldProcess("ticket $Id", 'Update')) {
         Invoke-SDRequest -Method 'PUT' -Path "/incidents/$Id.json" -Body $body -ChaosMode:$ChaosMode

--- a/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
+++ b/src/ServiceDeskTools/Public/Set-SDTicketBulk.ps1
@@ -27,7 +27,7 @@ function Set-SDTicketBulk {
     }
 
     foreach ($ticketId in $Id) {
-        Write-STLog -Message "Set-SDTicketBulk $ticketId" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Set-SDTicketBulk $ticketId"
         if ($PSCmdlet.ShouldProcess("ticket $ticketId", 'Update')) {
             Set-SDTicket -Id $ticketId -Fields $Fields -ChaosMode:$ChaosMode
         }

--- a/src/ServiceDeskTools/Public/Submit-Ticket.ps1
+++ b/src/ServiceDeskTools/Public/Submit-Ticket.ps1
@@ -27,7 +27,7 @@ function Submit-Ticket {
         return
     }
 
-    Write-STLog -Message "Submit-Ticket $Subject" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "Submit-Ticket $Subject"
     if ($PSCmdlet.ShouldProcess("ticket $Subject", 'Create')) {
         New-SDTicket -Subject $Subject -Description $Description -RequesterEmail $RequesterEmail -ChaosMode:$ChaosMode
     }

--- a/src/SharePointTools/Public/Test-SPToolsSiteAdmin.ps1
+++ b/src/SharePointTools/Public/Test-SPToolsSiteAdmin.ps1
@@ -31,7 +31,7 @@ function Test-SPToolsSiteAdmin {
 
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $result = 'Success'
-    Write-STLog -Message "Test-SPToolsSiteAdmin $SiteUrl" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "Test-SPToolsSiteAdmin $SiteUrl"
 
     try {
         Write-STStatus 'Checking HTTP response' -Level INFO
@@ -40,7 +40,7 @@ function Test-SPToolsSiteAdmin {
         Write-STStatus "HTTP status: $status" -Level SUB
     } catch {
         $result = 'Failure'
-        Write-STLog -Message "HTTP check failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "HTTP check failed: $_" -Level ERROR
         throw
     }
 
@@ -52,13 +52,13 @@ function Test-SPToolsSiteAdmin {
         Write-STStatus "Site admin: $isAdmin" -Level SUB
     } catch {
         $result = 'Failure'
-        Write-STLog -Message "Admin rights check failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Admin rights check failed: $_" -Level ERROR
         throw
     } finally {
         Disconnect-PnPOnline -ErrorAction SilentlyContinue
         $sw.Stop()
         Write-STTelemetryEvent -ScriptName 'Test-SPToolsSiteAdmin' -Result $result -Duration $sw.Elapsed -Category 'SharePointTools'
-        Write-STLog -Message 'Test-SPToolsSiteAdmin result' -Structured:$($env:ST_LOG_STRUCTURED -eq '1') -Metadata @{ url = $SiteUrl; status = $status; isAdmin = $isAdmin }
+        Write-STLog -Message 'Test-SPToolsSiteAdmin result' -Metadata @{ url = $SiteUrl; status = $status; isAdmin = $isAdmin }
     }
 
     [pscustomobject]@{

--- a/src/SupportTools/Public/Sync-SupportTools.ps1
+++ b/src/SupportTools/Public/Sync-SupportTools.ps1
@@ -75,7 +75,7 @@ function Sync-SupportTools {
         }
     } catch {
         Write-STStatus "Sync-SupportTools failed: $_" -Level ERROR -Log
-        Write-STLog -Message "Sync-SupportTools failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STLog -Message "Sync-SupportTools failed: $_" -Level ERROR
         $result = 'Failure'
         return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
     } finally {


### PR DESCRIPTION
### Summary
- rely on ST_LOG_STRUCTURED instead of passing `-Structured:$($env:ST_LOG_STRUCTURED -eq '1')`

### File Citations
- `src/STCore/STCore.psm1`【F:src/STCore/STCore.psm1†L60-L122】
- `src/Logging/Logging.psm1`【F:src/Logging/Logging.psm1†L228-L235】
- `src/OutTools/OutTools.psm1`【F:src/OutTools/OutTools.psm1†L29-L31】
- `src/ServiceDeskTools/Private/Invoke-SDRequest.ps1`【F:src/ServiceDeskTools/Private/Invoke-SDRequest.ps1†L24-L42】

### Test Results
- ❌ `/tmp/pwsh -NoLogo -NoProfile -File /tmp/run_tests.ps1` exited with errors due to call depth overflow and other issues【ce22b2†L1-L29】

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f12a440c832ca3b16fc62e5ca4f9