### PR TITLE
Fix ShouldProcess usage in maintenance plan command

### DIFF
--- a/src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1
@@ -4,25 +4,21 @@ function Invoke-MaintenancePlan {
         Execute all steps in a maintenance plan.
     .PARAMETER Plan
         Plan object created by New-MaintenancePlan or Import-MaintenancePlan.
-    .PARAMETER WhatIf
-        Display commands without executing.
     #>
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNull()]
-        [object]$Plan,
-        [switch]$WhatIf
+        [object]$Plan
     )
     Assert-ParameterNotNull $Plan 'Plan'
     foreach ($step in $Plan.Steps) {
         Write-STStatus "Running $step" -Level INFO -Log
-        if (-not $WhatIf) {
-            if (Test-Path $step) {
-                & $step
-            } else {
-                Invoke-Expression $step
-            }
+        if (-not $PSCmdlet.ShouldProcess($step)) { continue }
+        if (Test-Path $step) {
+            & $step
+        } else {
+            Invoke-Expression $step
         }
     }
 }


### PR DESCRIPTION
### Summary
- remove custom `-WhatIf` handling from `Invoke-MaintenancePlan`
- rely on `ShouldProcess` inside loop for each step

### File Citations
- `src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1`【F:src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1†L1-L24】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed due to missing modules)【ae5683†L1-L5】

------
https://chatgpt.com/codex/tasks/task_e_68474efab984832c9fcfdb1cbeee7532