### PR TITLE
Update ServiceDeskTools tests to use Safe-It

### DIFF
--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -201,7 +201,7 @@ Describe 'ServiceDeskTools Module' {
                 (Get-Command Invoke-SDRequest).Parameters.Keys | Should -Contain 'Vault'
             }
         }
-        It 'loads token from vault when variable missing' {
+        Safe-It 'loads token from vault when variable missing' {
             InModuleScope ServiceDeskTools {
                 Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
                 Mock Get-Secret { 'fromvault' }
@@ -213,7 +213,7 @@ Describe 'ServiceDeskTools Module' {
                 Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
             }
         }
-        It 'passes Vault to Get-Secret when specified' {
+        Safe-It 'passes Vault to Get-Secret when specified' {
             InModuleScope ServiceDeskTools {
                 Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
                 Mock Get-Secret { 'vaultvalue' }
@@ -230,7 +230,7 @@ Describe 'ServiceDeskTools Module' {
                 { Invoke-SDRequest -Method 'GET' -Path '/incidents/1.json' } | Should -Throw
             }
         }
-        It 'throws an ErrorRecord when token cleared and vault missing' {
+        Safe-It 'throws an ErrorRecord when token cleared and vault missing' {
             InModuleScope ServiceDeskTools {
                 $env:SD_API_TOKEN = 't'
                 Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
@@ -303,7 +303,7 @@ Describe 'ServiceDeskTools Module' {
             }
         }
 
-        It 'uses retry helper for requests' {
+        Safe-It 'uses retry helper for requests' {
             InModuleScope ServiceDeskTools {
                 $env:SD_API_TOKEN = 't'
                 Mock Write-STLog {} -ModuleName ServiceDeskTools


### PR DESCRIPTION
### Summary
- update remaining `It` blocks in ServiceDeskTools tests to `Safe-It`

### File Citations
- `tests/ServiceDeskTools.Tests.ps1`【F:tests/ServiceDeskTools.Tests.ps1†L200-L239】【F:tests/ServiceDeskTools.Tests.ps1†L300-L312】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to pass)【45d113†L1-L32】
- `dotnet --list-runtimes` shows runtime installed【341121†L1-L3】
- PowerShell version check【442d4a†L1-L7】

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474eef3028832c8246dc3aa33e2a78