### PR TITLE
Fix ShouldProcess in Invoke-MaintenancePlan

### DIFF
--- a/src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1
@@ -4,20 +4,17 @@ function Invoke-MaintenancePlan {
         Execute all steps in a maintenance plan.
     .PARAMETER Plan
         Plan object created by New-MaintenancePlan or Import-MaintenancePlan.
-    .PARAMETER WhatIf
-        Display commands without executing.
     #>
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNull()]
-        [object]$Plan,
-        [switch]$WhatIf
+        [object]$Plan
     )
     Assert-ParameterNotNull $Plan 'Plan'
     foreach ($step in $Plan.Steps) {
         Write-STStatus "Running $step" -Level INFO -Log
-        if (-not $WhatIf) {
+        if ($PSCmdlet.ShouldProcess($step)) {
             if (Test-Path $step) {
                 & $step
             } else {


### PR DESCRIPTION
### Summary
- drop custom `-WhatIf` parameter
- use `$PSCmdlet.ShouldProcess` when executing steps

### File Citations
- `src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1`【F:src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1†L1-L25】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to run tests)【b28611†L1-L24】

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474e835524832ca90d7853f40dc5d0