### PR TITLE
Add negative tests for MaintenancePlan module

### DIFF
--- a/tests/MaintenancePlan.Tests.ps1
+++ b/tests/MaintenancePlan.Tests.ps1
@@ -63,4 +63,27 @@ Describe 'MaintenancePlan Module' {
             $entry | Should -Match '/tmp/p.json'
         }
     }
+
+    Safe-It 'Import-MaintenancePlan throws when file missing' {
+        { Import-MaintenancePlan -Path '/no/plan.json' } | Should -Throw 'File not found'
+    }
+
+    Safe-It 'Export-MaintenancePlan errors when directory missing' {
+        $plan = New-MaintenancePlan -Name Demo -Steps @('echo hi')
+        $dir  = Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName())
+        $path = Join-Path $dir 'plan.json'
+        { $plan | Export-MaintenancePlan -Path $path } | Should -Throw
+    }
+
+    Safe-It 'Schedule-MaintenancePlan throws on invalid cron' {
+        InModuleScope MaintenancePlan {
+            Set-Variable -Name IsWindows -Value $true -Scope Script -Force
+            { Schedule-MaintenancePlan -PlanPath '/tmp/p.json' -Cron 'bad' -Name 'MP' } | Should -Throw 'Cron expression'
+        }
+    }
+
+    Safe-It 'Invoke-MaintenancePlan errors when script file missing' {
+        $plan = New-MaintenancePlan -Name Demo -Steps @('/tmp/nosuch.ps1')
+        { Invoke-MaintenancePlan -Plan $plan } | Should -Throw '/tmp/nosuch.ps1'
+    }
 }


### PR DESCRIPTION
### Summary
- add negative tests for Import/Export-MaintenancePlan
- ensure Schedule-MaintenancePlan handles invalid cron values
- verify Invoke-MaintenancePlan errors on missing script path

### File Citations
- `tests/MaintenancePlan.Tests.ps1`

### Test Results
```
/opt/pwsh/pwsh -NoLogo -NoProfile -Command "Import-Module Pester -MinimumVersion 5.0 -ErrorAction Stop; Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)"
Tests Passed: 0, Failed: 410
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474ec77730832ca5b41bf80e6e11b5