### PR TITLE
Update CredentialStore doc with lock note

### DIFF
--- a/docs/CredentialStorage.md
+++ b/docs/CredentialStorage.md
@@ -14,6 +14,14 @@ Register the built‑in SecretStore as the default vault:
 Register-SecretVault -Name LocalStore -ModuleName Microsoft.PowerShell.SecretStore -DefaultVault
 ```
 
+The SecretStore vault starts out locked. In unattended scenarios configure it to avoid prompting:
+
+```powershell
+Set-SecretStoreConfiguration -Scope CurrentUser -Authentication None -Interaction None
+```
+
+If you secured the store with a password, unlock it first using `Unlock-SecretStore`.
+
 ## Save secrets
 
 Store the required application values and API tokens as secrets. Use the same names as the environment variables expected by the modules:


### PR DESCRIPTION
### Summary
- clarify that SecretStore vault is locked by default
- show how to disable the password for unattended use

### File Citations
- `docs/CredentialStorage.md` lines 13-23【F:docs/CredentialStorage.md†L13-L23】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to convert configuration path)【97c391†L1-L4】
- Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846f96da344832c950881f83a69a2a6