### PR TITLE
Fix duplicate TenantId aliases

### DIFF
--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -428,10 +428,6 @@ function Invoke-ArchiveCleanup {
         [string]$LibraryName = 'Shared Documents',
         [string]$ClientId = $SharePointToolsSettings.ClientId,
         [Alias('TenantID','tenantId')]
-        [Alias('TenantID','tenantId')]
-        [Alias('TenantID','tenantId')]
-        [Alias('TenantID','tenantId')]
-        [Alias('TenantID','tenantId')]
         [string]$TenantId = $SharePointToolsSettings.TenantId,
         [string]$CertPath = $SharePointToolsSettings.CertPath,
         [string]$TranscriptPath,


### PR DESCRIPTION
### Summary
- remove redundant `TenantId` alias declarations

### File Citations
- `src/SharePointTools/SharePointTools.psm1` lines showing cleaned alias

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` *(failed: Could not find Command Write-STLog, numerous test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68474e1b8034832c9c1474df45d752ff