### PR TITLE
Add parameter validation for Start-HealthMonitor

### DIFF
--- a/src/MonitoringTools/Public/Start-HealthMonitor.ps1
+++ b/src/MonitoringTools/Public/Start-HealthMonitor.ps1
@@ -16,7 +16,9 @@ function Start-HealthMonitor {
     #>
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
+        [ValidateRange(0,[int]::MaxValue)]
         [int]$IntervalSeconds = 60,
+        [ValidateRange(0,[int]::MaxValue)]
         [int]$Count = 0,
         [string]$LogPath
     )
@@ -26,6 +28,8 @@ function Start-HealthMonitor {
     }
 
     if (-not $PSCmdlet.ShouldProcess('system health monitoring')) { return }
+
+    $script:StopHealthMonitor = $false
 
     try {
         $collected = 0


### PR DESCRIPTION
### Summary
- validate parameters in `Start-HealthMonitor`
- set default stop flag to avoid undefined variable

### File Citations
- `src/MonitoringTools/Public/Start-HealthMonitor.ps1`

### Test Results
Tests failed due to missing dependencies.


------
https://chatgpt.com/codex/tasks/task_e_68474e769dc8832ca3df9cb80472a7b1