### PR TITLE
Refactor mock API server

### DIFF
--- a/tests/Start-MockApiServer.Tests.ps1
+++ b/tests/Start-MockApiServer.Tests.ps1
@@ -30,10 +30,7 @@ Describe 'Start-MockApiServer script' {
         }
         $listener = [FakeHttpListener]::new([FakeContext]::new('/graph/test'))
         $scriptPath = Join-Path $PSScriptRoot/.. 'scripts/Start-MockApiServer.ps1'
-        $code = Get-Content $scriptPath -Raw -Encoding UTF8
-        $code = ($code -split "`n") | Where-Object { $_ -notmatch 'Import-Module' } | Out-String
-        $code = $code -replace '\[System.Net.HttpListener\]::new\(\)', '$listener'
-        & ([scriptblock]::Create($code))
+        & $scriptPath -Listener $listener -Port 8080
         $listener.StopCount | Should -Be 1
         $listener.Context.Response.OutputStream.Position = 0
         $body = [System.Text.Encoding]::UTF8.GetString($listener.Context.Response.OutputStream.ToArray())


### PR DESCRIPTION
### Summary
- make Start-MockApiServer accept a custom HttpListener
- update Start-MockApiServer tests to pass a fake listener

### File Citations
- `scripts/Start-MockApiServer.ps1`【F:scripts/Start-MockApiServer.ps1†L1-L18】【F:scripts/Start-MockApiServer.ps1†L40-L44】
- `tests/Start-MockApiServer.Tests.ps1`【F:tests/Start-MockApiServer.Tests.ps1†L27-L37】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to run: `pwsh: command not found`)【8cefcd†L1-L5】

------
https://chatgpt.com/codex/tasks/task_e_684788458acc832ca6dad4becf6aec1b