### PR TITLE
Add export tests for STCore module

### DIFF
--- a/tests/STCore.Tests.ps1
+++ b/tests/STCore.Tests.ps1
@@ -5,7 +5,30 @@ Describe 'STCore Module' {
         Import-Module $PSScriptRoot/../src/STCore/STCore.psd1 -Force
     }
 
-    Safe-It 'exports Invoke-STRequest' {
-        (Get-Command -Module STCore).Name | Should -Contain 'Invoke-STRequest'
+    Context 'Exported commands' {
+        $expected = @(
+            'Assert-ParameterNotNull',
+            'New-STErrorObject',
+            'New-STErrorRecord',
+            'Write-STDebug',
+            'Test-IsElevated',
+            'Get-STConfig',
+            'Get-STConfigValue',
+            'Invoke-STRequest'
+        )
+
+        $exported = (Get-Command -Module STCore).Name
+        foreach ($cmd in $expected) {
+            Safe-It "exports $cmd" {
+                $exported | Should -Contain $cmd
+            }
+        }
+    }
+
+    Safe-It 'Show-STCoreBanner reports module version' {
+        $banner = Show-STCoreBanner
+        $manifest = Import-PowerShellDataFile $PSScriptRoot/../src/STCore/STCore.psd1
+        $banner.Module  | Should -Be 'STCore'
+        $banner.Version | Should -Be $manifest.ModuleVersion
     }
 }


### PR DESCRIPTION
### Summary
- extend STCore module tests to verify all public functions are exported
- check Show-STCoreBanner version output

### File Citations
- `tests/STCore.Tests.ps1`【F:tests/STCore.Tests.ps1†L8-L33】

### Test Results
- ❌ `Invoke-Pester` failed: ParameterBindingValidationException due to missing `$TestRoot` variable【a97841†L1-L25】

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474ed459fc832cbd66b75573600c04