### PR TITLE
Fix module import order and syntax error

### DIFF
--- a/scripts/Install-SupportTools.ps1
+++ b/scripts/Install-SupportTools.ps1
@@ -24,10 +24,10 @@ Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -
 
 $modules = @(
     'Telemetry',
-    'IncidentResponseTools',
     'SharePointTools',
     'ServiceDeskTools',
-    'SupportTools'
+    'SupportTools',
+    'IncidentResponseTools'
 )
 
 Show-STPrompt -Command './scripts/Install-SupportTools.ps1'

--- a/src/SupportTools/Public/Export-ITReport.ps1
+++ b/src/SupportTools/Public/Export-ITReport.ps1
@@ -46,7 +46,7 @@ function Export-ITReport {
     }
     process {
         # Add each augmented object without reallocating an array
-        $items.Add( $Data | Add-Member -NotePropertyName OsBuild -NotePropertyValue $osBuild -PassThru )
+        $items.Add( ($Data | Add-Member -NotePropertyName OsBuild -NotePropertyValue $osBuild -PassThru) )
     }
     end {
         try {


### PR DESCRIPTION
### Summary
- fix Add-Member pipeline in `Export-ITReport.ps1`
- load modules in dependency order in `Install-SupportTools.ps1`

### File Citations
- `scripts/Install-SupportTools.ps1`【F:scripts/Install-SupportTools.ps1†L22-L40】
- `src/SupportTools/Public/Export-ITReport.ps1`【F:src/SupportTools/Public/Export-ITReport.ps1†L46-L52】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684727b3a6f4832c9c92bd6a13cf0656