### PR TITLE
Update ChaosTools docs links

### DIFF
--- a/docs/ChaosTools.md
+++ b/docs/ChaosTools.md
@@ -23,3 +23,7 @@ See [ChaosTools/Invoke-ChaosTest.md](ChaosTools/Invoke-ChaosTest.md) for full
 command documentation.
 
 Use these tools to validate that your automation gracefully handles transient failures.
+
+Chaos tests write log entries using the [Rich Log Format](Logging/RichLogFormat.md).
+Enabling telemetry (`ST_ENABLE_TELEMETRY=1`) can help track chaos test results.
+Summarize captured metrics with [Telemetry/Get-STTelemetryMetrics.md](Telemetry/Get-STTelemetryMetrics.md).


### PR DESCRIPTION
### Summary
- cross-reference logging and telemetry docs from ChaosTools
- mention enabling telemetry to track chaos tests

### File Citations
- `docs/ChaosTools.md`【F:docs/ChaosTools.md†L26-L29】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to run: `pwsh: command not found`)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f98aa4f8832c8a41fcef25267726