### PR TITLE
Update credential docs on removing session variables

### DIFF
--- a/docs/CredentialStorage.md
+++ b/docs/CredentialStorage.md
@@ -40,6 +40,8 @@ $env:SD_BASE_URI       = Get-Secret SD_BASE_URI -AsPlainText
 $env:SD_ASSET_BASE_URI = Get-Secret SD_ASSET_BASE_URI -AsPlainText
 ```
 
+These environment variables remain in your PowerShell session until removed. Once the modules complete, run `Remove-Item env:VAR_NAME` for each sensitive entry. Keeping them only as long as needed reduces the risk of exposure.
+
 With the variables set, you can import the modules and run the commands normally.
 
 This workflow keeps credentials encrypted within the SecretStore and prevents accidental exposure in scripts or source control.


### PR DESCRIPTION
### Summary
- clarify that environment variables remain in session
- show how to clean them up with `Remove-Item`

### File Citations
- `docs/CredentialStorage.md` lines 34-47

### Test Results
- `Invoke-Pester` failed with `ScriptCallDepthException` during test run


------
https://chatgpt.com/codex/tasks/task_e_6846f96e9880832c8252177d659b7b7c