### PR TITLE
Remove ShouldProcess from countdown

### DIFF
--- a/src/SupportTools/Public/Start-Countdown.ps1
+++ b/src/SupportTools/Public/Start-Countdown.ps1
@@ -18,7 +18,7 @@ function Start-Countdown {
     .NOTES
         Intended for demo scripts and small delays.
     #>
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]


### PR DESCRIPTION
### Summary
- remove SupportsShouldProcess from `Start-Countdown`

### File Citations
- `src/SupportTools/Public/Start-Countdown.ps1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474e24c110832ca93cd37d93e90a0e