### PR TITLE
Refactor test drive initialization

### DIFF
--- a/tests/AddUsersToGroup.Tests.ps1
+++ b/tests/AddUsersToGroup.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'AddUsersToGroup Script' {
+    Initialize-TestDrive
     BeforeAll {
         function Install-Module {}
         function Import-Module {}

--- a/tests/ArchiveCleanup.Tests.ps1
+++ b/tests/ArchiveCleanup.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'Invoke-ArchiveCleanup' {
+    Initialize-TestDrive
     BeforeAll {
         if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
             Remove-PSDrive -Name TestDrive -Force

--- a/tests/ChaosTools.Tests.ps1
+++ b/tests/ChaosTools.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'ChaosTools Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/ChaosTools/ChaosTools.psd1 -Force

--- a/tests/ConfigManagementTools.Tests.ps1
+++ b/tests/ConfigManagementTools.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'ConfigManagementTools Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/ConfigManagementTools/ConfigManagementTools.psd1 -Force

--- a/tests/ConfigManagementTools/Add-UserToGroup.Tests.ps1
+++ b/tests/ConfigManagementTools/Add-UserToGroup.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'Add-UserToGroup function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/ConfigManagementTools/ConfigManagementTools.psd1 -Force

--- a/tests/ConfigManagementTools/Invoke-CompanyPlaceManagement.Tests.ps1
+++ b/tests/ConfigManagementTools/Invoke-CompanyPlaceManagement.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Invoke-CompanyPlaceManagement command' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/ConfigManagementTools/ConfigManagementTools.psd1 -Force

--- a/tests/ConfigManagementTools/PublicFunctions.Tests.ps1
+++ b/tests/ConfigManagementTools/PublicFunctions.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'ConfigManagementTools public functions' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/ConfigManagementTools/ConfigManagementTools.psd1 -Force

--- a/tests/ConfigManagementTools/Test-Drift.Tests.ps1
+++ b/tests/ConfigManagementTools/Test-Drift.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'Test-Drift function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/ConfigManagementTools/ConfigManagementTools.psd1 -Force

--- a/tests/Create-NewHireUser.Tests.ps1
+++ b/tests/Create-NewHireUser.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'Create-NewHireUser script' {
+    Initialize-TestDrive
     BeforeAll {
         function Search-SDTicket {}
         function Set-SDTicket {}

--- a/tests/Ensure-TestCoverage.Tests.ps1
+++ b/tests/Ensure-TestCoverage.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'Ensure-TestCoverage script' {
+    Initialize-TestDrive
     $repoRoot = Resolve-Path "$PSScriptRoot/.."
     $publicDir = Join-Path $repoRoot 'src/SupportTools/Public'
     $tempFile = Join-Path $publicDir 'Temp-TestFunction.ps1'

--- a/tests/EntraIDTools.Tests.ps1
+++ b/tests/EntraIDTools.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/TestHelpers.ps1
 
 Describe 'EntraIDTools Module' {
+    Initialize-TestDrive
     BeforeAll {
         if (-not (Get-Module -ListAvailable -Name 'MSAL.PS')) {
             try { Install-Module -Name 'MSAL.PS' -Scope CurrentUser -Force } catch {}

--- a/tests/EntraIDTools/Disable-GraphUser.Tests.ps1
+++ b/tests/EntraIDTools/Disable-GraphUser.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Disable-GraphUser' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/EntraIDTools/Get-GraphGroupDetails.Tests.ps1
+++ b/tests/EntraIDTools/Get-GraphGroupDetails.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Get-GraphGroupDetails outputs' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/EntraIDTools/Get-GraphRiskySignIns.Tests.ps1
+++ b/tests/EntraIDTools/Get-GraphRiskySignIns.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Get-GraphRiskySignIns function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/EntraIDTools/Get-GraphSignInLogs.Tests.ps1
+++ b/tests/EntraIDTools/Get-GraphSignInLogs.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Get-GraphSignInLogs request' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/EntraIDTools/Get-GraphUserDetails.Tests.ps1
+++ b/tests/EntraIDTools/Get-GraphUserDetails.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Get-GraphUserDetails exports' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/EntraIDTools/Get-UserInfoHybrid.Tests.ps1
+++ b/tests/EntraIDTools/Get-UserInfoHybrid.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Get-UserInfoHybrid results' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/EntraIDTools/Watch-GraphSignIns.Tests.ps1
+++ b/tests/EntraIDTools/Watch-GraphSignIns.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Watch-GraphSignIns batch output' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/IncidentResponseTools.Tests.ps1
+++ b/tests/IncidentResponseTools.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'IncidentResponseTools Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/IncidentResponseTools/PublicFunctions.Tests.ps1
+++ b/tests/IncidentResponseTools/PublicFunctions.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'IncidentResponseTools public functions' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/IncidentResponseTools/IncidentResponseTools.psd1 -Force

--- a/tests/IncidentResponseTools/Submit-SystemInfoTicket.Tests.ps1
+++ b/tests/IncidentResponseTools/Submit-SystemInfoTicket.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'Submit-SystemInfoTicket.ps1 script' {
+    Initialize-TestDrive
     BeforeAll {
         $ScriptPath = Join-Path $PSScriptRoot/../.. 'scripts/Submit-SystemInfoTicket.ps1'
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force

--- a/tests/Install-SupportTools.Tests.ps1
+++ b/tests/Install-SupportTools.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/TestHelpers.ps1
 
 Describe 'Install-SupportTools script' {
+    Initialize-TestDrive
     BeforeEach {
         function Import-Module {}
         Mock Import-Module {}

--- a/tests/Invoke-DailyAuditWorkflow.Tests.ps1
+++ b/tests/Invoke-DailyAuditWorkflow.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/TestHelpers.ps1
 
 Describe 'Invoke-DailyAuditWorkflow.ps1 script' {
+    Initialize-TestDrive
     BeforeAll {
         $ScriptPath = Join-Path $PSScriptRoot/.. 'scripts/Invoke-DailyAuditWorkflow.ps1'
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force

--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'Logging Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
     }

--- a/tests/Logging.UI.Tests.ps1
+++ b/tests/Logging.UI.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'Logging UI Functions' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
     }

--- a/tests/MaintenancePlan.Tests.ps1
+++ b/tests/MaintenancePlan.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'MaintenancePlan Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/MaintenancePlan/MaintenancePlan.psd1 -Force

--- a/tests/MonitoringTools.Tests.ps1
+++ b/tests/MonitoringTools.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'MonitoringTools Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/MonitoringTools/Get-CPUUsage.Tests.ps1
+++ b/tests/MonitoringTools/Get-CPUUsage.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Get-CPUUsage function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/MonitoringTools/Get-DiskSpaceInfo.Tests.ps1
+++ b/tests/MonitoringTools/Get-DiskSpaceInfo.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Get-DiskSpaceInfo function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/MonitoringTools/Get-EventLogSummary.Tests.ps1
+++ b/tests/MonitoringTools/Get-EventLogSummary.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Get-EventLogSummary function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/MonitoringTools/Get-SystemHealth.Tests.ps1
+++ b/tests/MonitoringTools/Get-SystemHealth.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'Get-SystemHealth function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/MonitoringTools/Start-HealthMonitor.Tests.ps1
+++ b/tests/MonitoringTools/Start-HealthMonitor.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Start-HealthMonitor and Stop-HealthMonitor' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/MonitoringTools/Stop-HealthMonitor.Tests.ps1
+++ b/tests/MonitoringTools/Stop-HealthMonitor.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Stop-HealthMonitor function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/OutTools.OutSTStatus.Tests.ps1
+++ b/tests/OutTools.OutSTStatus.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'Out-STStatus function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/OutTools/OutTools.psd1 -Force

--- a/tests/OutTools.Tests.ps1
+++ b/tests/OutTools.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'OutTools Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/OutTools/OutTools.psd1 -Force

--- a/tests/PerformanceTools.Tests.ps1
+++ b/tests/PerformanceTools.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'PerformanceTools Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/PerformanceTools/PerformanceTools.psd1 -Force

--- a/tests/PerformanceTools/Invoke-PerformanceAudit.Tests.ps1
+++ b/tests/PerformanceTools/Invoke-PerformanceAudit.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'Invoke-PerformanceAudit.ps1 script' {
+    Initialize-TestDrive
     BeforeAll {
         $ScriptPath = Join-Path $PSScriptRoot/../.. 'src/PerformanceTools/Invoke-PerformanceAudit.ps1'
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force

--- a/tests/PerformanceTools/Measure-STCommand.Tests.ps1
+++ b/tests/PerformanceTools/Measure-STCommand.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'Measure-STCommand function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/PerformanceTools/PerformanceTools.psd1 -Force

--- a/tests/STCore.ErrorHelpers.Tests.ps1
+++ b/tests/STCore.ErrorHelpers.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'STCore Error Helpers' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/STCore/STCore.psd1 -Force
     }

--- a/tests/STCore.Helper.Tests.ps1
+++ b/tests/STCore.Helper.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'STCore Helper Functions' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/STCore/STCore.psd1 -Force

--- a/tests/STCore.Tests.ps1
+++ b/tests/STCore.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'STCore Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/STCore/STCore.psd1 -Force
     }

--- a/tests/STPlatform.Tests.ps1
+++ b/tests/STPlatform.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'STPlatform Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/ScriptFiles.Tests.ps1
+++ b/tests/ScriptFiles.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'Standalone Scripts' {
+    Initialize-TestDrive
     Safe-It 'generates maintenance task XML without registering' {
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         New-Item -ItemType Directory -Path $tempDir | Out-Null

--- a/tests/ScriptLauncher.Tests.ps1
+++ b/tests/ScriptLauncher.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'ScriptLauncher' {
+    Initialize-TestDrive
     Safe-It 'executes first script once and loops until quit' {
         if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
             Remove-PSDrive -Name TestDrive -Force

--- a/tests/Send-TelemetryToLogAnalytics.Tests.ps1
+++ b/tests/Send-TelemetryToLogAnalytics.Tests.ps1
@@ -1,5 +1,7 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'Send-TelemetryToLogAnalytics.ps1' {
+    Initialize-TestDrive
+    Initialize-TestDrive
     Safe-It 'posts JSON telemetry to workspace URI' {
         $log = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         $event = @{Timestamp='2024-01-01T00:00:00Z'; Script='Test.ps1'; Result='Success'; Duration=1} | ConvertTo-Json -Compress

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'ServiceDeskTools Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/ServiceDeskTools/Add-SDTicketComment.Tests.ps1
+++ b/tests/ServiceDeskTools/Add-SDTicketComment.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Add-SDTicketComment' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force

--- a/tests/ServiceDeskTools/Export-SDConfig.Tests.ps1
+++ b/tests/ServiceDeskTools/Export-SDConfig.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Export-SDConfig' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force

--- a/tests/ServiceDeskTools/Get-SDUser.Tests.ps1
+++ b/tests/ServiceDeskTools/Get-SDUser.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Get-SDUser' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force

--- a/tests/ServiceDeskTools/Get-ServiceDeskAsset.Tests.ps1
+++ b/tests/ServiceDeskTools/Get-ServiceDeskAsset.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Get-ServiceDeskAsset' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force

--- a/tests/ServiceDeskTools/Get-ServiceDeskRelationship.Tests.ps1
+++ b/tests/ServiceDeskTools/Get-ServiceDeskRelationship.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Get-ServiceDeskRelationship' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force

--- a/tests/ServiceDeskTools/Get-ServiceDeskStats.Tests.ps1
+++ b/tests/ServiceDeskTools/Get-ServiceDeskStats.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Get-ServiceDeskStats' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/ServiceDeskTools/Remove-SDTicketAttachment.Tests.ps1
+++ b/tests/ServiceDeskTools/Remove-SDTicketAttachment.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Remove-SDTicketAttachment' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force

--- a/tests/ServiceDeskTools/TicketObject.Tests.ps1
+++ b/tests/ServiceDeskTools/TicketObject.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'TicketObject class' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/ServiceDeskTools/TicketObject.psm1 -Force
     }
@@ -44,6 +45,7 @@ Describe 'TicketObject class' {
 }
 
 Describe 'Ticket ID argument completer' {
+    Initialize-TestDrive
     Safe-It 'registers completer for Id parameters' {
         Mock Register-ArgumentCompleter {}
         Import-Module $PSScriptRoot/../../src/ServiceDeskTools/ServiceDeskTools.psd1 -Force

--- a/tests/SharePointTools.Tests.ps1
+++ b/tests/SharePointTools.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'SharePointTools Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/SharePointTools/SharePointTools.psd1 -Force

--- a/tests/SharePointTools/Get-SPToolsSiteUrl.Tests.ps1
+++ b/tests/SharePointTools/Get-SPToolsSiteUrl.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'Get-SPToolsSiteUrl function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/SharePointTools/SharePointTools.psd1 -Force

--- a/tests/SharePointTools/Helper.Tests.ps1
+++ b/tests/SharePointTools/Helper.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'SharePointTools helper functions' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/SharePointTools/SharePointTools.psd1 -Force

--- a/tests/SharePointTools/Integration.Tests.ps1
+++ b/tests/SharePointTools/Integration.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'SharePointTools Integration Functions' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/SharePointTools/SharePointTools.psd1 -Force

--- a/tests/SharePointTools/Test-SPToolsSiteAdmin.Tests.ps1
+++ b/tests/SharePointTools/Test-SPToolsSiteAdmin.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/../TestHelpers.ps1
 
 Describe 'Test-SPToolsSiteAdmin function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/Sign-RepositoryFiles.Tests.ps1
+++ b/tests/Sign-RepositoryFiles.Tests.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot/TestHelpers.ps1
 
 Describe 'Sign-RepositoryFiles script' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
     }

--- a/tests/Start-MockApiServer.Tests.ps1
+++ b/tests/Start-MockApiServer.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'Start-MockApiServer script' {
+    Initialize-TestDrive
     Safe-It 'serves one Graph request and stops' {
         function Write-STStatus { param([string]$Message,[string]$Level) }
         class FakeResponse {

--- a/tests/SupportTools.Tests.ps1
+++ b/tests/SupportTools.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'SupportTools Module' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/SupportTools/CommandBehavior.Tests.ps1
+++ b/tests/SupportTools/CommandBehavior.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'SupportTools command behaviors' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force

--- a/tests/SupportTools/Export-ITReport.Tests.ps1
+++ b/tests/SupportTools/Export-ITReport.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'Export-ITReport function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force

--- a/tests/SupportTools/New-STDashboard.Tests.ps1
+++ b/tests/SupportTools/New-STDashboard.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'New-STDashboard function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/Telemetry/Telemetry.psd1 -Force

--- a/tests/SupportTools/NewHireUserAutomation.Tests.ps1
+++ b/tests/SupportTools/NewHireUserAutomation.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/../TestHelpers.ps1
 Describe 'Invoke-NewHireUserAutomation function' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force

--- a/tests/SupportToolsLoader.Tests.ps1
+++ b/tests/SupportToolsLoader.Tests.ps1
@@ -7,6 +7,7 @@ $moduleFiles = Get-ChildItem -Path (Join-Path $repoRoot 'src') -Recurse -Filter 
 $moduleNames = $moduleFiles | ForEach-Object { $_.BaseName }
 
 Describe 'SupportToolsLoader Script' {
+    Initialize-TestDrive
     BeforeAll {
         $repoRoot = Split-Path $PSScriptRoot -Parent
         $tempRepo = Join-Path $TestDrive 'repo'

--- a/tests/SystemScripts.Tests.ps1
+++ b/tests/SystemScripts.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'System Scripts' {
+    Initialize-TestDrive
     BeforeAll {
         . "$PSScriptRoot/../scripts/Get-NetworkShares.ps1"
         . "$PSScriptRoot/../scripts/Get-FailedLogins.ps1"

--- a/tests/Telemetry.Tests.ps1
+++ b/tests/Telemetry.Tests.ps1
@@ -1,5 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'Telemetry Opt-In' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force
@@ -81,6 +82,7 @@ Describe 'Telemetry Opt-In' {
 }
 
 Describe 'Telemetry Metrics Summary' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force
@@ -153,6 +155,7 @@ Describe 'Telemetry Metrics Summary' {
 }
 
 Describe 'Telemetry Banner' {
+    Initialize-TestDrive
     BeforeAll {
         Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force
     }

--- a/tests/TestHelpers.ps1
+++ b/tests/TestHelpers.ps1
@@ -19,16 +19,18 @@ function Safe-It {
     }
 }
 
-BeforeEach {
-    if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
-        Remove-PSDrive -Name TestDrive -Force
+function Initialize-TestDrive {
+    BeforeEach {
+        if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
+            Remove-PSDrive -Name TestDrive -Force
+        }
+        New-PSDrive -Name TestDrive -PSProvider FileSystem -Root $TestRoot | Out-Null
     }
-    New-PSDrive -Name TestDrive -PSProvider FileSystem -Root $TestRoot | Out-Null
-}
 
-AfterEach {
-    if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
-        Remove-PSDrive -Name TestDrive -Force
+    AfterEach {
+        if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
+            Remove-PSDrive -Name TestDrive -Force
+        }
     }
 }
 


### PR DESCRIPTION
### Summary
- move BeforeEach/AfterEach logic to new helper `Initialize-TestDrive`
- call `Initialize-TestDrive` inside each test's `Describe` block

### File Citations
- tests/TestHelpers.ps1【F:tests/TestHelpers.ps1†L22-L35】
- tests/OutTools.Tests.ps1【F:tests/OutTools.Tests.ps1†L1-L6】
- tests/ServiceDeskTools/TicketObject.Tests.ps1【F:tests/ServiceDeskTools/TicketObject.Tests.ps1†L1-L8】【F:tests/ServiceDeskTools/TicketObject.Tests.ps1†L47-L50】

### Test Results
- ❌ `Invoke-Pester -Configuration (Import-PowerShellDataFile './PesterConfiguration.psd1')` (failed tests due to missing dependencies)【9728f5†L1-L28】


------
https://chatgpt.com/codex/tasks/task_e_68470a63effc832c8cbfe1239b15ca76