### PR TITLE
Update export and variable usage

### DIFF
--- a/scripts/Invoke-IncidentResponse.ps1
+++ b/scripts/Invoke-IncidentResponse.ps1
@@ -32,8 +32,18 @@ if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null
 try {
     New-Item -Path $OutputDirectory -ItemType Directory -Force | Out-Null
     Write-STStatus "Collecting event logs" -Level INFO -Log
-    Get-WinEvent -LogName Security -MaxEvents 200 | Export-Clixml -Path (Join-Path $OutputDirectory 'Security.xml')
-    Get-WinEvent -LogName System   -MaxEvents 200 | Export-Clixml -Path (Join-Path $OutputDirectory 'System.xml')
+    try {
+        Get-WinEvent -LogName Security -MaxEvents 200 |
+            Export-Clixml -Path (Join-Path $OutputDirectory 'Security.xml')
+    } catch {
+        Write-STStatus "Failed to export Security log: $_" -Level WARN -Log
+    }
+    try {
+        Get-WinEvent -LogName System -MaxEvents 200 |
+            Export-Clixml -Path (Join-Path $OutputDirectory 'System.xml')
+    } catch {
+        Write-STStatus "Failed to export System log: $_" -Level WARN -Log
+    }
 
     Write-STStatus "Gathering process information" -Level INFO -Log
     $processes = Get-Process | ForEach-Object {

--- a/scripts/SS_DEPLOYMENT_TEMPLATE.ps1
+++ b/scripts/SS_DEPLOYMENT_TEMPLATE.ps1
@@ -151,8 +151,12 @@ function Export-Client {
     if (!$isXmlExportDir){
         New-Item -Path $xmlExportDir -ItemType Directory | Out-Null
     }
-    $xmlExportPath = "$($xmlExportDir)\$($ComputerName)_$($UpdateVersion).xml"
-    $clientObject | Export-Clixml $xmlExportPath
+    $xmlExportPath = "$($xmlExportDir)\$($env:COMPUTERNAME)_$($UpdateVersion).xml"
+    try {
+        $clientObject | Export-Clixml $xmlExportPath
+    } catch {
+        Write-STStatus "Export-Clixml failed: $_" -Level WARN
+    }
 }
 
 function Get-WHVersions {


### PR DESCRIPTION
### Summary
- fix export path to use `$env:COMPUTERNAME`
- log Export-Clixml failures

### File Citations
- `scripts/SS_DEPLOYMENT_TEMPLATE.ps1`
- `scripts/Invoke-IncidentResponse.ps1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684788210548832c9d1716fecb698d3a