### PR TITLE
Improve Codex config

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,7 @@
+# Codex Configuration
+
+This directory contains settings for automated code analysis. The
+`config.json` file defines the entrypoint module, public and private
+folders, and the test configuration. Analysis is limited to the `src`,
+`scripts`, and `tests` directories while ignoring generated logs and the
+`.git` folder. Adjust these paths if the repository layout changes.

--- a/.codex/config.json
+++ b/.codex/config.json
@@ -8,8 +8,8 @@
     "config": "PesterConfiguration.psd1"
   },
   "analysis": {
-    "include": ["./"],
-    "exclude": ["*.log"]
+    "include": ["src", "scripts", "tests"],
+    "exclude": ["*.log", ".git"]
   },
   "language": "powershell",
   "features": ["summarize", "doc", "test", "refactor"]


### PR DESCRIPTION
### Summary
- narrow automated analysis to relevant directories and ignore `.git`
- document Codex configuration

### File Citations
- `.codex/config.json` lines 10-13
- `.codex/README.md` lines 1-7

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f81e7180832cb5bc5b725385da3e