### PR TITLE
Add pipeline input tests for Out-STStatus

### DIFF
--- a/tests/OutTools.OutSTStatus.Tests.ps1
+++ b/tests/OutTools.OutSTStatus.Tests.ps1
@@ -12,11 +12,25 @@ Describe 'Out-STStatus function' {
         Assert-MockCalled Write-STStatus -ModuleName OutTools -ParameterFilter { $Message -eq 'hello' -and $Level -eq 'WARN' } -Times 1
     }
 
+    Safe-It 'accepts pipeline input for Message' {
+        Mock Write-STStatus {} -ModuleName OutTools
+        'hello' | Out-STStatus -Level INFO
+        Assert-MockCalled Write-STStatus -ModuleName OutTools -ParameterFilter { $Message -eq 'hello' -and $Level -eq 'INFO' } -Times 1
+    }
+
     Safe-It 'invokes Write-STLog when -Log specified' {
         Mock Write-STStatus {} -ModuleName OutTools
         Mock Write-STLog {} -ModuleName Logging
         Out-STStatus -Message 'log me' -Level INFO -Log
         Assert-MockCalled Write-STStatus -ModuleName OutTools -ParameterFilter { $Message -eq 'log me' -and $Level -eq 'INFO' -and $Log } -Times 1
         Assert-MockCalled Write-STLog -ModuleName Logging -ParameterFilter { $Message -eq '[*] log me' } -Times 1
+    }
+
+    Safe-It 'does not invoke Write-STLog when -Log omitted' {
+        Mock Write-STStatus {} -ModuleName OutTools
+        Mock Write-STLog {} -ModuleName Logging
+        Out-STStatus -Message 'skip log' -Level INFO
+        Assert-MockCalled Write-STStatus -ModuleName OutTools -ParameterFilter { $Message -eq 'skip log' -and $Level -eq 'INFO' -and -not $Log } -Times 1
+        Assert-MockCalled Write-STLog -ModuleName Logging -Times 0
     }
 }


### PR DESCRIPTION
### Summary
- ensure Out-STStatus accepts pipeline messages
- check Write-STLog isn't invoked unless -Log is used

### File Citations
- `tests/OutTools.OutSTStatus.Tests.ps1`【F:tests/OutTools.OutSTStatus.Tests.ps1†L15-L34】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474ece26e4832ca24a650ac6e7740f