### PR TITLE
Add ShouldProcess safeguards to file ops

### DIFF
--- a/src/SupportTools/Public/Clear-TempFile.ps1
+++ b/src/SupportTools/Public/Clear-TempFile.ps1
@@ -39,6 +39,9 @@ function Clear-TempFile {
             throw
         }
 
+        if (-not $PSCmdlet.ShouldProcess($repoRoot, 'Clear temporary files')) {
+            return
+        }
         try {
             $tmpFiles | Remove-Item -Force -ErrorAction Stop
             $logFiles | Remove-Item -Force -ErrorAction Stop

--- a/src/SupportTools/Public/Convert-ExcelToCsv.ps1
+++ b/src/SupportTools/Public/Convert-ExcelToCsv.ps1
@@ -41,6 +41,15 @@ function Convert-ExcelToCsv {
         $directory = $xlsxFile.DirectoryName
         $basename = $xlsxFile.BaseName
         $csvFilePath = Join-Path $directory "$basename.csv"
+        if (-not $PSCmdlet.ShouldProcess($csvFilePath, 'Convert to CSV')) {
+            $workbook.Close($false)
+            $excel.Quit()
+            [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($workbook)
+            [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($excel)
+            [GC]::Collect()
+            [GC]::WaitForPendingFinalizers()
+            return
+        }
 
         $xlCSV = 6
         foreach ($worksheet in $workbook.Worksheets) {

--- a/src/SupportTools/Public/Export-ITReport.ps1
+++ b/src/SupportTools/Public/Export-ITReport.ps1
@@ -59,6 +59,10 @@ function Export-ITReport {
                 }
                 $OutputPath = Join-Path (Get-Location) "ITReport_$((Get-Date).ToString('yyyyMMdd_HHmmss')).$ext"
             }
+            if (-not $PSCmdlet.ShouldProcess($OutputPath, 'Export IT report')) {
+                if ($TranscriptPath) { Stop-Transcript | Out-Null }
+                return
+            }
             switch ($Format) {
                 'HTML' {
                     $items | ConvertTo-Html -PreContent '<h1>IT Report</h1>' | Out-File -FilePath $OutputPath -Encoding utf8

--- a/src/SupportTools/Public/Export-ProductKey.ps1
+++ b/src/SupportTools/Public/Export-ProductKey.ps1
@@ -45,6 +45,9 @@ function Export-ProductKey {
             return
         }
 
+        if (-not $PSCmdlet.ShouldProcess($OutputPath, 'Write product key')) {
+            return
+        }
         try {
             Set-Content -Path $OutputPath -Value $key -ErrorAction Stop
         } catch {

--- a/src/SupportTools/Public/Invoke-JobBundle.ps1
+++ b/src/SupportTools/Public/Invoke-JobBundle.ps1
@@ -48,6 +48,10 @@ function Invoke-JobBundle {
 
         $files = @($transcript)
         if (Test-Path $logFile) { $files += $logFile }
+        if (-not $PSCmdlet.ShouldProcess($LogArchivePath, 'Archive job logs')) {
+            Remove-Item $transcript -Force -ErrorAction SilentlyContinue
+            return
+        }
         try {
             Compress-Archive -Path $files -DestinationPath $LogArchivePath -Force -ErrorAction Stop
             Remove-Item $transcript -Force -ErrorAction Stop

--- a/src/SupportTools/Public/Sync-SupportTools.ps1
+++ b/src/SupportTools/Public/Sync-SupportTools.ps1
@@ -69,6 +69,11 @@ function Sync-SupportTools {
             return
         }
 
+        if (-not $PSCmdlet.ShouldProcess($InstallPath, 'Sync SupportTools repository')) {
+            if ($TranscriptPath) { Stop-Transcript | Out-Null }
+            return
+        }
+
         $sw = [System.Diagnostics.Stopwatch]::StartNew()
         $result = 'Success'
         if (Test-Path (Join-Path $InstallPath '.git')) {


### PR DESCRIPTION
### Summary
- guard file write operations with `ShouldProcess`

### File Citations
- `src/SupportTools/Public/Convert-ExcelToCsv.ps1`【F:src/SupportTools/Public/Convert-ExcelToCsv.ps1†L38-L52】
- `src/SupportTools/Public/Export-ProductKey.ps1`【F:src/SupportTools/Public/Export-ProductKey.ps1†L42-L56】
- `src/SupportTools/Public/Export-ITReport.ps1`【F:src/SupportTools/Public/Export-ITReport.ps1†L60-L75】
- `src/SupportTools/Public/Clear-TempFile.ps1`【F:src/SupportTools/Public/Clear-TempFile.ps1†L32-L47】
- `src/SupportTools/Public/Invoke-JobBundle.ps1`【F:src/SupportTools/Public/Invoke-JobBundle.ps1†L46-L58】
- `src/SupportTools/Public/Sync-SupportTools.ps1`【F:src/SupportTools/Public/Sync-SupportTools.ps1†L66-L78】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474efce9c4832c862eebbce015465c