### PR TITLE
Add Measure-STCommand validation tests

### DIFF
--- a/tests/PerformanceTools/Measure-STCommand.Tests.ps1
+++ b/tests/PerformanceTools/Measure-STCommand.Tests.ps1
@@ -35,4 +35,20 @@ Describe 'Measure-STCommand function' {
             Assert-MockCalled Write-STStatus -Times 0
         }
     }
+
+    Safe-It 'throws when ScriptBlock is null' {
+        InModuleScope PerformanceTools {
+            { Measure-STCommand -ScriptBlock $null } | Should -Throw 'ScriptBlock'
+        }
+    }
+
+    Safe-It 'returns consistent structure across runs' {
+        InModuleScope PerformanceTools {
+            function Send-STMetric {}
+            Mock Write-STStatus {}
+            $first = Measure-STCommand -ScriptBlock { Start-Sleep -Milliseconds 5 }
+            $second = Measure-STCommand -ScriptBlock { Start-Sleep -Milliseconds 5 }
+            $first.PSObject.Properties.Name | Should -Be $second.PSObject.Properties.Name
+        }
+    }
 }


### PR DESCRIPTION
### Summary
- expand Measure-STCommand tests
  - ensure error thrown when script block is `$null`
  - ensure repeated calls return the same property structure

### File Citations
- `tests/PerformanceTools/Measure-STCommand.Tests.ps1`

### Test Results
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.
```

------
https://chatgpt.com/codex/tasks/task_e_68474ed0cfec832cae1f54b7b2197eeb