### PR TITLE
Add parameter validation to Get-ServiceDeskStats

### DIFF
--- a/src/ServiceDeskTools/Public/Get-ServiceDeskStats.ps1
+++ b/src/ServiceDeskTools/Public/Get-ServiceDeskStats.ps1
@@ -37,6 +37,12 @@ function Get-ServiceDeskStats {
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $result = 'Success'
     Write-STLog -Message "Get-ServiceDeskStats" -Metadata @{ start=$StartDate; end=$EndDate }
+
+    if ($StartDate -gt $EndDate) {
+        Write-STStatus 'StartDate must be earlier than EndDate.' -Level ERROR -Log
+        throw 'StartDate must be earlier than EndDate.'
+    }
+
     try {
         $after  = [uri]::EscapeDataString($StartDate.ToString('yyyy-MM-dd'))
         $before = [uri]::EscapeDataString($EndDate.ToString('yyyy-MM-dd'))


### PR DESCRIPTION
### Summary
- ensure `Get-ServiceDeskStats` throws when `StartDate` is greater than `EndDate`
- log an error status before throwing

### File Citations
- `src/ServiceDeskTools/Public/Get-ServiceDeskStats.ps1`

### Test Results
```
Tests Passed: 0, Failed: 406, Skipped: 0
BeforeAll \ AfterAll failed: 2
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474e169b64832ca5afcbd52a8cab7b