### PR TITLE
Remove UseBasicParsing from Test-SPToolsSiteAdmin

### DIFF
--- a/src/SharePointTools/Public/Test-SPToolsSiteAdmin.ps1
+++ b/src/SharePointTools/Public/Test-SPToolsSiteAdmin.ps1
@@ -35,7 +35,7 @@ function Test-SPToolsSiteAdmin {
 
     try {
         Write-STStatus 'Checking HTTP response' -Level INFO
-        $resp = Invoke-WebRequest -Uri $SiteUrl -Method Head -UseBasicParsing -ErrorAction Stop
+        $resp = Invoke-WebRequest -Uri $SiteUrl -Method Head -ErrorAction Stop
         $status = [int]$resp.StatusCode
         Write-STStatus "HTTP status: $status" -Level SUB
     } catch {


### PR DESCRIPTION
### Summary
- update `Test-SPToolsSiteAdmin` to drop `-UseBasicParsing`

### File Citations
- `src/SharePointTools/Public/Test-SPToolsSiteAdmin.ps1`

### Test Results
- ❌ `Invoke-Pester` *(failed: missing modules)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474e1f0fdc832c9e2760a7163ced33