### PR TITLE
Remove redundant PSDrive cleanup

### DIFF
--- a/tests/ScriptLauncher.Tests.ps1
+++ b/tests/ScriptLauncher.Tests.ps1
@@ -2,9 +2,6 @@
 Describe 'ScriptLauncher' {
     Initialize-TestDrive
     Safe-It 'executes first script once and loops until quit' {
-        if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
-            Remove-PSDrive -Name TestDrive -Force
-        }
         $tempDir = Join-Path $TestDrive 'scripts'
         New-Item -ItemType Directory -Path $tempDir | Out-Null
         try {


### PR DESCRIPTION
### Summary
- streamline ScriptLauncher tests

### File Citations
- `tests/ScriptLauncher.Tests.ps1` lines 4-8

### Test Results
```bash
Invoke-Pester failed: ParameterBindingValidationException
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474ef14678832cbc2557fb13eaba28