### PR TITLE
Update Remove-SDTicketAttachment

### DIFF
--- a/src/ServiceDeskTools/Public/Remove-SDTicketAttachment.ps1
+++ b/src/ServiceDeskTools/Public/Remove-SDTicketAttachment.ps1
@@ -7,7 +7,7 @@ function Remove-SDTicketAttachment {
     #>
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [int]$Id,
         [Parameter(Mandatory=$false)]
@@ -24,5 +24,7 @@ function Remove-SDTicketAttachment {
     Write-STLog -Message "Remove-SDTicketAttachment $Id"
     if ($PSCmdlet.ShouldProcess("attachment $Id", 'Remove')) {
         Invoke-SDRequest -Method 'DELETE' -Path "/attachments/$Id.json" -ChaosMode:$ChaosMode
+        Write-STStatus "Removed attachment $Id" -Level SUCCESS -Log
+        return [pscustomobject]@{ Id = $Id }
     }
 }


### PR DESCRIPTION
### Summary
- allow pipeline input for `Id`
- log success and return removed ID

### File Citations
- `src/ServiceDeskTools/Public/Remove-SDTicketAttachment.ps1`【F:src/ServiceDeskTools/Public/Remove-SDTicketAttachment.ps1†L10-L28】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474e179b94832c81ad833f0ac9d834