### PR TITLE
Add git check to Sync-SupportTools

### DIFF
--- a/src/SupportTools/Public/Sync-SupportTools.ps1
+++ b/src/SupportTools/Public/Sync-SupportTools.ps1
@@ -71,6 +71,10 @@ function Sync-SupportTools {
 
         $sw = [System.Diagnostics.Stopwatch]::StartNew()
         $result = 'Success'
+        if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+            Write-STStatus -Message 'Git is required but was not found in PATH.' -Level WARN
+            throw 'Git is required but was not found in PATH.'
+        }
         if (Test-Path (Join-Path $InstallPath '.git')) {
             git -C $InstallPath pull
         }


### PR DESCRIPTION
### Summary
- verify git is available before cloning or pulling in `Sync-SupportTools`
- warn the user when git isn't in PATH

### File Citations
- `src/SupportTools/Public/Sync-SupportTools.ps1`【F:src/SupportTools/Public/Sync-SupportTools.ps1†L68-L82】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474e23c8c8832c825b3cbfce8f7532