### PR TITLE
Fix naming for PowerShell functions

### DIFF
--- a/docs/EntraIDTools.md
+++ b/docs/EntraIDTools.md
@@ -41,7 +41,7 @@ Install-Module MSAL.PS
 | `Get-GraphUserDetails` | Retrieve metadata for a user | `Get-GraphUserDetails -UserPrincipalName user@contoso.com -TenantId <tenant> -ClientId <app>` |
 | `Get-GraphGroupDetails` | Retrieve metadata for a group | `Get-GraphGroupDetails -GroupId <id> -TenantId <tenant> -ClientId <app>` |
 | `Get-GraphSignInLogs` | Retrieve user sign-in events | `Get-GraphSignInLogs -UserPrincipalName user@contoso.com -TenantId <tenant> -ClientId <app>` |
-| `Watch-GraphSignIns` | Ticket risky sign-ins automatically | `Watch-GraphSignIns -TenantId <tenant> -ClientId <app> -RequesterEmail admin@example.com` |
+| `Monitor-GraphSignIn` | Ticket risky sign-ins automatically | `Monitor-GraphSignIn -TenantId <tenant> -ClientId <app> -RequesterEmail admin@example.com` |
 
 The command requires an Entra ID application registration. Provide the tenant ID, client ID and optional client secret for authentication.
 

--- a/docs/EntraIDTools/Monitor-GraphSignIn.md
+++ b/docs/EntraIDTools/Monitor-GraphSignIn.md
@@ -5,13 +5,13 @@ online version:
 schema: 2.0.0
 ---
 
-# Watch-GraphSignIns
+# Monitor-GraphSignIn
 
 Monitor sign-in logs and create Service Desk tickets for risky events.
 
 ## SYNTAX
 ```powershell
-Watch-GraphSignIns [-UserPrincipalName <String>] [-StartTime <DateTime>] [-EndTime <DateTime>]
+Monitor-GraphSignIn [-UserPrincipalName <String>] [-StartTime <DateTime>] [-EndTime <DateTime>]
  [-TenantId] <String> [-ClientId] <String> [-ClientSecret <String>] [-RequesterEmail] <String>
  [-Threshold <String>] [-ChaosMode] [<CommonParameters>]
 ```
@@ -23,7 +23,7 @@ meets or exceeds `-Threshold` trigger ticket creation. Use `-ChaosMode` or set
 
 ## EXAMPLE
 ```powershell
-PS C:\> Watch-GraphSignIns -TenantId <tenant> -ClientId <app> -RequesterEmail 'admin@example.com'
+PS C:\> Monitor-GraphSignIn -TenantId <tenant> -ClientId <app> -RequesterEmail 'admin@example.com'
 ```
 Retrieves the last hour of sign-ins and opens Service Desk tickets for any high risk events.
 

--- a/docs/IncidentResponseTools.md
+++ b/docs/IncidentResponseTools.md
@@ -16,6 +16,6 @@ Import-Module ./src/IncidentResponseTools/IncidentResponseTools.psd1
 | `Invoke-IncidentResponse` | Collect forensic data for an incident. | `Invoke-IncidentResponse` |
 | `Invoke-RemoteAudit` | Run Get-CommonSystemInfo on remote computers. | `Invoke-RemoteAudit -ComputerName PC1` |
 | `Invoke-FullSystemAudit` | Execute common audit scripts and summarize. | `Invoke-FullSystemAudit` |
-| `Submit-SystemInfoTicket` | Upload system info and create a ticket. | `Submit-SystemInfoTicket -SiteName IT -RequesterEmail user@contoso.com` |
+| `New-SystemInfoTicket` | Upload system info and create a ticket. | `New-SystemInfoTicket -SiteName IT -RequesterEmail user@contoso.com` |
 | `Update-Sysmon` | Update the Sysmon installation. | `Update-Sysmon -SourcePath D:\Tools` |
 | `Search-Indicators` | Find indicators in logs, registry and files. | `Search-Indicators -IndicatorList .\indicators.csv` |

--- a/docs/IncidentResponseTools/Invoke-IncidentResponse.md
+++ b/docs/IncidentResponseTools/Invoke-IncidentResponse.md
@@ -20,4 +20,4 @@ Invoke-IncidentResponse [[-Arguments] <Object[]>] [[-TranscriptPath] <String>] [
 Wraps the `Invoke-IncidentResponse.ps1` script. The command gathers recent event logs,
 process details, network connections and other information into a timestamped folder.
 If unsigned processes are found running from temporary directories a ticket is created
-via `Submit-Ticket` in the ServiceDeskTools module.
+via `New-SimpleTicket` in the ServiceDeskTools module.

--- a/docs/IncidentResponseTools/New-SystemInfoTicket.md
+++ b/docs/IncidentResponseTools/New-SystemInfoTicket.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Submit-SystemInfoTicket
+# New-SystemInfoTicket
 
 ## SYNOPSIS
 Collects system information, uploads it to SharePoint and creates a Service Desk ticket.
@@ -13,17 +13,17 @@ Collects system information, uploads it to SharePoint and creates a Service Desk
 ## SYNTAX
 
 ```
-Submit-SystemInfoTicket [-SiteName] <String> [-RequesterEmail] <String> [[-Subject] <String>] [[-Description] <String>] [[-LibraryName] <String>] [[-FolderPath] <String>] [[-TranscriptPath] <String>] [[-SmtpServer] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+New-SystemInfoTicket [-SiteName] <String> [-RequesterEmail] <String> [[-Subject] <String>] [[-Description] <String>] [[-LibraryName] <String>] [[-FolderPath] <String>] [[-TranscriptPath] <String>] [[-SmtpServer] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Wraps the Submit-SystemInfoTicket.ps1 script. The command gathers common system information, uploads the JSON report to the specified SharePoint site and then opens a Service Desk ticket referencing the uploaded file.
+Wraps the New-SystemInfoTicket.ps1 script. The command gathers common system information, uploads the JSON report to the specified SharePoint site and then opens a Service Desk ticket referencing the uploaded file.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> Submit-SystemInfoTicket -SiteName IT -RequesterEmail "jane.doe@example.com"
+PS C:\> New-SystemInfoTicket -SiteName IT -RequesterEmail "jane.doe@example.com"
 ```
 Collects system info, uploads the report to the IT site and creates a ticket for jane.doe@example.com.
 

--- a/docs/MaintenancePlan.md
+++ b/docs/MaintenancePlan.md
@@ -15,8 +15,8 @@ Import-Module ./src/MaintenancePlan/MaintenancePlan.psd1
 | `Import-MaintenancePlan` | Load a plan from JSON. | `Import-MaintenancePlan -Path plan.json` |
 | `Invoke-MaintenancePlan` | Execute plan steps. | `Invoke-MaintenancePlan -Plan $plan` |
 | `Show-MaintenancePlan` | Display a summary of a plan. | `Show-MaintenancePlan -Plan $plan` |
-| `Schedule-MaintenancePlan` | Register a task or generate cron. | `Schedule-MaintenancePlan -PlanPath plan.json -Cron '0 3 * * 0' -Name Weekly` |
+| `Register-MaintenancePlan` | Register a task or generate cron. | `Register-MaintenancePlan -PlanPath plan.json -Cron '0 3 * * 0' -Name Weekly` |
 
 ### Scheduling
-`Schedule-MaintenancePlan` registers a Windows scheduled task when running on Windows.
+`Register-MaintenancePlan` registers a Windows scheduled task when running on Windows.
 On Linux or macOS it outputs a cron line you can add with `crontab -e`.

--- a/docs/ServiceDeskTools.md
+++ b/docs/ServiceDeskTools.md
@@ -16,8 +16,8 @@ Commands for interacting with the Service Desk ticketing API. **ServiceDeskTools
 | `Get-ServiceDeskRelationship` | Retrieve asset relationships | `Get-ServiceDeskRelationship -AssetId 99 -Type 'component'` |
 | `Get-ServiceDeskStats` | Summarize incidents by status | `Get-ServiceDeskStats -StartDate (Get-Date).AddDays(-1) -EndDate (Get-Date)` |
 | `Set-SDTicketBulk` | Apply updates to multiple incidents | `Set-SDTicketBulk -Id 1,2,3 -Fields @{ status='Closed' }` |
-| `Link-SDTicketToSPTask` | Add a related SharePoint task link | `Link-SDTicketToSPTask -TicketId 42 -TaskUrl 'https://contoso.sharepoint.com/tasks/1'` |
-| `Submit-Ticket` | Create a Service Desk incident with minimal parameters | `Submit-Ticket -Subject 'Alert' -Description 'Issue detected' -RequesterEmail 'ops@example.com'` |
+| `Join-SDTicketToSPTask` | Add a related SharePoint task link | `Join-SDTicketToSPTask -TicketId 42 -TaskUrl 'https://contoso.sharepoint.com/tasks/1'` |
+| `New-SimpleTicket` | Create a Service Desk incident with minimal parameters | `New-SimpleTicket -Subject 'Alert' -Description 'Issue detected' -RequesterEmail 'ops@example.com'` |
 | `Export-SDConfig` | Output current Service Desk configuration to JSON | `Export-SDConfig -Path ./sdconfig.json` |
 
 `SD_API_TOKEN` must be set in the environment. Optionally set `SD_BASE_URI` if your Service Desk API uses a custom URL. Use `SD_ASSET_BASE_URI` when assets are hosted on a separate endpoint.

--- a/docs/ServiceDeskTools/Join-SDTicketToSPTask.md
+++ b/docs/ServiceDeskTools/Join-SDTicketToSPTask.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Link-SDTicketToSPTask
+# Join-SDTicketToSPTask
 
 ## SYNOPSIS
 Associates a Service Desk incident with a SharePoint task.
@@ -13,7 +13,7 @@ Associates a Service Desk incident with a SharePoint task.
 ## SYNTAX
 
 ```
-Link-SDTicketToSPTask [-TicketId] <Int32> [-TaskUrl] <String> [-FieldName <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Join-SDTicketToSPTask [-TicketId] <Int32> [-TaskUrl] <String> [-FieldName <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/docs/ServiceDeskTools/New-SimpleTicket.md
+++ b/docs/ServiceDeskTools/New-SimpleTicket.md
@@ -5,6 +5,6 @@ online version:
 schema: 2.0.0
 ---
 
-# Submit-Ticket
+# New-SimpleTicket
 
 Creates a Service Desk incident using the supplied subject, description and requester email. This is a wrapper around `New-SDTicket`.

--- a/docs/SharePointTools.md
+++ b/docs/SharePointTools.md
@@ -47,11 +47,11 @@ All functions emit short, high contrast messages following the style in [ModuleS
 | `Get-SPToolsPreservationHoldReport` | Report Preservation Hold Library size. | `SiteName`, `[SiteUrl]`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `Get-SPToolsPreservationHoldReport -SiteName HR` |
 | `Get-SPToolsAllPreservationHoldReports` | Run `Get-SPToolsPreservationHoldReport` for all sites. | none | `Get-SPToolsAllPreservationHoldReports` |
 | `Get-SPPermissionsReport` | List role assignments for a site or folder. | `SiteUrl`, `[FolderUrl]`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `Get-SPPermissionsReport -SiteUrl https://contoso.sharepoint.com/sites/hr` |
-| `Clean-SPVersionHistory` | Trim file versions beyond a limit. | `SiteUrl`, `[LibraryName]`, `[KeepVersions]`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `Clean-SPVersionHistory -SiteUrl https://contoso.sharepoint.com/sites/hr -KeepVersions 5` |
+| `Clear-SPVersionHistory` | Trim file versions beyond a limit. | `SiteUrl`, `[LibraryName]`, `[KeepVersions]`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `Clear-SPVersionHistory -SiteUrl https://contoso.sharepoint.com/sites/hr -KeepVersions 5` |
 | `Find-OrphanedSPFiles` | Locate files not modified for a period. | `SiteUrl`, `[LibraryName]`, `[Days]`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `Find-OrphanedSPFiles -SiteUrl https://contoso.sharepoint.com/sites/hr -Days 90` |
 | `Get-SPToolsFileReport` | Export file metadata from a library. | `SiteName`, `[SiteUrl]`, `[LibraryName]`, `[ClientId]`, `[TenantId]`, `[CertPath]`, `[ReportPath]` | `Get-SPToolsFileReport -SiteName HR -ReportPath files.csv` |
 | `Select-SPToolsFolder` | Recursively choose a library folder. | `SiteName`, `[SiteUrl]`, `[LibraryName]`, `[Filter]` | `Select-SPToolsFolder -SiteName HR` |
-| `List-OneDriveUsage` | Report OneDrive storage use across the tenant. | `AdminUrl`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `List-OneDriveUsage -AdminUrl https://contoso-admin.sharepoint.com` |
+| `Get-OneDriveUsage` | Report OneDrive storage use across the tenant. | `AdminUrl`, `[ClientId]`, `[TenantId]`, `[CertPath]` | `Get-OneDriveUsage -AdminUrl https://contoso-admin.sharepoint.com` |
 
 
 ## Example Scenarios

--- a/docs/SharePointTools/Clear-SPVersionHistory.md
+++ b/docs/SharePointTools/Clear-SPVersionHistory.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Clean-SPVersionHistory
+# Clear-SPVersionHistory
 
 ## SYNOPSIS
 See DESCRIPTION section.
@@ -13,7 +13,7 @@ See DESCRIPTION section.
 ## SYNTAX
 
 ```
-Clean-SPVersionHistory [-SiteUrl] <String> [[-LibraryName] <String>] [[-KeepVersions] <Int32>]
+Clear-SPVersionHistory [-SiteUrl] <String> [[-LibraryName] <String>] [[-KeepVersions] <Int32>]
  [[-ClientId] <String>] [[-TenantId] <String>] [[-CertPath] <String>] [-ProgressAction <ActionPreference>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
@@ -25,10 +25,10 @@ Deletes old document versions from a library.
 
 ### Example 1
 ```powershell
-PS C:\> Clean-SPVersionHistory -? # replace with actual parameters
+PS C:\> Clear-SPVersionHistory -? # replace with actual parameters
 ```
 
-Demonstrates typical usage of Clean-SPVersionHistory.
+Demonstrates typical usage of Clear-SPVersionHistory.
 
 ## PARAMETERS
 

--- a/docs/SharePointTools/Get-OneDriveUsage.md
+++ b/docs/SharePointTools/Get-OneDriveUsage.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# List-OneDriveUsage
+# Get-OneDriveUsage
 
 ## SYNOPSIS
 See DESCRIPTION section.
@@ -13,7 +13,7 @@ See DESCRIPTION section.
 ## SYNTAX
 
 ```
-List-OneDriveUsage [-AdminUrl] <String> [[-ClientId] <String>] [[-TenantId] <String>] [[-CertPath] <String>]
+Get-OneDriveUsage [-AdminUrl] <String> [[-ClientId] <String>] [[-TenantId] <String>] [[-CertPath] <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -24,10 +24,10 @@ Lists storage usage details for each OneDrive site.
 
 ### Example 1
 ```powershell
-PS C:\> List-OneDriveUsage -? # replace with actual parameters
+PS C:\> Get-OneDriveUsage -? # replace with actual parameters
 ```
 
-Demonstrates typical usage of List-OneDriveUsage.
+Demonstrates typical usage of Get-OneDriveUsage.
 
 ## PARAMETERS
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -23,7 +23,7 @@ This document summarizes the key security aspects of the PowerShell modules cont
 
 - Commands call `Write-STLog` which writes to `$env:ST_LOG_PATH` or `~/SupportToolsLogs/supporttools.log`.
 - Structured events can be recorded via `Write-STRichLog` and `Write-STTelemetryEvent` in `~/SupportToolsTelemetry/telemetry.jsonl` when telemetry is enabled.
-- Scripts like `Submit-SystemInfoTicket` optionally start a transcript log file for additional auditing.
+- Scripts like `New-SystemInfoTicket` optionally start a transcript log file for additional auditing.
 - Actions performed through SharePoint or Exchange are also captured in their respective tenant audit logs when enabled.
 
 ## Risks of Misuse

--- a/scripts/Invoke-IncidentResponse.ps1
+++ b/scripts/Invoke-IncidentResponse.ps1
@@ -7,7 +7,7 @@
     connections, local administrators, services and startup items.
     Results are saved to a timestamped folder. If unsigned processes
     executing from temporary directories are detected, the script
-    triggers Submit-Ticket from the ServiceDeskTools module.
+    triggers New-SimpleTicket from the ServiceDeskTools module.
 .PARAMETER OutputDirectory
     Directory to store collected data. Defaults to a folder in TEMP.
 .PARAMETER RequesterEmail
@@ -87,7 +87,7 @@ try {
         $desc = "Unsigned processes found in temp locations on $env:COMPUTERNAME.`n`n" +
                  ($highRisk | Format-Table Name,Path -AutoSize | Out-String) +
                  "`nReport folder: $OutputDirectory"
-        Submit-Ticket -Subject "Incident Response - $env:COMPUTERNAME" -Description $desc -RequesterEmail $RequesterEmail | Out-Null
+        New-SimpleTicket -Subject "Incident Response - $env:COMPUTERNAME" -Description $desc -RequesterEmail $RequesterEmail | Out-Null
     }
 
     Write-STStatus "Incident response data saved to $OutputDirectory" -Level SUCCESS -Log

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,7 +24,7 @@ The following table provides a brief description of each script.
 | **SimpleCountdown.ps1** | Outputs a simple countdown from 10 to 1. |
 | **Update-Sysmon.ps1** | Reinstalls Sysmon from a removable drive and verifies it is running. |
 | **Invoke-IncidentResponse.ps1** | Collects forensic data for immediate incident response and submits a ticket when threats are detected. |
-| **Submit-SystemInfoTicket.ps1** | Collects system info, uploads it to SharePoint and opens a Service Desk ticket. |
+| **New-SystemInfoTicket.ps1** | Collects system info, uploads it to SharePoint and opens a Service Desk ticket. |
 | **SS_DEPLOYMENT_TEMPLATE.ps1** | Template for sneaker net deployments that installs agents and configures a system. |
 | **Configure-SharePointTools.ps1** | Prompts for SharePoint application values and saves them to a settings file. |
 | **Test-SPToolsPrereqs.ps1** | Checks for PnP.PowerShell and installs it if requested. |

--- a/src/EntraIDTools/EntraIDTools.psd1
+++ b/src/EntraIDTools/EntraIDTools.psd1
@@ -11,5 +11,5 @@
             ReleaseNotes = 'Initial stable release of EntraIDTools.'
         }
     }
-    FunctionsToExport = @('Get-GraphUserDetails','Get-GraphGroupDetails','Get-UserInfoHybrid','Disable-GraphUser','Get-GraphSignInLogs','Get-GraphRiskySignIns','Watch-GraphSignIns')
+    FunctionsToExport = @('Get-GraphUserDetails','Get-GraphGroupDetails','Get-UserInfoHybrid','Disable-GraphUser','Get-GraphSignInLogs','Get-GraphRiskySignIns','Monitor-GraphSignIn')
 }

--- a/src/EntraIDTools/EntraIDTools.psm1
+++ b/src/EntraIDTools/EntraIDTools.psm1
@@ -8,7 +8,7 @@ Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue -DisableName
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Get-GraphUserDetails','Get-GraphGroupDetails','Get-UserInfoHybrid','Disable-GraphUser','Get-GraphSignInLogs','Get-GraphRiskySignIns','Watch-GraphSignIns'
+Export-ModuleMember -Function 'Get-GraphUserDetails','Get-GraphGroupDetails','Get-UserInfoHybrid','Disable-GraphUser','Get-GraphSignInLogs','Get-GraphRiskySignIns','Monitor-GraphSignIn'
 
 function Show-EntraIDToolsBanner {
     <#

--- a/src/EntraIDTools/Public/Watch-GraphSignIns.ps1
+++ b/src/EntraIDTools/Public/Watch-GraphSignIns.ps1
@@ -1,4 +1,5 @@
-function Watch-GraphSignIns {
+# Original name: Watch-GraphSignIns
+function Monitor-GraphSignIn {
     <#
     .SYNOPSIS
         Monitor sign-in logs and create Service Desk tickets when risky events are detected.
@@ -25,7 +26,7 @@ function Watch-GraphSignIns {
     .PARAMETER ChaosMode
         Enable chaos testing during ticket creation.
     .EXAMPLE
-        Watch-GraphSignIns -TenantId <tenant> -ClientId <app> -RequesterEmail 'admin@example.com'
+        Monitor-GraphSignIn -TenantId <tenant> -ClientId <app> -RequesterEmail 'admin@example.com'
     #>
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
@@ -48,7 +49,7 @@ function Watch-GraphSignIns {
     if ($Explain) { Get-Help $MyInvocation.PSCommandPath -Full; return }
 
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
-    Write-STLog -Message 'Watch-GraphSignIns' -Structured -Metadata @{ threshold=$Threshold }
+    Write-STLog -Message 'Monitor-GraphSignIn' -Structured -Metadata @{ threshold=$Threshold }
     $result = 'Success'
     try {
         $logs = Get-GraphSignInLogs -UserPrincipalName $UserPrincipalName -StartTime $StartTime -EndTime $EndTime -TenantId $TenantId -ClientId $ClientId -ClientSecret $ClientSecret
@@ -68,10 +69,10 @@ function Watch-GraphSignIns {
         return $logs
     } catch {
         $result = 'Failure'
-        Write-STLog -Message "Watch-GraphSignIns failed: $_" -Level ERROR
+        Write-STLog -Message "Monitor-GraphSignIn failed: $_" -Level ERROR
         throw
     } finally {
         $sw.Stop()
-        Write-STTelemetryEvent -ScriptName 'Watch-GraphSignIns' -Result $result -Duration $sw.Elapsed
+        Write-STTelemetryEvent -ScriptName 'Monitor-GraphSignIn' -Result $result -Duration $sw.Elapsed
     }
 }

--- a/src/IncidentResponseTools/IncidentResponseTools.psd1
+++ b/src/IncidentResponseTools/IncidentResponseTools.psd1
@@ -13,7 +13,7 @@
         'Invoke-IncidentResponse',
         'Invoke-RemoteAudit',
         'Invoke-FullSystemAudit',
-        'Submit-SystemInfoTicket',
+        'New-SystemInfoTicket',
         'Update-Sysmon',
         'Search-Indicators'
     )

--- a/src/IncidentResponseTools/IncidentResponseTools.psm1
+++ b/src/IncidentResponseTools/IncidentResponseTools.psm1
@@ -10,7 +10,7 @@ Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue -DisableName
 Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
-Export-ModuleMember -Function 'Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Invoke-IncidentResponse','Invoke-RemoteAudit','Invoke-FullSystemAudit','Submit-SystemInfoTicket','Update-Sysmon','Search-Indicators'
+Export-ModuleMember -Function 'Get-CommonSystemInfo','Get-FailedLogin','Get-NetworkShare','Invoke-IncidentResponse','Invoke-RemoteAudit','Invoke-FullSystemAudit','New-SystemInfoTicket','Update-Sysmon','Search-Indicators'
 
 function Show-IncidentResponseToolsBanner {
     [CmdletBinding()]

--- a/src/IncidentResponseTools/Public/Invoke-FullSystemAudit.ps1
+++ b/src/IncidentResponseTools/Public/Invoke-FullSystemAudit.ps1
@@ -44,7 +44,8 @@ function Invoke-FullSystemAudit {
         $summary = [ordered]@{}
         $errors  = @()
 
-        function Run-Step {
+        # Original name: Run-Step
+        function Invoke-Step {
             param(
                 [string]$Name,
                 [scriptblock]$Action
@@ -69,12 +70,12 @@ function Invoke-FullSystemAudit {
             return $out
         }
 
-        $summary.CommonSystemInfo = Run-Step 'Get-CommonSystemInfo' { Get-CommonSystemInfo }
-        $summary.SPUsageReport    = Run-Step 'Generate-SPUsageReport' {
+        $summary.CommonSystemInfo = Invoke-Step 'Get-CommonSystemInfo' { Get-CommonSystemInfo }
+        $summary.SPUsageReport    = Invoke-Step 'Generate-SPUsageReport' {
             Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Generate-SPUsageReport.ps1' -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
         }
-        $summary.FailedLogin      = Run-Step 'Get-FailedLogin' { Get-FailedLogin }
-        $summary.PerformanceAudit = Run-Step 'Invoke-PerformanceAudit' {
+        $summary.FailedLogin      = Invoke-Step 'Get-FailedLogin' { Get-FailedLogin }
+        $summary.PerformanceAudit = Invoke-Step 'Invoke-PerformanceAudit' {
             Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Invoke-PerformanceAudit.ps1' -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
         }
 

--- a/src/IncidentResponseTools/Public/New-SystemInfoTicket.ps1
+++ b/src/IncidentResponseTools/Public/New-SystemInfoTicket.ps1
@@ -1,4 +1,5 @@
-function Submit-SystemInfoTicket {
+# Original name: Submit-SystemInfoTicket
+function New-SystemInfoTicket {
     <#
     .SYNOPSIS
         Collect system info, upload it to SharePoint, and create a Service Desk ticket.

--- a/src/Logging/Logging.psd1
+++ b/src/Logging/Logging.psd1
@@ -5,5 +5,5 @@
     Author = 'Contoso'
     Description = 'Provides centralized logging utilities for all modules.'
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','Logging','Internal') } }
-    FunctionsToExport = @('Write-STLog','Write-STRichLog','Write-STStatus','Show-STPrompt','Write-STDivider','Write-STBlock','Write-STClosing','Sanitize-STMessage')
+    FunctionsToExport = @('Write-STLog','Write-STRichLog','Write-STStatus','Show-STPrompt','Write-STDivider','Write-STBlock','Write-STClosing','Protect-STMessage')
 }

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -11,7 +11,8 @@ if ($SupportToolsConfig.maintenanceMode) {
     exit 1
 }
 
-function Sanitize-STMessage {
+# Original name: Sanitize-STMessage
+function Protect-STMessage {
     [CmdletBinding(PositionalBinding=$false)]
     param(
         [Parameter(Mandatory)][string]$Message
@@ -66,7 +67,7 @@ function Write-STLog {
         $Message = $Metric
         if (-not $Structured) { $Structured = $true }
     }
-    $Message = Sanitize-STMessage -Message $Message
+    $Message = Protect-STMessage -Message $Message
     if (-not $Structured -and $env:ST_LOG_STRUCTURED -eq '1') {
         $Structured = $true
     }
@@ -189,11 +190,11 @@ function Write-STRichLog {
         tool      = $Tool
         status    = $Status
     }
-    if ($PSBoundParameters.ContainsKey('User'))     { $entry.user = Sanitize-STMessage -Message $User }
+    if ($PSBoundParameters.ContainsKey('User'))     { $entry.user = Protect-STMessage -Message $User }
     if ($PSBoundParameters.ContainsKey('Duration')) { $entry.duration = $Duration.ToString() }
     if ($PSBoundParameters.ContainsKey('Details'))  {
         $entry.details = @()
-        foreach ($d in $Details) { $entry.details += Sanitize-STMessage -Message $d }
+        foreach ($d in $Details) { $entry.details += Protect-STMessage -Message $d }
     }
 
     ($entry | ConvertTo-Json -Depth 5 -Compress) | Out-File -FilePath $logFile -Append -Encoding utf8
@@ -295,7 +296,7 @@ function Write-STClosing {
     Write-Host "┌──[ $Message ]──────────────" -ForegroundColor DarkGray
 }
 
-Export-ModuleMember -Function 'Write-STLog','Write-STRichLog','Write-STStatus','Show-STPrompt','Write-STDivider','Write-STBlock','Write-STClosing','Sanitize-STMessage'
+Export-ModuleMember -Function 'Write-STLog','Write-STRichLog','Write-STStatus','Show-STPrompt','Write-STDivider','Write-STBlock','Write-STClosing','Protect-STMessage'
 
 function Show-LoggingBanner {
     <#

--- a/src/MaintenancePlan/MaintenancePlan.psd1
+++ b/src/MaintenancePlan/MaintenancePlan.psd1
@@ -6,5 +6,5 @@
     Description = 'Create and manage maintenance plans.'
     RequiredModules = @('Logging')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','Maintenance','Internal') } }
-    FunctionsToExport = @('New-MaintenancePlan','Export-MaintenancePlan','Import-MaintenancePlan','Invoke-MaintenancePlan','Schedule-MaintenancePlan','Show-MaintenancePlan')
+    FunctionsToExport = @('New-MaintenancePlan','Export-MaintenancePlan','Import-MaintenancePlan','Invoke-MaintenancePlan','Register-MaintenancePlan','Show-MaintenancePlan')
 }

--- a/src/MaintenancePlan/Public/Register-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/Register-MaintenancePlan.ps1
@@ -1,4 +1,5 @@
-function Schedule-MaintenancePlan {
+# Original name: Schedule-MaintenancePlan
+function Register-MaintenancePlan {
     <#
     .SYNOPSIS
         Schedule execution of a maintenance plan.
@@ -12,7 +13,7 @@ function Schedule-MaintenancePlan {
     .PARAMETER Name
         Name for the scheduled task or cron job.
     .EXAMPLE
-        Schedule-MaintenancePlan -PlanPath plan.json -Cron '0 3 * * 0' -Name Weekly
+        Register-MaintenancePlan -PlanPath plan.json -Cron '0 3 * * 0' -Name Weekly
     #>
     [CmdletBinding()]
     param(

--- a/src/ServiceDeskTools/Public/Join-SDTicketToSPTask.ps1
+++ b/src/ServiceDeskTools/Public/Join-SDTicketToSPTask.ps1
@@ -1,4 +1,5 @@
-function Link-SDTicketToSPTask {
+# Original name: Link-SDTicketToSPTask
+function Join-SDTicketToSPTask {
     <#
     .SYNOPSIS
         Associates a Service Desk incident with a SharePoint task.
@@ -31,9 +32,9 @@ function Link-SDTicketToSPTask {
         return
     }
 
-    Write-STLog -Message "Link-SDTicketToSPTask $TicketId $TaskUrl" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "Join-SDTicketToSPTask $TicketId $TaskUrl" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
     $fields = @{ $FieldName = $TaskUrl }
-    if ($PSCmdlet.ShouldProcess("ticket $TicketId", 'Link to SP task')) {
+    if ($PSCmdlet.ShouldProcess("ticket $TicketId", 'Join to SP task')) {
         Set-SDTicket -Id $TicketId -Fields $fields -ChaosMode:$ChaosMode
     }
 }

--- a/src/ServiceDeskTools/Public/New-SimpleTicket.ps1
+++ b/src/ServiceDeskTools/Public/New-SimpleTicket.ps1
@@ -1,4 +1,5 @@
-function Submit-Ticket {
+# Original name: Submit-Ticket
+function New-SimpleTicket {
     <#
     .SYNOPSIS
         Creates a basic Service Desk incident.
@@ -27,7 +28,7 @@ function Submit-Ticket {
         return
     }
 
-    Write-STLog -Message "Submit-Ticket $Subject" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
+    Write-STLog -Message "New-SimpleTicket $Subject" -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
     if ($PSCmdlet.ShouldProcess("ticket $Subject", 'Create')) {
         New-SDTicket -Subject $Subject -Description $Description -RequesterEmail $RequesterEmail -ChaosMode:$ChaosMode
     }

--- a/src/ServiceDeskTools/ServiceDeskTools.psd1
+++ b/src/ServiceDeskTools/ServiceDeskTools.psd1
@@ -6,5 +6,5 @@
     Description = 'Commands for interacting with the Service Desk ticketing system.'
     RequiredModules = @('Logging','Telemetry')
     PrivateData = @{ PSData = @{ Tags = @('PowerShell','ServiceDesk','Internal') } }
-    FunctionsToExport = @('Add-SDTicketComment','Export-SDConfig','Get-SDTicket','Get-SDTicketHistory','Get-ServiceDeskAsset','Get-ServiceDeskRelationship','Get-ServiceDeskStats','Get-SDUser','Link-SDTicketToSPTask','New-SDTicket','Remove-SDTicketAttachment','Search-SDTicket','Set-SDTicket','Set-SDTicketBulk','Submit-Ticket')
+    FunctionsToExport = @('Add-SDTicketComment','Export-SDConfig','Get-SDTicket','Get-SDTicketHistory','Get-ServiceDeskAsset','Get-ServiceDeskRelationship','Get-ServiceDeskStats','Get-SDUser','Join-SDTicketToSPTask','New-SDTicket','Remove-SDTicketAttachment','Search-SDTicket','Set-SDTicket','Set-SDTicketBulk','New-SimpleTicket')
 }

--- a/src/SharePointTools/SharePointTools.psd1
+++ b/src/SharePointTools/SharePointTools.psd1
@@ -32,11 +32,11 @@
         'Get-SPToolsPreservationHoldReport',
         'Get-SPToolsAllPreservationHoldReports',
         'Get-SPPermissionsReport',
-        'Clean-SPVersionHistory',
+        'Clear-SPVersionHistory',
         'Find-OrphanedSPFiles',
         'Get-SPToolsFileReport',
         'Select-SPToolsFolder',
-        'List-OneDriveUsage',
+        'Get-OneDriveUsage',
         'Test-SPToolsPrereqs',
         'Test-SPToolsSiteAdmin',
         'Invoke-SPSiteAudit'

--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -1007,12 +1007,13 @@ function Get-SPPermissionsReport {
     $report
 }
 
-function Clean-SPVersionHistory {
+# Original name: Clean-SPVersionHistory
+function Clear-SPVersionHistory {
     <#
     .SYNOPSIS
         Deletes old document versions from a library.
     .EXAMPLE
-        Clean-SPVersionHistory -SiteUrl 'https://contoso.sharepoint.com'
+        Clear-SPVersionHistory -SiteUrl 'https://contoso.sharepoint.com'
     #>
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
@@ -1235,12 +1236,13 @@ function Get-SPToolsFileReport {
     Write-SPToolsHacker 'File report complete'
     $report
 }
-function List-OneDriveUsage {
+# Original name: List-OneDriveUsage
+function Get-OneDriveUsage {
     <#
     .SYNOPSIS
         Lists usage information for all OneDrive sites.
     .EXAMPLE
-        List-OneDriveUsage -AdminUrl 'https://contoso-admin.sharepoint.com'
+        Get-OneDriveUsage -AdminUrl 'https://contoso-admin.sharepoint.com'
     #>
     [CmdletBinding()]
     param(
@@ -1270,7 +1272,7 @@ function List-OneDriveUsage {
     Write-SPToolsHacker 'Report complete'
     $report
 }
-Export-ModuleMember -Function 'Invoke-YFArchiveCleanup','Invoke-IBCCentralFilesArchiveCleanup','Invoke-MexCentralFilesArchiveCleanup','Invoke-ArchiveCleanup','Invoke-YFFileVersionCleanup','Invoke-IBCCentralFilesFileVersionCleanup','Invoke-MexCentralFilesFileVersionCleanup','Invoke-FileVersionCleanup','Invoke-SharingLinkCleanup','Invoke-YFSharingLinkCleanup','Invoke-IBCCentralFilesSharingLinkCleanup','Invoke-MexCentralFilesSharingLinkCleanup','Get-SPToolsSettings','Get-SPToolsSiteUrl','Add-SPToolsSite','Set-SPToolsSite','Remove-SPToolsSite','Get-SPToolsLibraryReport','Get-SPToolsAllLibraryReports','Out-SPToolsLibraryReport','Get-SPToolsRecycleBinReport','Clear-SPToolsRecycleBin','Get-SPToolsAllRecycleBinReports','Get-SPToolsFileReport','Get-SPToolsPreservationHoldReport','Get-SPToolsAllPreservationHoldReports','Get-SPPermissionsReport','Clean-SPVersionHistory','Find-OrphanedSPFiles','Select-SPToolsFolder','List-OneDriveUsage','Test-SPToolsPrereqs','Test-SPToolsSiteAdmin','Invoke-SPSiteAudit' -Variable 'SharePointToolsSettings'
+Export-ModuleMember -Function 'Invoke-YFArchiveCleanup','Invoke-IBCCentralFilesArchiveCleanup','Invoke-MexCentralFilesArchiveCleanup','Invoke-ArchiveCleanup','Invoke-YFFileVersionCleanup','Invoke-IBCCentralFilesFileVersionCleanup','Invoke-MexCentralFilesFileVersionCleanup','Invoke-FileVersionCleanup','Invoke-SharingLinkCleanup','Invoke-YFSharingLinkCleanup','Invoke-IBCCentralFilesSharingLinkCleanup','Invoke-MexCentralFilesSharingLinkCleanup','Get-SPToolsSettings','Get-SPToolsSiteUrl','Add-SPToolsSite','Set-SPToolsSite','Remove-SPToolsSite','Get-SPToolsLibraryReport','Get-SPToolsAllLibraryReports','Out-SPToolsLibraryReport','Get-SPToolsRecycleBinReport','Clear-SPToolsRecycleBin','Get-SPToolsAllRecycleBinReports','Get-SPToolsFileReport','Get-SPToolsPreservationHoldReport','Get-SPToolsAllPreservationHoldReports','Get-SPPermissionsReport','Clear-SPVersionHistory','Find-OrphanedSPFiles','Select-SPToolsFolder','Get-OneDriveUsage','Test-SPToolsPrereqs','Test-SPToolsSiteAdmin','Invoke-SPSiteAudit' -Variable 'SharePointToolsSettings'
 
 function Register-SPToolsCompleters {
     <#

--- a/tests/EntraIDTools.Tests.ps1
+++ b/tests/EntraIDTools.Tests.ps1
@@ -25,8 +25,8 @@ Describe 'EntraIDTools Module' {
         Safe-It 'Exports Get-GraphSignInLogs' {
             (Get-Command -Module EntraIDTools).Name | Should -Contain 'Get-GraphSignInLogs'
         }
-        Safe-It 'Exports Watch-GraphSignIns' {
-            (Get-Command -Module EntraIDTools).Name | Should -Contain 'Watch-GraphSignIns'
+        Safe-It 'Exports Monitor-GraphSignIn' {
+            (Get-Command -Module EntraIDTools).Name | Should -Contain 'Monitor-GraphSignIn'
         }
     }
 
@@ -71,7 +71,7 @@ Describe 'EntraIDTools Module' {
         Safe-It 'Creates tickets for risky sign-ins' {
             Mock Get-GraphSignInLogs { @(@{ userPrincipalName='u'; createdDateTime=(Get-Date); ipAddress='1.2.3.4'; riskLevelAggregated='high' }) } -ModuleName EntraIDTools
             Mock New-SDTicket {} -ModuleName EntraIDTools
-            Watch-GraphSignIns -TenantId 'tid' -ClientId 'cid' -RequesterEmail 'r@contoso.com'
+            Monitor-GraphSignIn -TenantId 'tid' -ClientId 'cid' -RequesterEmail 'r@contoso.com'
             Assert-MockCalled New-SDTicket -ModuleName EntraIDTools -Times 1
         }
     }

--- a/tests/EntraIDTools/Monitor-GraphSignIn.Tests.ps1
+++ b/tests/EntraIDTools/Monitor-GraphSignIn.Tests.ps1
@@ -1,6 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
-Describe 'Watch-GraphSignIns batch output' {
+Describe 'Monitor-GraphSignIn batch output' {
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force
@@ -19,7 +19,7 @@ Describe 'Watch-GraphSignIns batch output' {
                 else { @() }
             } -ModuleName EntraIDTools
 
-            $result = Watch-GraphSignIns -TenantId 'tid' -ClientId 'cid' -RequesterEmail 'r@test' -Count 2 -IntervalSeconds 0
+            $result = Monitor-GraphSignIn -TenantId 'tid' -ClientId 'cid' -RequesterEmail 'r@test' -Count 2 -IntervalSeconds 0
 
             $result.Count | Should -Be 10
             $script:calls | Should -Be 2

--- a/tests/IncidentResponseTools/New-SystemInfoTicket.Tests.ps1
+++ b/tests/IncidentResponseTools/New-SystemInfoTicket.Tests.ps1
@@ -1,7 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
-Describe 'Submit-SystemInfoTicket.ps1 script' {
+Describe 'New-SystemInfoTicket.ps1 script' {
     BeforeAll {
-        $ScriptPath = Join-Path $PSScriptRoot/../.. 'scripts/Submit-SystemInfoTicket.ps1'
+        $ScriptPath = Join-Path $PSScriptRoot/../.. 'scripts/New-SystemInfoTicket.ps1'
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/IncidentResponseTools/IncidentResponseTools.psd1 -Force
         Import-Module $PSScriptRoot/../../src/SharePointTools/SharePointTools.psd1 -Force

--- a/tests/IncidentResponseTools/PublicFunctions.Tests.ps1
+++ b/tests/IncidentResponseTools/PublicFunctions.Tests.ps1
@@ -11,7 +11,7 @@ Describe 'IncidentResponseTools public functions' {
         'Get-NetworkShare'      = 'Get-NetworkShares.ps1'
         'Invoke-IncidentResponse' = 'Invoke-IncidentResponse.ps1'
         'Search-Indicators'     = 'Search-Indicators.ps1'
-        'Submit-SystemInfoTicket' = 'Submit-SystemInfoTicket.ps1'
+        'New-SystemInfoTicket' = 'New-SystemInfoTicket.ps1'
         'Update-Sysmon'         = 'Update-Sysmon.ps1'
     }
 
@@ -20,7 +20,7 @@ Describe 'IncidentResponseTools public functions' {
         InModuleScope IncidentResponseTools {
             Mock Invoke-ScriptFile {} -ModuleName IncidentResponseTools
             switch ($case.Key) {
-                'Submit-SystemInfoTicket' { & $case.Key -SiteName 'A' -RequesterEmail 'r@c.com' }
+                'New-SystemInfoTicket' { & $case.Key -SiteName 'A' -RequesterEmail 'r@c.com' }
                 default { & $case.Key }
             }
             Assert-MockCalled Invoke-ScriptFile -ModuleName IncidentResponseTools -Times 1 -ParameterFilter { $Name -eq $case.Value }
@@ -32,7 +32,7 @@ Describe 'IncidentResponseTools public functions' {
         InModuleScope IncidentResponseTools {
             Mock Invoke-ScriptFile { throw 'fail' } -ModuleName IncidentResponseTools
             switch ($case.Key) {
-                'Submit-SystemInfoTicket' { { & $case.Key -SiteName 'A' -RequesterEmail 'r@c.com' } | Should -Throw }
+                'New-SystemInfoTicket' { { & $case.Key -SiteName 'A' -RequesterEmail 'r@c.com' } | Should -Throw }
                 default { { & $case.Key } | Should -Throw }
             }
         }

--- a/tests/MaintenancePlan.Tests.ps1
+++ b/tests/MaintenancePlan.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'MaintenancePlan Module' {
             function Register-ScheduledTask {}
             function New-ScheduledTaskAction { param($Execute,$Argument) $script:arg = $Argument; [pscustomobject]@{Execute=$Execute;Argument=$Argument} }
             function New-ScheduledTaskTrigger { param([string]$Daily,[string]$At) [pscustomobject]@{At=$At} }
-            Schedule-MaintenancePlan -PlanPath '/tmp/p.json' -Cron '5 1 * * *' -Name 'MP'
+            Register-MaintenancePlan -PlanPath '/tmp/p.json' -Cron '5 1 * * *' -Name 'MP'
             $expectedModule = Join-Path (Get-Module MaintenancePlan).ModuleBase 'MaintenancePlan.psd1'
             $script:arg | Should -Match [Regex]::Escape($expectedModule)
             $script:arg | Should -Match '/tmp/p.json'
@@ -56,7 +56,7 @@ Describe 'MaintenancePlan Module' {
     Safe-It 'returns cron entry on non-windows' {
         InModuleScope MaintenancePlan {
             Set-Variable -Name IsWindows -Value $false -Scope Script -Force
-            $entry = Schedule-MaintenancePlan -PlanPath '/tmp/p.json' -Cron '5 1 * * *' -Name 'MP'
+            $entry = Register-MaintenancePlan -PlanPath '/tmp/p.json' -Cron '5 1 * * *' -Name 'MP'
             $expectedModule = Join-Path (Get-Module MaintenancePlan).ModuleBase 'MaintenancePlan.psd1'
             $entry | Should -Match [Regex]::Escape($expectedModule)
             $entry | Should -Match '/tmp/p.json'

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'ServiceDeskTools Module' {
         $expected = @(
             'Get-SDTicket','Get-SDTicketHistory','New-SDTicket','Set-SDTicket',
             'Add-SDTicketComment','Search-SDTicket','Get-ServiceDeskAsset',
-            'Get-SDUser','Set-SDTicketBulk','Link-SDTicketToSPTask','Export-SDConfig'
+            'Get-SDUser','Set-SDTicketBulk','Join-SDTicketToSPTask','Export-SDConfig'
         )
         $exported = (Get-Command -Module ServiceDeskTools).Name
         foreach ($cmd in $expected) {
@@ -117,9 +117,9 @@ Describe 'ServiceDeskTools Module' {
             Assert-MockCalled Set-SDTicket -ModuleName ServiceDeskTools -ParameterFilter { $Id -eq 10 } -Times 1
             Assert-MockCalled Set-SDTicket -ModuleName ServiceDeskTools -ParameterFilter { $Id -eq 11 } -Times 1
         }
-        Safe-It 'Link-SDTicketToSPTask calls Set-SDTicket' {
+        Safe-It 'Join-SDTicketToSPTask calls Set-SDTicket' {
             Mock Set-SDTicket {} -ModuleName ServiceDeskTools
-            Link-SDTicketToSPTask -TicketId 12 -TaskUrl 'https://contoso/tasks/1'
+            Join-SDTicketToSPTask -TicketId 12 -TaskUrl 'https://contoso/tasks/1'
             Assert-MockCalled Set-SDTicket -ModuleName ServiceDeskTools -ParameterFilter {
                 $Id -eq 12 -and $Fields.sharepoint_task_url -eq 'https://contoso/tasks/1'
             } -Times 1
@@ -176,20 +176,20 @@ Describe 'ServiceDeskTools Module' {
             Add-SDTicketComment -Id 8 -Comment 'c'
             Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Add-SDTicketComment 8' } -Times 1
         }
-        Safe-It 'Link-SDTicketToSPTask logs the update' {
+        Safe-It 'Join-SDTicketToSPTask logs the update' {
             Mock Set-SDTicket {} -ModuleName ServiceDeskTools
             Mock Write-STLog {} -ModuleName ServiceDeskTools
-            Link-SDTicketToSPTask -TicketId 9 -TaskUrl 'https://contoso/tasks/9'
-            Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Link-SDTicketToSPTask 9 https://contoso/tasks/9' } -Times 1
+            Join-SDTicketToSPTask -TicketId 9 -TaskUrl 'https://contoso/tasks/9'
+            Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Join-SDTicketToSPTask 9 https://contoso/tasks/9' } -Times 1
         }
-        Safe-It 'Submit-Ticket calls New-SDTicket and logs the action' {
+        Safe-It 'New-SimpleTicket calls New-SDTicket and logs the action' {
             Mock New-SDTicket {} -ModuleName ServiceDeskTools
             Mock Write-STLog {} -ModuleName ServiceDeskTools
-            Submit-Ticket -Subject 'S' -Description 'D' -RequesterEmail 'a@b.com'
+            New-SimpleTicket -Subject 'S' -Description 'D' -RequesterEmail 'a@b.com'
             Assert-MockCalled New-SDTicket -ModuleName ServiceDeskTools -ParameterFilter {
                 $Subject -eq 'S' -and $Description -eq 'D' -and $RequesterEmail -eq 'a@b.com'
             } -Times 1
-            Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'Submit-Ticket S' } -Times 1
+            Assert-MockCalled Write-STLog -ModuleName ServiceDeskTools -ParameterFilter { $Message -eq 'New-SimpleTicket S' } -Times 1
         }
     }
 

--- a/tests/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools.Tests.ps1
@@ -32,9 +32,9 @@ Describe 'SharePointTools Module' {
             'Get-SPToolsPreservationHoldReport',
             'Get-SPToolsAllPreservationHoldReports',
             'Get-SPPermissionsReport',
-            'Clean-SPVersionHistory',
+            'Clear-SPVersionHistory',
             'Find-OrphanedSPFiles','Get-SPToolsFileReport',
-            'Select-SPToolsFolder','List-OneDriveUsage'
+            'Select-SPToolsFolder','Get-OneDriveUsage'
         )
         $exported = (Get-Command -Module SharePointTools).Name
         foreach ($cmd in $expected) {

--- a/tests/SharePointTools/Integration.Tests.ps1
+++ b/tests/SharePointTools/Integration.Tests.ps1
@@ -213,7 +213,7 @@ Describe 'SharePointTools Integration Functions' {
         }
     }
 
-    Context 'Clean-SPVersionHistory' {
+    Context 'Clear-SPVersionHistory' {
         Safe-It 'invokes version cleanup when versions exceed threshold' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
@@ -228,7 +228,7 @@ Describe 'SharePointTools Integration Functions' {
                 Mock Get-PnPListItem { @( @{ } ) }
                 Mock Get-PnPProperty { @( $ver,$ver,$ver,$ver,$ver,$ver ) }
                 Mock Invoke-PnPQuery {}
-                Clean-SPVersionHistory -SiteUrl 'https://c' -KeepVersions 3 -Confirm:$false
+                Clear-SPVersionHistory -SiteUrl 'https://c' -KeepVersions 3 -Confirm:$false
                 Assert-MockCalled Invoke-PnPQuery -Times 1
             }
         }
@@ -291,7 +291,7 @@ Describe 'SharePointTools Integration Functions' {
         }
     }
 
-    Context 'List-OneDriveUsage' {
+    Context 'Get-OneDriveUsage' {
         Safe-It 'reports tenant site usage' {
             InModuleScope SharePointTools {
                 function Connect-PnPOnline {}
@@ -301,7 +301,7 @@ Describe 'SharePointTools Integration Functions' {
                 Mock Disconnect-PnPOnline {}
                 $site = [pscustomobject]@{ Template='SPSPERS'; Url='https://u'; Owner='o'; StorageUsageCurrent=1GB }
                 Mock Get-PnPTenantSite { @($site) }
-                $r = List-OneDriveUsage -AdminUrl 'https://admin'
+                $r = Get-OneDriveUsage -AdminUrl 'https://admin'
                 $r[0].Url | Should -Be 'https://u'
                 $r[0].StorageGB | Should -Be 1
             }


### PR DESCRIPTION
### Summary
- rename functions to use approved PowerShell verbs
- adjust documentation and tests for new names
- keep comments noting original names

### File Citations
- `src/SharePointTools/SharePointTools.psm1`【F:src/SharePointTools/SharePointTools.psm1†L1009-L1014】
- `src/ServiceDeskTools/Public/Join-SDTicketToSPTask.ps1`【F:src/ServiceDeskTools/Public/Join-SDTicketToSPTask.ps1†L1-L4】
- `src/MaintenancePlan/Public/Register-MaintenancePlan.ps1`【F:src/MaintenancePlan/Public/Register-MaintenancePlan.ps1†L1-L4】
- `src/Logging/Logging.psm1`【F:src/Logging/Logging.psm1†L14-L18】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846efc7b8b8832c8953d7f5b9234053