### PR TITLE
Fix Show-STPrompt usage

### DIFF
--- a/scripts/Install-SupportTools.ps1
+++ b/scripts/Install-SupportTools.ps1
@@ -30,7 +30,7 @@ $modules = @(
 
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
-Show-STPrompt './scripts/Install-SupportTools.ps1'
+Show-STPrompt -Command './scripts/Install-SupportTools.ps1'
 
 foreach ($module in $modules) {
     $localPath = Join-Path $PSScriptRoot '..' 'src' $module "$module.psd1"

--- a/scripts/Send-TelemetrySummary.ps1
+++ b/scripts/Send-TelemetrySummary.ps1
@@ -37,7 +37,7 @@ param(
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Telemetry/Telemetry.psd1') -Force -ErrorAction SilentlyContinue
 
-Show-STPrompt './scripts/Send-TelemetrySummary.ps1'
+Show-STPrompt -Command './scripts/Send-TelemetrySummary.ps1'
 
 if ($env:ST_ENABLE_TELEMETRY -ne '1') {
     Write-STStatus -Message 'ST_ENABLE_TELEMETRY is not set. Telemetry will not be read.' -Level WARN

--- a/scripts/Sign-RepositoryFiles.ps1
+++ b/scripts/Sign-RepositoryFiles.ps1
@@ -18,7 +18,7 @@ param(
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 Import-Module (Join-Path $repoRoot 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
-Show-STPrompt './scripts/Sign-RepositoryFiles.ps1'
+Show-STPrompt -Command './scripts/Sign-RepositoryFiles.ps1'
 
 if (-not $CertificatePath) {
     Write-STStatus 'Code signing certificate path not specified.' -Level ERROR


### PR DESCRIPTION
### Summary
- use the `-Command` parameter when invoking `Show-STPrompt`

### File Citations
- `scripts/Install-SupportTools.ps1`【F:scripts/Install-SupportTools.ps1†L31-L35】
- `scripts/Send-TelemetrySummary.ps1`【F:scripts/Send-TelemetrySummary.ps1†L38-L41】
- `scripts/Sign-RepositoryFiles.ps1`【F:scripts/Sign-RepositoryFiles.ps1†L19-L22】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to run all tests)【0fd655†L1-L7】

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68470e8fa0bc832cbd154a2df704b87c