### PR TITLE
Add export assertion for banners

### DIFF
--- a/tests/ModuleBanner.Tests.ps1
+++ b/tests/ModuleBanner.Tests.ps1
@@ -21,13 +21,13 @@ Describe 'Module Banner Functions' {
         }
     }
 
-    foreach ($case in $Cases) {
-        It "returns correct banner for $($case.Name)" {
-            $sb = [scriptblock]::Create($case.Function)
-            $result = $case.ModuleObject.NewBoundScriptBlock($sb).Invoke()
-            $manifest = Import-PowerShellDataFile $case.Psd1
-            $result.Module  | Should -Be $case.Name
-            $result.Version | Should -Be $manifest.ModuleVersion
-        }
+    It 'returns correct banner for <Name> and exports <Function>' -ForEach $Cases {
+        param($case)
+        $sb = [scriptblock]::Create($case.Function)
+        $result = $case.ModuleObject.NewBoundScriptBlock($sb).Invoke()
+        $manifest = Import-PowerShellDataFile $case.Psd1
+        $result.Module  | Should -Be $case.Name
+        $result.Version | Should -Be $manifest.ModuleVersion
+        Get-Command -Module $case.Name -Name $case.Function | Should -Not -BeNullOrEmpty
     }
 }


### PR DESCRIPTION
### Summary
- refactor banner tests to use `-ForEach`
- assert each banner function is exported from its module

### File Citations
- `tests/ModuleBanner.Tests.ps1`

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed: `pwsh: command not found`)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474ec8d870832cb05e2c31c93e5526