### PR TITLE
Fix Test-Drift env cleanup

### DIFF
--- a/tests/ConfigManagementTools/Test-Drift.Tests.ps1
+++ b/tests/ConfigManagementTools/Test-Drift.Tests.ps1
@@ -13,12 +13,14 @@ Describe 'Test-Drift function' {
             $baseline | ConvertTo-Json | Set-Content -Path $file
             Mock Get-TimeZone { [pscustomobject]@{ Id='EST' } }
             Mock Get-Service { [pscustomobject]@{ Status='Stopped' } }
+            $originalComputerName = $env:COMPUTERNAME
             $env:COMPUTERNAME = 'HOST2'
             try {
                 $result = Test-Drift -BaselinePath $file
                 $result.Count | Should -Be 3
             } finally {
                 Remove-Item $file -ErrorAction SilentlyContinue
+                $env:COMPUTERNAME = $originalComputerName
             }
         }
     }
@@ -30,12 +32,14 @@ Describe 'Test-Drift function' {
             $baseline | ConvertTo-Json | Set-Content -Path $file
             Mock Get-TimeZone { [pscustomobject]@{ Id='UTC' } }
             Mock Get-Service { [pscustomobject]@{ Status='Running' } }
+            $originalComputerName = $env:COMPUTERNAME
             $env:COMPUTERNAME = 'HOST1'
             try {
                 $result = Test-Drift -BaselinePath $file
                 $result.Count | Should -Be 0
             } finally {
                 Remove-Item $file -ErrorAction SilentlyContinue
+                $env:COMPUTERNAME = $originalComputerName
             }
         }
     }
@@ -47,12 +51,14 @@ Describe 'Test-Drift function' {
             $baseline | ConvertTo-Json | Set-Content -Path $file
             Mock Get-TimeZone { [pscustomobject]@{ Id='EST' } }
             Mock Get-Service { [pscustomobject]@{ Status='Stopped' } }
+            $originalComputerName = $env:COMPUTERNAME
             $env:COMPUTERNAME = 'HOST2'
             try {
                 $result = [pscustomobject]@{ BaselinePath = $file } | Test-Drift
                 $result.Count | Should -Be 3
             } finally {
                 Remove-Item $file -ErrorAction SilentlyContinue
+                $env:COMPUTERNAME = $originalComputerName
             }
         }
     }


### PR DESCRIPTION
### Summary
- restore `$env:COMPUTERNAME` after `Test-Drift` tests

### File Citations
- `tests/ConfigManagementTools/Test-Drift.Tests.ps1` lines 14-23 and 32-42 and 50-61

### Test Results
```
=: The term '=' is not recognized as a name of a cmdlet, function, script file, or executable program.
Invoke-Pester: Missing an argument for parameter 'Configuration'. Specify a parameter of type 'PesterConfiguration' and try again.
[!] PnP.PowerShell module not found. SharePoint functions may not work until it is installed.
Tests Passed: 0, Failed: 431, Skipped: 0, Inconclusive: 0, NotRun: 0
BeforeAll \ AfterAll failed: 3
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68478842aa08832c9a12c812ae3f9895