### PR TITLE
Add tests for ST error helpers

### DIFF
--- a/tests/STCore.ErrorHelpers.Tests.ps1
+++ b/tests/STCore.ErrorHelpers.Tests.ps1
@@ -11,11 +11,20 @@ Describe 'STCore Error Helpers' {
         $err.Exception.Message | Should -Be 'oops'
     }
 
+    Safe-It 'New-STErrorRecord throws on empty message' {
+        { New-STErrorRecord -Message '' } | Should -Throw
+    }
+
     Safe-It 'New-STErrorObject returns PSCustomObject with Timestamp, Category and Message' {
         $obj = New-STErrorObject -Message 'fail' -Category 'Test'
         $obj | Should -BeOfType 'pscustomobject'
         @('Timestamp','Category','Message') | ForEach-Object { $obj.PSObject.Properties.Name | Should -Contain $_ }
         $obj.Category | Should -Be 'Test'
         $obj.Message | Should -Be 'fail'
+    }
+
+    Safe-It 'New-STErrorObject defaults category to General when unspecified' {
+        $obj = New-STErrorObject -Message 'oops'
+        $obj.Category | Should -Be 'General'
     }
 }


### PR DESCRIPTION
### Summary
- add failing scenario for New-STErrorRecord with empty message
- ensure New-STErrorObject defaults category to General

### File Citations
- `tests/STCore.ErrorHelpers.Tests.ps1` lines 14-16
- `tests/STCore.ErrorHelpers.Tests.ps1` lines 26-28

### Test Results
```
bash: pwsh: command not found
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474ed18c60832c83ab0bcb7cb8a139