### PR TITLE
Add prompt and robust error handling to ScriptLauncher

### DIFF
--- a/scripts/ScriptLauncher.ps1
+++ b/scripts/ScriptLauncher.ps1
@@ -11,6 +11,8 @@
 
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
+Show-STPrompt -Command './scripts/ScriptLauncher.ps1'
+
 function Get-ScriptInfo {
     [CmdletBinding()]
     param([Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$Path)
@@ -42,7 +44,11 @@ while ($true) {
     if ($choice -match '^[Qq]$') { break }
     $index = [int]$choice - 1
     if ($index -ge 0 -and $index -lt $scriptFiles.Count) {
-        & $scriptFiles[$index].Path
+        try {
+            & $scriptFiles[$index].Path
+        } catch {
+            Write-STStatus -Message "Failed to run $($scriptFiles[$index].Path): $_" -Level ERROR
+        }
     } else {
         Write-STStatus -Message 'Invalid choice. Try again.' -Level WARN
     }


### PR DESCRIPTION
### Summary
- display Show-STPrompt before the ScriptLauncher menu
- catch script errors and log them with Write-STStatus

### File Citations
- `scripts/ScriptLauncher.ps1`【F:scripts/ScriptLauncher.ps1†L12-L58】

### Test Results
```
ParameterBindingValidationException: Cannot bind argument to parameter 'Root' because it is null.
Import-Module: /workspace/PowerShell/tests/EntraIDTools/Watch-GraphSignIns.Tests.ps1:8
Tests completed in 18.6s
Tests Passed: 0, Failed: 431, Skipped: 0, Inconclusive: 0, NotRun: 0
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684788226e44832c874766d0438473e5