### PR TITLE
Fix Install-ModuleDependencies test

### DIFF
--- a/tests/Install-ModuleDependencies.Tests.ps1
+++ b/tests/Install-ModuleDependencies.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/TestHelpers.ps1
 Describe 'Install-ModuleDependencies script' {
     BeforeEach {
         function Get-Module {}
@@ -8,7 +9,7 @@ Describe 'Install-ModuleDependencies script' {
         Mock Read-Host { 'Y' }
     }
 
-    It 'installs all modules from the nuspec when missing' {
+    Safe-It 'installs all modules from the nuspec when missing' {
         & $PSScriptRoot/../scripts/Install-ModuleDependencies.ps1
         $nuspec = [xml](Get-Content "$PSScriptRoot/../SupportTools.nuspec")
         $modules = $nuspec.package.metadata.dependencies.dependency | ForEach-Object { $_.id }


### PR DESCRIPTION
### Summary
- load TestHelpers in Install-ModuleDependencies tests
- use `Safe-It` for consistent error handling

### File Citations
- `tests/Install-ModuleDependencies.Tests.ps1`

### Test Results
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.
```


------
https://chatgpt.com/codex/tasks/task_e_68474eb73438832cb0fef15042409f62