### PR TITLE
Fix certificate path validation

### DIFF
--- a/src/SharePointTools/SharePointTools.psm1
+++ b/src/SharePointTools/SharePointTools.psm1
@@ -120,6 +120,12 @@ function Connect-SPToolsOnline {
         [Alias('TenantID','tenantId')]
         [string]$TenantId,
         [Parameter(Mandatory, ParameterSetName='Certificate')]
+        [ValidateScript({
+            if (-not (Test-Path $_)) {
+                throw "Certificate file not found at path '$_'"
+            }
+            $true
+        })]
         [string]$CertPath,
         [Parameter(Mandatory, ParameterSetName='Secret')]
         [string]$ClientSecret,


### PR DESCRIPTION
### Summary
- enforce certificate file existence in `Connect-SPToolsOnline`

### File Citations
- `src/SharePointTools/SharePointTools.psm1` lines 120-129

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474e1c91cc832cb52a546bd41e9694