### PR TITLE
Fix missing export in STCore module

### DIFF
--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -173,7 +173,7 @@ function Invoke-STRequest {
     }
 }
 
-Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Invoke-STRequest'
+Export-ModuleMember -Function 'Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Get-STConfigValue','Invoke-STRequest'
 
 function Show-STCoreBanner {
     <#


### PR DESCRIPTION
### Summary
- export `Get-STConfigValue` so dependent scripts can import STCore correctly

### File Citations
- `src/STCore/STCore.psm1` lines 170-176

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` failed with repeated `ScriptCallDepthException` errors.


------
https://chatgpt.com/codex/tasks/task_e_6846f467aae0832cb6157dafef35e599