### PR TITLE
Use Logging module in Install-SupportTools

### DIFF
--- a/scripts/Install-SupportTools.ps1
+++ b/scripts/Install-SupportTools.ps1
@@ -20,7 +20,7 @@ param(
 )
 
 # Load Logging first so status functions are available
-# Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue -DisableNameChecking
+Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue -DisableNameChecking
 
 $modules = @(
     'Telemetry',
@@ -30,17 +30,17 @@ $modules = @(
     'IncidentResponseTools'
 )
 
-Write-Host '$ ./scripts/Install-SupportTools.ps1'
+Write-STStatus -Message '$ ./scripts/Install-SupportTools.ps1' -Level INFO
 
 foreach ($module in $modules) {
     $localPath = Join-Path $PSScriptRoot '..' 'src' $module "$module.psd1"
     if (Test-Path $localPath) {
-        Write-Host "Importing $module..."
+        Write-STStatus -Message "Importing $module..." -Level INFO
         Import-Module $localPath -Force -DisableNameChecking
-        Write-Host "Imported $module from $localPath"
+        Write-STStatus -Message "Imported $module from $localPath" -Level SUCCESS
     } else {
-        Write-Host "Could not find $module in src"
+        Write-STStatus -Message "Could not find $module in src" -Level WARN
     }
 }
 
-Write-Host 'Module import complete'
+Write-STStatus -Message 'Module import complete' -Level SUCCESS


### PR DESCRIPTION
### Summary
- update Install-SupportTools.ps1 to import Logging
- replace Write-Host calls with Write-STStatus

### File Citations
- [scripts/Install-SupportTools.ps1](scripts/Install-SupportTools.ps1)

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failures due to missing modules)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68474eb587e8832c97544d364ace6ab4