### PR TITLE
Add ShouldProcess to Get-SystemHealth

### DIFF
--- a/src/MonitoringTools/Public/Get-SystemHealth.ps1
+++ b/src/MonitoringTools/Public/Get-SystemHealth.ps1
@@ -6,8 +6,10 @@ function Get-SystemHealth {
         Returns CPU usage, disk free space and recent event log summary.
         The combined snapshot is also written to the structured log.
     #>
-    [CmdletBinding(SupportsShouldProcess=$true)]
+[CmdletBinding(SupportsShouldProcess=$true)]
     param()
+
+    if (-not $PSCmdlet.ShouldProcess('system health')) { return }
 
     $computer = if ($env:COMPUTERNAME) { $env:COMPUTERNAME } else { $env:HOSTNAME }
     $timestamp = (Get-Date).ToString('o')

--- a/tests/MonitoringTools/Get-SystemHealth.Tests.ps1
+++ b/tests/MonitoringTools/Get-SystemHealth.Tests.ps1
@@ -19,4 +19,16 @@ Describe 'Get-SystemHealth function' {
         $result.DiskInfo | Should -Be $disk
         $result.EventLogSummary | Should -Be $events
     }
+
+    Safe-It 'does not query health when -WhatIf specified' {
+        Mock Get-CPUUsage {} -ModuleName MonitoringTools
+        Mock Get-DiskSpaceInfo {} -ModuleName MonitoringTools
+        Mock Get-EventLogSummary {} -ModuleName MonitoringTools
+
+        Get-SystemHealth -WhatIf
+
+        Assert-MockCalled Get-CPUUsage -Times 0 -ModuleName MonitoringTools
+        Assert-MockCalled Get-DiskSpaceInfo -Times 0 -ModuleName MonitoringTools
+        Assert-MockCalled Get-EventLogSummary -Times 0 -ModuleName MonitoringTools
+    }
 }


### PR DESCRIPTION
### Summary
- respect `-WhatIf` in `Get-SystemHealth`
- update tests for new `-WhatIf` behavior

### File Citations
- `src/MonitoringTools/Public/Get-SystemHealth.ps1`
- `tests/MonitoringTools/Get-SystemHealth.Tests.ps1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474e90e6d4832c942dc57c0ef58c8b