### PR TITLE
Add Show-STPrompt env fallback tests

### DIFF
--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Logging Module' {
             (Get-Content $temp) | Should -Match 'env test'
         } finally {
             Remove-Item $temp -ErrorAction SilentlyContinue
-            Remove-Item env:ST_LOG_PATH
+            Remove-Item env:ST_LOG_PATH -ErrorAction SilentlyContinue
         }
     }
 

--- a/tests/Logging.UI.Tests.ps1
+++ b/tests/Logging.UI.Tests.ps1
@@ -19,6 +19,26 @@ Describe 'Logging UI Functions' {
         }
     }
 
+    Safe-It 'uses USER and HOSTNAME when USERNAME or COMPUTERNAME unset' {
+        $oldUser = $env:USER
+        $oldHost = $env:HOSTNAME
+        $oldUname = $env:USERNAME
+        $oldCname = $env:COMPUTERNAME
+        try {
+            $env:USER = 'tester2'
+            $env:HOSTNAME = 'demo2'
+            Remove-Item env:USERNAME -ErrorAction SilentlyContinue
+            Remove-Item env:COMPUTERNAME -ErrorAction SilentlyContinue
+            { Show-STPrompt -Command './script.ps1' -Path '/tmp' } |
+                Should -Output '┌──(tester2@demo2)-[/tmp]','└─$ ./script.ps1'
+        } finally {
+            if ($null -ne $oldUser) { $env:USER = $oldUser } else { Remove-Item env:USER -ErrorAction SilentlyContinue }
+            if ($null -ne $oldHost) { $env:HOSTNAME = $oldHost } else { Remove-Item env:HOSTNAME -ErrorAction SilentlyContinue }
+            if ($null -ne $oldUname) { $env:USERNAME = $oldUname } else { Remove-Item env:USERNAME -ErrorAction SilentlyContinue }
+            if ($null -ne $oldCname) { $env:COMPUTERNAME = $oldCname } else { Remove-Item env:COMPUTERNAME -ErrorAction SilentlyContinue }
+        }
+    }
+
     Safe-It 'renders dividers for light and heavy styles' {
         function Get-ExpectedDivider($title, $style) {
             $char = if ($style -eq 'heavy') { '═' } else { '─' }
@@ -48,7 +68,8 @@ Describe 'Logging UI Functions' {
     }
 
     Safe-It 'prints closing banner with custom message' {
-        { Write-STClosing -Message 'Done' } | Should -Output '┌──[ Done ]──────────────'
+        $expected = "┌──[ Done ]" + ('─' * 14)
+        { Write-STClosing -Message 'Done' } | Should -Output $expected
     }
 
     Safe-It 'returns module name and version' {

--- a/tests/STCore.Helper.Tests.ps1
+++ b/tests/STCore.Helper.Tests.ps1
@@ -49,7 +49,7 @@ Describe 'STCore Helper Functions' {
                 try {
                     $env:ST_DEBUG = '1'
                     Write-STDebug 'msg'
-                    Remove-Item env:ST_DEBUG
+                    Remove-Item env:ST_DEBUG -ErrorAction SilentlyContinue
                     Write-STDebug 'msg'
                     Assert-MockCalled Write-STStatus -Times 1 -ParameterFilter { $Message -eq '[DEBUG] msg' }
                     Assert-MockCalled Write-STLog -Times 1 -ParameterFilter { $Message -eq '[DEBUG] msg' }

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -248,7 +248,7 @@ Describe 'ServiceDeskTools Module' {
                 Mock Invoke-RestMethod {} -ModuleName ServiceDeskTools
                 Invoke-SDRequest -Method 'GET' -Path '/incidents/1.json'
                 Assert-MockCalled Invoke-RestMethod -ModuleName ServiceDeskTools -ParameterFilter { $Uri -eq 'https://api.samanage.com/incidents/1.json' } -Times 1
-                Remove-Item env:SD_API_TOKEN
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
             }
         }
         Safe-It 'uses SD_BASE_URI when set' {
@@ -259,8 +259,8 @@ Describe 'ServiceDeskTools Module' {
                 Mock Invoke-RestMethod {} -ModuleName ServiceDeskTools
                 Invoke-SDRequest -Method 'GET' -Path '/incidents/2.json'
                 Assert-MockCalled Invoke-RestMethod -ModuleName ServiceDeskTools -ParameterFilter { $Uri -eq 'https://custom.example.com/api/incidents/2.json' } -Times 1
-                Remove-Item env:SD_API_TOKEN
-                Remove-Item env:SD_BASE_URI
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Remove-Item env:SD_BASE_URI -ErrorAction SilentlyContinue
             }
         }
         Safe-It 'uses SD_BASE_URI for assets when SD_ASSET_BASE_URI not set' {
@@ -272,8 +272,8 @@ Describe 'ServiceDeskTools Module' {
                 Mock Invoke-RestMethod {} -ModuleName ServiceDeskTools
                 Get-ServiceDeskAsset -Id 3
                 Assert-MockCalled Invoke-RestMethod -ModuleName ServiceDeskTools -ParameterFilter { $Uri -eq 'https://custom.example.com/api/assets/3.json' } -Times 1
-                Remove-Item env:SD_API_TOKEN
-                Remove-Item env:SD_BASE_URI
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Remove-Item env:SD_BASE_URI -ErrorAction SilentlyContinue
             }
         }
         Safe-It 'uses SD_ASSET_BASE_URI when set' {
@@ -284,8 +284,8 @@ Describe 'ServiceDeskTools Module' {
                 Mock Invoke-RestMethod {} -ModuleName ServiceDeskTools
                 Get-ServiceDeskAsset -Id 4
                 Assert-MockCalled Invoke-RestMethod -ModuleName ServiceDeskTools -ParameterFilter { $Uri -eq 'https://assets.example.com/api/assets/4.json' } -Times 1
-                Remove-Item env:SD_API_TOKEN
-                Remove-Item env:SD_ASSET_BASE_URI
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Remove-Item env:SD_ASSET_BASE_URI -ErrorAction SilentlyContinue
             }
         }
         Safe-It 'converts body to JSON' {
@@ -299,7 +299,7 @@ Describe 'ServiceDeskTools Module' {
                 Assert-MockCalled Invoke-RestMethod -ModuleName ServiceDeskTools -ParameterFilter {
                     $Body -eq $expected -and $ContentType -eq 'application/json'
                 } -Times 1
-                Remove-Item env:SD_API_TOKEN
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
             }
         }
 
@@ -310,7 +310,7 @@ Describe 'ServiceDeskTools Module' {
                 Mock Invoke-SDRestWithRetry {} -ModuleName ServiceDeskTools
                 Invoke-SDRequest -Method 'GET' -Path '/test'
                 Assert-MockCalled Invoke-SDRestWithRetry -ModuleName ServiceDeskTools -Times 1
-                Remove-Item env:SD_API_TOKEN
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
             }
         }
     }
@@ -351,8 +351,8 @@ Describe 'ServiceDeskTools Module' {
                 Assert-MockCalled Wait-SDRateLimit -ModuleName ServiceDeskTools -Times 3
                 Assert-MockCalled Start-Sleep -ModuleName ServiceDeskTools -Times 1
 
-                Remove-Item env:SD_API_TOKEN
-                Remove-Item env:SD_RATE_LIMIT_PER_MINUTE
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Remove-Item env:SD_RATE_LIMIT_PER_MINUTE -ErrorAction SilentlyContinue
             }
         }
 
@@ -369,8 +369,8 @@ Describe 'ServiceDeskTools Module' {
 
                 Assert-MockCalled Start-Sleep -ModuleName ServiceDeskTools -ParameterFilter { $Milliseconds -eq 1000 } -Times 1
 
-                Remove-Item env:SD_API_TOKEN
-                Remove-Item env:ST_CHAOS_MODE
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Remove-Item env:ST_CHAOS_MODE -ErrorAction SilentlyContinue
             }
         }
     }

--- a/tests/ServiceDeskTools/Get-ServiceDeskAsset.Tests.ps1
+++ b/tests/ServiceDeskTools/Get-ServiceDeskAsset.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Get-ServiceDeskAsset' {
             Assert-MockCalled Invoke-SDRequest -Times 1 -ParameterFilter {
                 $Method -eq 'GET' -and $Path -eq '/assets/9.json' -and $BaseUri -eq 'https://assets.example.com/api/'
             }
-            Remove-Item env:SD_ASSET_BASE_URI
+            Remove-Item env:SD_ASSET_BASE_URI -ErrorAction SilentlyContinue
         }
     }
 }


### PR DESCRIPTION
### Summary
- test fallback to USER/HOSTNAME when USERNAME/COMPUTERNAME unset
- compute closing banner string dynamically in test
- remove environment variables using `-ErrorAction SilentlyContinue`

### File Citations
- `tests/Logging.UI.Tests.ps1` lines 22-38, 70-72
- `tests/Logging.Tests.ps1` lines 20-26
- `tests/STCore.Helper.Tests.ps1` lines 46-55
- `tests/ServiceDeskTools/Get-ServiceDeskAsset.Tests.ps1` lines 12-18
- `tests/ServiceDeskTools.Tests.ps1` lines 248-288, 300-374

### Test Results
`Invoke-Pester` failed with module import errors. 407 tests failed.


------
https://chatgpt.com/codex/tasks/task_e_68474ec62168832c916b235d8ed962f6