### PR TITLE
Add Get-STComputerName helper

### DIFF
--- a/src/MonitoringTools/MonitoringTools.psm1
+++ b/src/MonitoringTools/MonitoringTools.psm1
@@ -1,9 +1,11 @@
-$PublicDir = Join-Path $PSScriptRoot 'Public'
+$PublicDir  = Join-Path $PSScriptRoot 'Public'
+$PrivateDir = Join-Path $PSScriptRoot 'Private'
 $loggingModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Logging/Logging.psd1'
 $telemetryModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'Telemetry/Telemetry.psd1'
 Import-Module $loggingModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 Import-Module $telemetryModule -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
+Get-ChildItem -Path "$PrivateDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 Get-ChildItem -Path "$PublicDir/*.ps1" -ErrorAction SilentlyContinue | ForEach-Object { . $_.FullName }
 
 Export-ModuleMember -Function 'Get-CPUUsage','Get-DiskSpaceInfo','Get-EventLogSummary','Get-SystemHealth','Start-HealthMonitor','Stop-HealthMonitor'

--- a/src/MonitoringTools/Private/Get-STComputerName.ps1
+++ b/src/MonitoringTools/Private/Get-STComputerName.ps1
@@ -1,0 +1,19 @@
+function Get-STComputerName {
+    <#
+    .SYNOPSIS
+        Returns the current system's computer name.
+    .DESCRIPTION
+        Cross-platform helper that checks common environment variables and
+        falls back to [System.Net.Dns]::GetHostName() if needed.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if ($env:COMPUTERNAME) { return $env:COMPUTERNAME }
+    if ($env:HOSTNAME)     { return $env:HOSTNAME }
+    try {
+        return [System.Net.Dns]::GetHostName()
+    } catch {
+        return 'localhost'
+    }
+}

--- a/src/MonitoringTools/Public/Get-CPUUsage.ps1
+++ b/src/MonitoringTools/Public/Get-CPUUsage.ps1
@@ -11,7 +11,7 @@ function Get-CPUUsage {
 
     if (-not $PSCmdlet.ShouldProcess('CPU usage')) { return }
 
-    $computer = if ($env:COMPUTERNAME) { $env:COMPUTERNAME } else { $env:HOSTNAME }
+    $computer = Get-STComputerName
     $timestamp = (Get-Date).ToString('o')
     $cpu = $null
     if (Get-Command Get-Counter -ErrorAction SilentlyContinue) {

--- a/src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1
+++ b/src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1
@@ -15,7 +15,7 @@ function Get-DiskSpaceInfo {
 
     if (-not $PSCmdlet.ShouldProcess('disk space information')) { return }
 
-    $computer = if ($env:COMPUTERNAME) { $env:COMPUTERNAME } else { $env:HOSTNAME }
+    $computer = Get-STComputerName
     $timestamp = (Get-Date).ToString('o')
     if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
     try {

--- a/src/MonitoringTools/Public/Get-EventLogSummary.ps1
+++ b/src/MonitoringTools/Public/Get-EventLogSummary.ps1
@@ -14,7 +14,7 @@ function Get-EventLogSummary {
         [int]$LastHours = 24
     )
 
-    $computer = if ($env:COMPUTERNAME) { $env:COMPUTERNAME } else { $env:HOSTNAME }
+    $computer = Get-STComputerName
     $timestamp = (Get-Date).ToString('o')
     $summary = @()
     if (Get-Command Get-WinEvent -ErrorAction SilentlyContinue) {

--- a/src/MonitoringTools/Public/Get-SystemHealth.ps1
+++ b/src/MonitoringTools/Public/Get-SystemHealth.ps1
@@ -9,7 +9,7 @@ function Get-SystemHealth {
     [CmdletBinding(SupportsShouldProcess=$true)]
     param()
 
-    $computer = if ($env:COMPUTERNAME) { $env:COMPUTERNAME } else { $env:HOSTNAME }
+    $computer = Get-STComputerName
     $timestamp = (Get-Date).ToString('o')
 
     $cpu = Get-CPUUsage


### PR DESCRIPTION
### Summary
- add a private function `Get-STComputerName` in MonitoringTools
- load private functions in MonitoringTools module
- replace inline computer name logic in monitoring commands with the helper

### File Citations
- `src/MonitoringTools/Private/Get-STComputerName.ps1`【F:src/MonitoringTools/Private/Get-STComputerName.ps1†L1-L19】
- `src/MonitoringTools/MonitoringTools.psm1` lines showing new private directory and imports【F:src/MonitoringTools/MonitoringTools.psm1†L1-L9】
- `src/MonitoringTools/Public/Get-CPUUsage.ps1` changed usage to helper【F:src/MonitoringTools/Public/Get-CPUUsage.ps1†L10-L16】
- `src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1` changed usage to helper【F:src/MonitoringTools/Public/Get-DiskSpaceInfo.ps1†L16-L20】
- `src/MonitoringTools/Public/Get-EventLogSummary.ps1` changed usage to helper【F:src/MonitoringTools/Public/Get-EventLogSummary.ps1†L13-L19】
- `src/MonitoringTools/Public/Get-SystemHealth.ps1` changed usage to helper【F:src/MonitoringTools/Public/Get-SystemHealth.ps1†L8-L14】

### Test Results
- ❌ `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)` (failed to run tests)【c6b6e1†L1-L27】

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474e8f7f28832c8d07dd7d6822d744