### PR TITLE
Add AfterEach cleanup for module dependency tests

### DIFF
--- a/tests/Install-ModuleDependencies.Tests.ps1
+++ b/tests/Install-ModuleDependencies.Tests.ps1
@@ -18,4 +18,10 @@ Describe 'Install-ModuleDependencies script' {
         Assert-MockCalled Get-Module -Times $modules.Count
         Assert-VerifiableMocks
     }
+
+    AfterEach {
+        Remove-Item function:Get-Module -ErrorAction SilentlyContinue
+        Remove-Item function:Install-Module -ErrorAction SilentlyContinue
+        Remove-Item function:Read-Host -ErrorAction SilentlyContinue
+    }
 }


### PR DESCRIPTION
### Summary
- clean up stub functions after `Install-ModuleDependencies` tests

### File Citations
- `tests/Install-ModuleDependencies.Tests.ps1` lines 20-26

### Test Results
```
Invoke-Pester failed: 0 tests passed.
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.
```


------
https://chatgpt.com/codex/tasks/task_e_68474eb41af0832c8003308a66968b54