### PR TITLE
Fix ShouldProcess for incident response cmdlets

### DIFF
--- a/src/IncidentResponseTools/Public/Get-NetworkShare.ps1
+++ b/src/IncidentResponseTools/Public/Get-NetworkShare.ps1
@@ -25,6 +25,7 @@ function Get-NetworkShare {
         [object]$Config
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess('network share enumeration')) { return }
         Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Get-NetworkShares.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/IncidentResponseTools/Public/Invoke-FullSystemAudit.ps1
+++ b/src/IncidentResponseTools/Public/Invoke-FullSystemAudit.ps1
@@ -29,6 +29,7 @@ function Invoke-FullSystemAudit {
     )
 
     process {
+        if (-not $PSCmdlet.ShouldProcess('full system audit')) { return }
         if ($Logger) { Import-Module $Logger -Force -ErrorAction SilentlyContinue }
         if ($TelemetryClient) {
             Import-Module $TelemetryClient -Force -ErrorAction SilentlyContinue

--- a/src/IncidentResponseTools/Public/Invoke-IncidentResponse.ps1
+++ b/src/IncidentResponseTools/Public/Invoke-IncidentResponse.ps1
@@ -24,6 +24,7 @@ function Invoke-IncidentResponse {
         [object]$Config
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess('incident response collection')) { return }
         Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Invoke-IncidentResponse.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
     }
 }

--- a/src/IncidentResponseTools/Public/Invoke-RemoteAudit.ps1
+++ b/src/IncidentResponseTools/Public/Invoke-RemoteAudit.ps1
@@ -31,6 +31,7 @@ function Invoke-RemoteAudit {
     )
     process {
         foreach ($comp in $ComputerName) {
+            if (-not $PSCmdlet.ShouldProcess($comp, 'Audit')) { continue }
             $invokeParams = @{ ComputerName = $comp }
             if ($PSBoundParameters.ContainsKey('Credential')) { $invokeParams.Credential = $Credential }
             if ($UseSSL) { $invokeParams.UseSSL = $true }

--- a/src/IncidentResponseTools/Public/Submit-SystemInfoTicket.ps1
+++ b/src/IncidentResponseTools/Public/Submit-SystemInfoTicket.ps1
@@ -43,6 +43,7 @@ function Submit-SystemInfoTicket {
         [object]$Config
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess('system info ticket')) { return }
         $arguments = @('-SiteName', $SiteName, '-RequesterEmail', $RequesterEmail)
         if ($PSBoundParameters.ContainsKey('Subject'))     { $arguments += @('-Subject', $Subject) }
         if ($PSBoundParameters.ContainsKey('Description')) { $arguments += @('-Description', $Description) }


### PR DESCRIPTION
### Summary
- ensure ShouldProcess checks are present for public IR tools

### File Citations
- `src/IncidentResponseTools/Public/Get-NetworkShare.ps1`【F:src/IncidentResponseTools/Public/Get-NetworkShare.ps1†L25-L31】
- `src/IncidentResponseTools/Public/Invoke-IncidentResponse.ps1`【F:src/IncidentResponseTools/Public/Invoke-IncidentResponse.ps1†L26-L29】
- `src/IncidentResponseTools/Public/Invoke-RemoteAudit.ps1`【F:src/IncidentResponseTools/Public/Invoke-RemoteAudit.ps1†L31-L52】
- `src/IncidentResponseTools/Public/Submit-SystemInfoTicket.ps1`【F:src/IncidentResponseTools/Public/Submit-SystemInfoTicket.ps1†L44-L54】
- `src/IncidentResponseTools/Public/Invoke-FullSystemAudit.ps1`【F:src/IncidentResponseTools/Public/Invoke-FullSystemAudit.ps1†L29-L35】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to load required modules)【a6f5bd†L1-L26】

------
https://chatgpt.com/codex/tasks/task_e_68474ef97e34832c8adbd4529ae6f4f9