### PR TITLE
Handle missing MSAL module

### DIFF
--- a/tests/EntraIDTools.Tests.ps1
+++ b/tests/EntraIDTools.Tests.ps1
@@ -3,10 +3,14 @@
 Describe 'EntraIDTools Module' {
     Initialize-TestDrive
     BeforeAll {
-        if (-not (Get-Module -ListAvailable -Name 'MSAL.PS')) {
-            try { Install-Module -Name 'MSAL.PS' -Scope CurrentUser -Force } catch {}
+        $msal = Get-Module -ListAvailable -Name 'MSAL.PS'
+        if ($msal) {
+            Import-Module MSAL.PS -ErrorAction SilentlyContinue
+        } else {
+            Mock Get-MsalToken {
+                [pscustomobject]@{ AccessToken = 'mock'; ExpiresOn = (Get-Date).AddMinutes(30) }
+            }
         }
-        Import-Module MSAL.PS -ErrorAction SilentlyContinue
         Import-Module $PSScriptRoot/../src/Logging/Logging.psd1 -Force
         Import-Module $PSScriptRoot/../src/Telemetry/Telemetry.psd1 -Force
         Import-Module $PSScriptRoot/../src/EntraIDTools/EntraIDTools.psd1 -Force


### PR DESCRIPTION
### Summary
- mock `Get-MsalToken` when `MSAL.PS` is absent to avoid installing modules during tests

### File Citations
- `tests/EntraIDTools.Tests.ps1` lines 5-16

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed)
  - `Tests Passed: 0, Failed: 406`

------
https://chatgpt.com/codex/tasks/task_e_68474eb30e2c832c9d4653dca04559ca