### PR TITLE
Implement Use-STTranscript helper

### DIFF
--- a/src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -45,16 +45,16 @@ function Invoke-ExchangeCalendarManager {
             return
         }
 
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
-        Write-STStatus -Message 'ExchangeCalendarManager launched' -Level SUCCESS -Log
-        if ($Simulate) {
-            Write-STStatus -Message 'Simulation mode active - no Exchange operations will occur.' -Level WARN -Log
-            $mock = [pscustomobject]@{
-                Simulated = $true
-                Timestamp = Get-Date
+        Use-STTranscript -Path $TranscriptPath -ScriptBlock {
+            Write-STStatus -Message 'ExchangeCalendarManager launched' -Level SUCCESS -Log
+            if ($Simulate) {
+                Write-STStatus -Message 'Simulation mode active - no Exchange operations will occur.' -Level WARN -Log
+                $mock = [pscustomobject]@{
+                    Simulated = $true
+                    Timestamp = Get-Date
+                }
+                return $mock
             }
-            return $mock
-        }
 
     if ($PSVersionTable.PSVersion.Major -lt 7) {
         throw 'This function requires PowerShell 7 or higher.'
@@ -119,14 +119,14 @@ function Invoke-ExchangeCalendarManager {
         }
     }
 
-        Write-STStatus -Message 'ExchangeCalendarManager finished' -Level FINAL -Log
+            Write-STStatus -Message 'ExchangeCalendarManager finished' -Level FINAL -Log
+        }
     } catch {
         Write-STStatus "Invoke-ExchangeCalendarManager failed: $_" -Level ERROR -Log
         Write-STLog -Message "Invoke-ExchangeCalendarManager failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
         $result = 'Failure'
         return New-STErrorObject -Message $_.Exception.Message -Category 'Exchange'
     } finally {
-        if ($TranscriptPath) { Stop-Transcript | Out-Null }
         Disconnect-ExchangeOnline -Confirm:$false | Out-Null
         $sw.Stop()
         Send-STMetric -MetricName 'Invoke-ExchangeCalendarManager' -Category 'Remediation' -Value $sw.Elapsed.TotalSeconds -Details @{ Result = $result }

--- a/src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1
+++ b/src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1
@@ -17,14 +17,14 @@ function Get-DiskSpaceInfo {
 
     $computer = if ($env:COMPUTERNAME) { $env:COMPUTERNAME } else { $env:HOSTNAME }
     $timestamp = (Get-Date).ToString('o')
-    if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
     $info = @()
-    try {
-        if ($IsWindows) {
-            $disks = Get-CimInstance -ClassName Win32_LogicalDisk -Filter "DriveType = 3"
-            foreach ($d in $disks) {
-                $info += [pscustomobject]@{
-                    Drive       = $d.DeviceID
+    Use-STTranscript -Path $TranscriptPath -ScriptBlock {
+        try {
+            if ($IsWindows) {
+                $disks = Get-CimInstance -ClassName Win32_LogicalDisk -Filter "DriveType = 3"
+                foreach ($d in $disks) {
+                    $info += [pscustomobject]@{
+                        Drive       = $d.DeviceID
                     SizeGB      = [math]::Round($d.Size / 1GB,2)
                     FreeGB      = [math]::Round($d.FreeSpace / 1GB,2)
                     FreePercent = if ($d.Size -gt 0) { [math]::Round(($d.FreeSpace/$d.Size)*100,2) } else { 0 }
@@ -38,12 +38,11 @@ function Get-DiskSpaceInfo {
                     FreeGB      = [math]::Round($_.Free/1GB,2)
                     FreePercent = if ($_.Used + $_.Free -gt 0) { [math]::Round(($_.Free/($_.Used+$_.Free))*100,2) } else { 0 }
                 }
+                }
             }
+        } catch {
+            return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
         }
-    } catch {
-        return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
-    } finally {
-        if ($TranscriptPath) { Stop-Transcript | Out-Null }
     }
     $json = @{ ComputerName = $computer; Timestamp = $timestamp; DiskInfo = $info } | ConvertTo-Json -Compress
     Write-STRichLog -Tool 'Get-DiskSpaceInfo' -Status 'queried' -Details $json

--- a/src/PerformanceTools/Invoke-PerformanceAudit.ps1
+++ b/src/PerformanceTools/Invoke-PerformanceAudit.ps1
@@ -44,16 +44,13 @@ if ($CreateTicket) {
     Import-Module (Join-Path $moduleRoot 'ServiceDeskTools/ServiceDeskTools.psd1') -Force -ErrorAction SilentlyContinue
 }
 
-if ($TranscriptPath) {
-    Start-Transcript -Path $TranscriptPath -Append | Out-Null
-}
+Use-STTranscript -Path $TranscriptPath -ScriptBlock {
+    $scriptName = Split-Path -Leaf $PSCommandPath
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $result = 'Success'
+    $alerts = @()
 
-$scriptName = Split-Path -Leaf $PSCommandPath
-$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-$result = 'Success'
-$alerts = @()
-
-try {
+    try {
     Write-STDivider -Title 'PERFORMANCE AUDIT' -Style heavy
 
     # CPU usage
@@ -130,6 +127,6 @@ try {
     $opId = [guid]::NewGuid().ToString()
     Write-STTelemetryEvent -ScriptName $scriptName -Result $result -Duration $stopwatch.Elapsed -Category 'Audit' -OperationId $opId
     Send-STMetric -MetricName 'PerformanceAuditDuration' -Category 'Audit' -Value $stopwatch.Elapsed.TotalSeconds -Details @{ Result = $result; OperationId = $opId }
-    if ($TranscriptPath) { Stop-Transcript | Out-Null }
     Write-STClosing
+}
 }

--- a/src/STCore/STCore.psd1
+++ b/src/STCore/STCore.psd1
@@ -4,5 +4,5 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000000'
     Author = 'Contoso'
     Description = 'Core utility functions.'
-    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest')
+    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest','Use-STTranscript')
 }

--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -161,7 +161,23 @@ function Invoke-STRequest {
     }
 }
 
-Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest'
+function Use-STTranscript {
+    [CmdletBinding()]
+    param(
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [scriptblock]$ScriptBlock
+    )
+
+    if ($Path) { Start-Transcript -Path $Path -Append | Out-Null }
+    try {
+        & $ScriptBlock
+    } finally {
+        if ($Path) { Stop-Transcript | Out-Null }
+    }
+}
+
+Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest','Use-STTranscript'
 
 function Show-STCoreBanner {
     <#

--- a/src/SupportTools/Public/Clear-TempFile.ps1
+++ b/src/SupportTools/Public/Clear-TempFile.ps1
@@ -13,9 +13,7 @@ function Clear-TempFile {
         [string]$TranscriptPath
     )
 
-    try {
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
-
+    Use-STTranscript -Path $TranscriptPath -ScriptBlock {
         $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '../../..')
         Write-STStatus -Message 'Cleaning temporary files...' -Level INFO
         $tmpFiles  = Get-ChildItem -Path $repoRoot -Recurse -Include '*.tmp' -File -ErrorAction SilentlyContinue
@@ -27,7 +25,5 @@ function Clear-TempFile {
             RemovedTmpFileCount = $tmpFiles.Count
             RemovedLogFileCount = $logFiles.Count
         }
-    } finally {
-        if ($TranscriptPath) { Stop-Transcript | Out-Null }
     }
 }

--- a/src/SupportTools/Public/Convert-ExcelToCsv.ps1
+++ b/src/SupportTools/Public/Convert-ExcelToCsv.ps1
@@ -17,34 +17,32 @@ function Convert-ExcelToCsv {
         [string]$TranscriptPath
     )
 
-    try {
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+    Use-STTranscript -Path $TranscriptPath -ScriptBlock {
+        try {
+            Write-STStatus "Converting $XlsxFilePath to CSV..." -Level INFO
+            $excel = New-Object -ComObject Excel.Application
+            $workbook = $excel.Workbooks.Open($XlsxFilePath)
 
-        Write-STStatus "Converting $XlsxFilePath to CSV..." -Level INFO
-        $excel = New-Object -ComObject Excel.Application
-        $workbook = $excel.Workbooks.Open($XlsxFilePath)
+            $xlsxFile = Get-ChildItem $XlsxFilePath
+            $directory = $xlsxFile.DirectoryName
+            $basename = $xlsxFile.BaseName
+            $csvFilePath = Join-Path $directory "$basename.csv"
 
-        $xlsxFile = Get-ChildItem $XlsxFilePath
-        $directory = $xlsxFile.DirectoryName
-        $basename = $xlsxFile.BaseName
-        $csvFilePath = Join-Path $directory "$basename.csv"
+            $xlCSV = 6
+            foreach ($worksheet in $workbook.Worksheets) {
+                $worksheet.SaveAs($csvFilePath, $xlCSV)
+            }
+            $workbook.Close($false)
+            $excel.Quit()
+            [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($workbook)
+            [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($excel)
+            [GC]::Collect()
+            [GC]::WaitForPendingFinalizers()
 
-        $xlCSV = 6
-        foreach ($worksheet in $workbook.Worksheets) {
-            $worksheet.SaveAs($csvFilePath, $xlCSV)
+            Write-STStatus "CSV saved to $csvFilePath" -Level SUCCESS
+            return (Import-Csv $csvFilePath)
+        } catch {
+            return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
         }
-        $workbook.Close($false)
-        $excel.Quit()
-        [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($workbook)
-        [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($excel)
-        [GC]::Collect()
-        [GC]::WaitForPendingFinalizers()
-
-        Write-STStatus "CSV saved to $csvFilePath" -Level SUCCESS
-        return (Import-Csv $csvFilePath)
-    } catch {
-        return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
-    } finally {
-        if ($TranscriptPath) { Stop-Transcript | Out-Null }
     }
 }

--- a/src/SupportTools/Public/Export-ITReport.ps1
+++ b/src/SupportTools/Public/Export-ITReport.ps1
@@ -33,13 +33,12 @@ function Export-ITReport {
     begin {
         $items = @()
         $osBuild = (Get-CimInstance -ClassName Win32_OperatingSystem | Select-Object -ExpandProperty BuildNumber)
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
     }
     process {
         $items += ($Data | Add-Member -NotePropertyName OsBuild -NotePropertyValue $osBuild -PassThru)
     }
     end {
-        try {
+        Use-STTranscript -Path $TranscriptPath -ScriptBlock {
             Assert-ParameterNotNull $Format 'Format'
             if (-not $OutputPath) {
                 $ext = switch ($Format) {
@@ -65,8 +64,6 @@ function Export-ITReport {
                 OutputPath = $OutputPath
                 Format     = $Format
             }
-        } finally {
-            if ($TranscriptPath) { Stop-Transcript | Out-Null }
         }
     }
 }

--- a/src/SupportTools/Public/Export-ProductKey.ps1
+++ b/src/SupportTools/Public/Export-ProductKey.ps1
@@ -18,9 +18,7 @@ function Export-ProductKey {
         [string]$TranscriptPath
     )
 
-    try {
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
-
+    Use-STTranscript -Path $TranscriptPath -ScriptBlock {
         $key = (Get-CimInstance -ClassName SoftwareLicensingService | Select-Object -ExpandProperty OA3xOriginalProductKey)
         if (-not $key) {
             Write-STStatus -Message 'Product key not found.' -Level WARN
@@ -33,7 +31,5 @@ function Export-ProductKey {
             ProductKey = $key
             OutputPath = $OutputPath
         }
-    } finally {
-        if ($TranscriptPath) { Stop-Transcript | Out-Null }
     }
 }

--- a/src/SupportTools/Public/Search-ReadMe.ps1
+++ b/src/SupportTools/Public/Search-ReadMe.ps1
@@ -13,15 +13,14 @@ function Search-ReadMe {
         [string]$TranscriptPath
     )
 
-    if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
-    try {
-        Write-STStatus -Message 'Searching for readme files...' -Level INFO
-        $results = Get-ChildItem -Path C:\*readme*.txt -Recurse -File -ErrorAction SilentlyContinue
-        Write-STStatus "Found $($results.Count) file(s)." -Level SUCCESS
-        return $results
-    } catch {
-        return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
-    } finally {
-        if ($TranscriptPath) { Stop-Transcript | Out-Null }
+    Use-STTranscript -Path $TranscriptPath -ScriptBlock {
+        try {
+            Write-STStatus -Message 'Searching for readme files...' -Level INFO
+            $results = Get-ChildItem -Path C:\*readme*.txt -Recurse -File -ErrorAction SilentlyContinue
+            Write-STStatus "Found $($results.Count) file(s)." -Level SUCCESS
+            return $results
+        } catch {
+            return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
+        }
     }
 }

--- a/src/SupportTools/Public/Start-Countdown.ps1
+++ b/src/SupportTools/Public/Start-Countdown.ps1
@@ -13,20 +13,18 @@ function Start-Countdown {
         [string]$TranscriptPath
     )
 
-    try {
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
-
-        foreach ($num in 10..1) {
-            Write-STStatus $num -Level INFO
-            Start-Sleep -Seconds 1
+    Use-STTranscript -Path $TranscriptPath -ScriptBlock {
+        try {
+            foreach ($num in 10..1) {
+                Write-STStatus $num -Level INFO
+                Start-Sleep -Seconds 1
+            }
+            return [pscustomobject]@{
+                CountdownFrom = 10
+                Completed     = $true
+            }
+        } catch {
+            return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
         }
-        return [pscustomobject]@{
-            CountdownFrom = 10
-            Completed     = $true
-        }
-    } catch {
-        return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
-    } finally {
-        if ($TranscriptPath) { Stop-Transcript | Out-Null }
     }
 }

--- a/src/SupportTools/Public/Sync-SupportTools.ps1
+++ b/src/SupportTools/Public/Sync-SupportTools.ps1
@@ -32,7 +32,7 @@ function Sync-SupportTools {
     )
 
     try {
-        if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+        Use-STTranscript -Path $TranscriptPath -ScriptBlock {
         if ($Logger) {
             Import-Module $Logger -Force -ErrorAction SilentlyContinue
         } else {
@@ -73,13 +73,13 @@ function Sync-SupportTools {
             InstallPath   = $InstallPath
             Result        = 'Success'
         }
+        }
     } catch {
         Write-STStatus "Sync-SupportTools failed: $_" -Level ERROR -Log
         Write-STLog -Message "Sync-SupportTools failed: $_" -Level ERROR -Structured:$($env:ST_LOG_STRUCTURED -eq '1')
         $result = 'Failure'
         return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
     } finally {
-        if ($TranscriptPath) { Stop-Transcript | Out-Null }
         $sw.Stop()
         Send-STMetric -MetricName 'Sync-SupportTools' -Category 'Deployment' -Value $sw.Elapsed.TotalSeconds -Details @{ Result = $result }
     }


### PR DESCRIPTION
### Summary
- add `Use-STTranscript` helper to STCore
- export new helper in STCore.psd1
- refactor several commands to use `Use-STTranscript` instead of manual transcript handling

### File Citations
- [`src/STCore/STCore.psm1`](src/STCore/STCore.psm1) lines 164-180
- [`src/STCore/STCore.psd1`](src/STCore/STCore.psd1) lines 7-8
- [`src/SupportTools/Public/Convert-ExcelToCsv.ps1`](src/SupportTools/Public/Convert-ExcelToCsv.ps1) lines 20-47
- [`src/SupportTools/Public/Start-Countdown.ps1`](src/SupportTools/Public/Start-Countdown.ps1) lines 16-29
- [`src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1`](src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1) lines 18-47

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f12629f8832ca5abe6a4dc98632f