### PR TITLE
Implement Write-STFailure and use in connection scripts

### DIFF
--- a/src/STCore/STCore.psd1
+++ b/src/STCore/STCore.psd1
@@ -4,5 +4,5 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000000'
     Author = 'Contoso'
     Description = 'Core utility functions.'
-    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest')
+    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Write-STFailure','Test-IsElevated','Get-STConfig','Invoke-STRequest')
 }

--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -62,6 +62,17 @@ function Write-STDebug {
     }
 }
 
+function Write-STFailure {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Message
+    )
+    Write-STStatus -Message $Message -Level ERROR -Log
+    Write-STLog -Message $Message -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+}
+
 function Test-IsElevated {
     [CmdletBinding()]
     param()
@@ -161,7 +172,7 @@ function Invoke-STRequest {
     }
 }
 
-Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest'
+Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Write-STFailure','Test-IsElevated','Get-STConfig','Invoke-STRequest'
 
 function Show-STCoreBanner {
     <#

--- a/src/STPlatform/Public/Connect-EntraID.ps1
+++ b/src/STPlatform/Public/Connect-EntraID.ps1
@@ -59,8 +59,7 @@ function Connect-EntraID {
         Write-STStatus -Message 'Graph connection established.' -Level SUCCESS -Log
     } catch {
         $result = 'Failure'
-        Write-STStatus "Connect-EntraID failed: $_" -Level ERROR -Log
-        Write-STLog -Message "Connect-EntraID failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STFailure "Connect-EntraID failed: $_"
         throw
     } finally {
         $sw.Stop()

--- a/src/STPlatform/Public/Connect-STPlatform.ps1
+++ b/src/STPlatform/Public/Connect-STPlatform.ps1
@@ -116,8 +116,7 @@ function Connect-STPlatform {
         Write-STStatus -Message 'Connections initialized.' -Level SUCCESS -Log
     } catch {
         $result = 'Failure'
-        Write-STStatus "Connect-STPlatform failed: $_" -Level ERROR -Log
-        Write-STLog -Message "Connect-STPlatform failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+        Write-STFailure "Connect-STPlatform failed: $_"
         throw
     } finally {
         $sw.Stop()


### PR DESCRIPTION
### Summary
- add Write-STFailure to centralize error logging
- export Write-STFailure from STCore
- use Write-STFailure in Connect-STPlatform and Connect-EntraID

### File Citations
- `src/STCore/STCore.psm1` lines 65-75 and 175
- `src/STCore/STCore.psd1` lines 1-8
- `src/STPlatform/Public/Connect-STPlatform.ps1` lines 116-124
- `src/STPlatform/Public/Connect-EntraID.ps1` lines 59-67

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f12713c8832c87b7d97a5c38e207