### PR TITLE
Update TestHelpers with TestDrive cleanup

### DIFF
--- a/tests/TestHelpers.ps1
+++ b/tests/TestHelpers.ps1
@@ -19,3 +19,16 @@ function Safe-It {
     }
 }
 
+BeforeEach {
+    if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
+        Remove-PSDrive -Name TestDrive -Force
+    }
+    New-PSDrive -Name TestDrive -PSProvider FileSystem -Root $TestRoot | Out-Null
+}
+
+AfterEach {
+    if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
+        Remove-PSDrive -Name TestDrive -Force
+    }
+}
+


### PR DESCRIPTION
### Summary
- add BeforeEach/AfterEach blocks to rebuild TestDrive

### File Citations
- `tests/TestHelpers.ps1` lines 22-33

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (406 tests failed)
  - Covered 1.36% / 80% code coverage
- Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6847027a5a00832c88b7d4125743bb84