### PR TITLE
Fix import error handling

### DIFF
--- a/SupportToolsLoader.ps1
+++ b/SupportToolsLoader.ps1
@@ -24,7 +24,11 @@ function Import-SupportToolsModules {
         $script:SupportToolsLoaderLoaded = $true
     }
 
-    Import-Module (Join-Path $PSScriptRoot 'src/OutTools/OutTools.psd1') -Force -ErrorAction SilentlyContinue -DisableNameChecking
+    try {
+        Import-Module (Join-Path $PSScriptRoot 'src/OutTools/OutTools.psd1') -Force -ErrorAction Stop -DisableNameChecking
+    } catch {
+        Write-STStatus -Message "Failed to import OutTools module: $($_.Exception.Message)" -Level WARN
+    }
 
     function Write-LoaderLog {
         param([string]$Message)

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -2,5 +2,9 @@ function Import-SupportToolsLogging {
     [CmdletBinding()]
     param()
     $modulePath = Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1'
-    Import-Module $modulePath -Force -ErrorAction SilentlyContinue -DisableNameChecking
+    try {
+        Import-Module $modulePath -Force -ErrorAction Stop -DisableNameChecking
+    } catch {
+        Write-STStatus -Message "Failed to import Logging module: $($_.Exception.Message)" -Level WARN
+    }
 }

--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -1,6 +1,10 @@
 $repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+try {
+    Import-Module $coreModule -Force -ErrorAction Stop -DisableNameChecking
+} catch {
+    Write-STStatus -Message "Failed to import STCore module: $($_.Exception.Message)" -Level WARN
+}
 $defaultsFile = Join-Path $repoRoot 'config/config.psd1'
 $STDefaults = Get-STConfig -Path $defaultsFile
 $configFile = Join-Path $repoRoot (Get-STConfigValue -Config $STDefaults -Key 'SupportToolsConfig')

--- a/src/Telemetry/Telemetry.psm1
+++ b/src/Telemetry/Telemetry.psm1
@@ -1,7 +1,15 @@
 $coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
-Import-Module $coreModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+try {
+    Import-Module $coreModule -Force -ErrorAction Stop -DisableNameChecking
+} catch {
+    Write-STStatus -Message "Failed to import STCore module: $($_.Exception.Message)" -Level WARN
+}
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
-Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
+try {
+    Import-Module $loggingModule -Force -ErrorAction Stop -DisableNameChecking
+} catch {
+    Write-STStatus -Message "Failed to import Logging module: $($_.Exception.Message)" -Level WARN
+}
 
 function Send-STMetric {
     [CmdletBinding()]


### PR DESCRIPTION
### Summary
- stop suppressing module import errors
- log warning when modules fail to load

### File Citations
- `SupportToolsLoader.ps1`【F:SupportToolsLoader.ps1†L27-L31】
- `scripts/Common.ps1`【F:scripts/Common.ps1†L1-L10】
- `src/Logging/Logging.psm1`【F:src/Logging/Logging.psm1†L1-L7】
- `src/Telemetry/Telemetry.psm1`【F:src/Telemetry/Telemetry.psm1†L1-L12】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474e8f1b4c832ca08d69733dcabbe3