### PR TITLE
Update ChaosTools docs with logging note

### DIFF
--- a/docs/ChaosTools.md
+++ b/docs/ChaosTools.md
@@ -1,6 +1,8 @@
 # ChaosTools Module
 
 Provides helpers for chaos testing and fault injection.
+Commands follow the logging conventions described in
+[ModuleStyleGuide.md](ModuleStyleGuide.md).
 Import the module with its manifest:
 
 ```powershell


### PR DESCRIPTION
### Summary
- mention ModuleStyleGuide logging conventions in ChaosTools docs

### File Citations
- `docs/ChaosTools.md` lines 3-6

### Test Results
- :x: `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed: `pwsh: command not found`)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f98adbf4832c8025ab6c1ead8cad