### PR TITLE
Add Beta note to ChaosTools docs

### DIFF
--- a/docs/ChaosTools.md
+++ b/docs/ChaosTools.md
@@ -1,5 +1,7 @@
 # ChaosTools Module
 
+ChaosTools is currently in **Beta**.
+
 Provides helpers for chaos testing and fault injection.
 Import the module with its manifest:
 


### PR DESCRIPTION
### Summary
- note that ChaosTools is currently in Beta

### File Citations
- `docs/ChaosTools.md`

### Test Results
- ❌ `Invoke-Pester` (failed to run)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f9884280832c906812d6d5f6c875