### PR TITLE
Update changelog with feature doc links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
-- Telemetry events recorded for Connect-SPToolsOnline
-- `Sync-SupportTools` cmdlet to download modules from a feed
+- Telemetry events recorded for `Connect-SPToolsOnline` ([SharePointTools docs](docs/SharePointTools.md#4-capture-telemetry-events))
+- [`Sync-SupportTools`](docs/SupportTools/Sync-SupportTools.md) cmdlet to download modules from a feed
 - Automatic registration of public functions in module manifests
-- Option to persist structured logs via environment variable
-- `Invoke-CompanyPlaceManagement` command for Microsoft Places
+- Option to persist structured logs via environment variable ([RichLogFormat](docs/Logging/RichLogFormat.md))
+- [`Invoke-CompanyPlaceManagement`](docs/ConfigManagementTools/Invoke-CompanyPlaceManagement.md) command for Microsoft Places
 - GitHub Actions workflows for caching modules and labeling PRs
 - SupportTools cmdlets can inject custom logging and telemetry modules
-- Detailed scenario documentation for the SharePointTools module
+- Detailed scenario documentation for the [SharePointTools](docs/SharePointTools.md) module
 - SharePointTools module graduated from Beta to Stable with version 1.2.0
-- `Out-STBanner` now accepts `-Color` to output ANSI colored titles
+- `Out-STBanner` now accepts `-Color` to output ANSI colored titles ([ModuleStyleGuide](docs/ModuleStyleGuide.md#banners-with-color))
 ### Breaking Changes
 - None in this release
 


### PR DESCRIPTION
### Summary
- add links to docs for telemetry, Sync-SupportTools, structured logging, CompanyPlaceManagement and banner color

### File Citations
- `CHANGELOG.md` lines 8-18
- `docs/SharePointTools.md` lines 90-103
- `docs/SupportTools/Sync-SupportTools.md` lines 1-25
- `docs/Logging/RichLogFormat.md` lines 14-16
- `docs/ConfigManagementTools/Invoke-CompanyPlaceManagement.md` lines 8-37
- `docs/ModuleStyleGuide.md` lines 24-30

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to convert configuration)

------
https://chatgpt.com/codex/tasks/task_e_6846f773a34c832cb7bc7cf2bf315523