### PR TITLE
Add ShouldProcess support for Schedule-MaintenancePlan

### DIFF
--- a/docs/MaintenancePlan.md
+++ b/docs/MaintenancePlan.md
@@ -20,3 +20,4 @@ Import-Module ./src/MaintenancePlan/MaintenancePlan.psd1
 ### Scheduling
 `Schedule-MaintenancePlan` registers a Windows scheduled task when running on Windows.
 On Linux or macOS it outputs a cron line you can add with `crontab -e`.
+The command supports `-WhatIf` and `-Confirm` to preview or approve the registration.

--- a/src/MaintenancePlan/Public/Schedule-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/Schedule-MaintenancePlan.ps1
@@ -14,7 +14,7 @@ function Schedule-MaintenancePlan {
     .EXAMPLE
         Schedule-MaintenancePlan -PlanPath plan.json -Cron '0 3 * * 0' -Name Weekly
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory)][string]$PlanPath,
         [Parameter(Mandatory)][string]$Cron,
@@ -26,6 +26,8 @@ function Schedule-MaintenancePlan {
 
     $modulePath = Join-Path (Split-Path $PSScriptRoot -Parent) 'MaintenancePlan.psd1'
     $command = "Import-Module '$modulePath'; `$plan = Import-MaintenancePlan -Path '$PlanPath'; Invoke-MaintenancePlan -Plan `$plan"
+
+    if (-not $PSCmdlet.ShouldProcess($Name,'Register scheduled task')) { return }
 
     if ($IsWindows) {
         Write-STStatus "Registering scheduled task $Name" -Level INFO -Log


### PR DESCRIPTION
### Summary
- support `SupportsShouldProcess` in `Schedule-MaintenancePlan`
- document usage of `-WhatIf`/`-Confirm`

### File Citations
- `docs/MaintenancePlan.md`【F:docs/MaintenancePlan.md†L16-L23】
- `src/MaintenancePlan/Public/Schedule-MaintenancePlan.ps1`【F:src/MaintenancePlan/Public/Schedule-MaintenancePlan.ps1†L15-L44】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to run due to parameter binding issues)【ab7da4†L1-L7】


------
https://chatgpt.com/codex/tasks/task_e_68474e8e4b0c832ca322c8d6b1a11f10