### PR TITLE
Add pipeline return and logging test

### DIFF
--- a/src/OutTools/OutTools.psm1
+++ b/src/OutTools/OutTools.psm1
@@ -11,24 +11,28 @@ function Out-STStatus {
 function Out-STBanner {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][pscustomobject]$Info,
+        [Parameter(Mandatory, ValueFromPipeline)][pscustomobject]$Info,
         [ValidateSet('Black','DarkBlue','DarkGreen','DarkCyan','DarkRed','DarkMagenta','DarkYellow','Gray','DarkGray','Blue','Green','Cyan','Red','Magenta','Yellow','White')]
-        [string]$Color
+        [string]$Color,
+        [switch]$Log
     )
-    if (-not $Info.Module) { throw 'Module property required' }
-    $title = "$($Info.Module.ToUpper()) MODULE LOADED"
-    if ($PSBoundParameters.ContainsKey('Color')) {
-        $ansiMap = @{
-            Black='30'; DarkBlue='34'; DarkGreen='32'; DarkCyan='36'; DarkRed='31';
-            DarkMagenta='35'; DarkYellow='33'; Gray='37'; DarkGray='90'; Blue='94';
-            Green='92'; Cyan='96'; Red='91'; Magenta='95'; Yellow='93'; White='97'
+    process {
+        if (-not $Info.Module) { throw 'Module property required' }
+        $title = "$($Info.Module.ToUpper()) MODULE LOADED"
+        if ($PSBoundParameters.ContainsKey('Color')) {
+            $ansiMap = @{
+                Black='30'; DarkBlue='34'; DarkGreen='32'; DarkCyan='36'; DarkRed='31';
+                DarkMagenta='35'; DarkYellow='33'; Gray='37'; DarkGray='90'; Blue='94';
+                Green='92'; Cyan='96'; Red='91'; Magenta='95'; Yellow='93'; White='97'
+            }
+            $code = $ansiMap[$Color]
+            if ($code) { $title = "`e[${code}m$title`e[0m" }
         }
-        $code = $ansiMap[$Color]
-        if ($code) { $title = "`e[${code}m$title`e[0m" }
+        Write-STDivider -Title $title -Style heavy
+        Write-STStatus "Run 'Get-Command -Module $($Info.Module)' to view available tools." -Level SUB
+        Write-STLog -Message "$($Info.Module) module loaded"
+        $Info
     }
-    Write-STDivider -Title $title -Style heavy
-    Write-STStatus "Run 'Get-Command -Module $($Info.Module)' to view available tools." -Level SUB
-    Write-STLog -Message "$($Info.Module) module loaded"
 }
 
 Export-ModuleMember -Function 'Out-STStatus','Out-STBanner'

--- a/tests/OutTools.OutSTBanner.Tests.ps1
+++ b/tests/OutTools.OutSTBanner.Tests.ps1
@@ -1,0 +1,22 @@
+. $PSScriptRoot/TestHelpers.ps1
+Describe 'Out-STBanner function' {
+    Initialize-TestDrive
+    BeforeAll {
+        Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../src/OutTools/OutTools.psd1 -Force
+    }
+
+    Safe-It 'invokes Write-STLog when -Log specified' {
+        Mock Write-STDivider {} -ModuleName Logging
+        Mock Write-STStatus {} -ModuleName OutTools
+        Mock Write-STLog {} -ModuleName Logging
+        Out-STBanner -Info @{ Module='TestMod' } -Log
+        Assert-MockCalled Write-STLog -ModuleName Logging -ParameterFilter { $Message -eq 'TestMod module loaded' } -Times 1
+    }
+
+    Safe-It 'returns banner object from the pipeline' {
+        $obj = [pscustomobject]@{ Module='TestMod'; Version='1.0' }
+        $result = $obj | Out-STBanner
+        $result | Should -Be $obj
+    }
+}


### PR DESCRIPTION
### Summary
- allow `Out-STBanner` to accept pipeline input and return the banner object
- add unit tests for `Out-STBanner -Log` and pipeline passthrough

### File Citations
- `src/OutTools/OutTools.psm1`
- `tests/OutTools.OutSTBanner.Tests.ps1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474ecfa81c832c97e306217287adfd