### PR TITLE
Simplify Install-SupportTools output

### DIFF
--- a/scripts/Install-SupportTools.ps1
+++ b/scripts/Install-SupportTools.ps1
@@ -20,7 +20,7 @@ param(
 )
 
 # Load Logging first so status functions are available
-Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue -DisableNameChecking
+# Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 $modules = @(
     'Telemetry',
@@ -30,17 +30,17 @@ $modules = @(
     'IncidentResponseTools'
 )
 
-Show-STPrompt -Command './scripts/Install-SupportTools.ps1'
+Write-Host '$ ./scripts/Install-SupportTools.ps1'
 
 foreach ($module in $modules) {
     $localPath = Join-Path $PSScriptRoot '..' 'src' $module "$module.psd1"
     if (Test-Path $localPath) {
-        Write-STStatus -Message "Importing $module..." -Level INFO
+        Write-Host "Importing $module..."
         Import-Module $localPath -Force -DisableNameChecking
-        Write-STStatus -Message "Imported $module from $localPath" -Level SUCCESS
+        Write-Host "Imported $module from $localPath"
     } else {
-        Write-STStatus -Message "Could not find $module in src" -Level ERROR
+        Write-Host "Could not find $module in src"
     }
 }
 
-Write-STClosing 'Module import complete'
+Write-Host 'Module import complete'


### PR DESCRIPTION
### Summary
- fall back to `Write-Host` instead of custom logging commands in `Install-SupportTools.ps1`

### File Citations
- `scripts/Install-SupportTools.ps1`【F:scripts/Install-SupportTools.ps1†L22-L46】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68473a3ab9ec832cbe157ca40908daa8