### PR TITLE
Implement ShouldProcess checks for script wrappers

### DIFF
--- a/src/ConfigManagementTools/Public/Add-UserToGroup.ps1
+++ b/src/ConfigManagementTools/Public/Add-UserToGroup.ps1
@@ -9,6 +9,8 @@ function Add-UserToGroup {
         Path to the CSV file containing user principal names.
     .PARAMETER GroupName
         Name of the Microsoft 365 group to modify.
+    .NOTES
+        Supports `-WhatIf` and `-Confirm`.
     #>
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
@@ -52,14 +54,11 @@ function Add-UserToGroup {
                 $arguments += $Cloud
             }
 
-            if ($PSBoundParameters.ContainsKey('WhatIf')) {
-                $arguments += '-WhatIf'
+            if ($PSCmdlet.ShouldProcess($GroupName, 'Add users')) {
+                if ($PSBoundParameters.ContainsKey('WhatIf')) { $arguments += '-WhatIf' }
+                if ($PSBoundParameters.ContainsKey('Confirm')) { $arguments += '-Confirm' }
+                Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
             }
-            if ($PSBoundParameters.ContainsKey('Confirm')) {
-                $arguments += '-Confirm'
-            }
-
-            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'AddUsersToGroup.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
         } catch {
             return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
         }

--- a/src/ConfigManagementTools/Public/Install-Font.ps1
+++ b/src/ConfigManagementTools/Public/Install-Font.ps1
@@ -25,6 +25,8 @@ function Install-Font {
         [object]$Config
     )
     process {
-        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Install-Fonts.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        if ($PSCmdlet.ShouldProcess('Install-Fonts.ps1')) {
+            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Install-Fonts.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        }
     }
 }

--- a/src/ConfigManagementTools/Public/Install-MaintenanceTasks.ps1
+++ b/src/ConfigManagementTools/Public/Install-MaintenanceTasks.ps1
@@ -29,6 +29,8 @@ function Install-MaintenanceTasks {
     process {
         $argsList = @()
         if ($Register) { $argsList += '-Register' }
-        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Setup-ScheduledMaintenance.ps1' -Args $argsList -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        if ($PSCmdlet.ShouldProcess('Setup-ScheduledMaintenance.ps1')) {
+            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Setup-ScheduledMaintenance.ps1' -Args $argsList -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        }
     }
 }

--- a/src/ConfigManagementTools/Public/Invoke-DeploymentTemplate.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-DeploymentTemplate.ps1
@@ -25,6 +25,8 @@ function Invoke-DeploymentTemplate {
         [object]$Config
     )
     process {
-        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "SS_DEPLOYMENT_TEMPLATE.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        if ($PSCmdlet.ShouldProcess('SS_DEPLOYMENT_TEMPLATE.ps1')) {
+            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "SS_DEPLOYMENT_TEMPLATE.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        }
     }
 }

--- a/src/ConfigManagementTools/Public/Invoke-GroupMembershipCleanup.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-GroupMembershipCleanup.ps1
@@ -37,6 +37,8 @@ function Invoke-GroupMembershipCleanup {
         if ($PSBoundParameters.ContainsKey('CsvPath')) { $arguments += '-CsvPath'; $arguments += $CsvPath }
         if ($PSBoundParameters.ContainsKey('GroupName')) { $arguments += '-GroupName'; $arguments += $GroupName }
         if ($PSBoundParameters.ContainsKey('Cloud')) { $arguments += '-Cloud'; $arguments += $Cloud }
-        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'CleanupGroupMembership.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Explain:$Explain
+        if ($PSCmdlet.ShouldProcess($GroupName, 'Cleanup membership')) {
+            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'CleanupGroupMembership.ps1' -Args $arguments -TranscriptPath $TranscriptPath -Explain:$Explain
+        }
     }
 }

--- a/src/ConfigManagementTools/Public/Invoke-PostInstall.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-PostInstall.ps1
@@ -25,6 +25,8 @@ function Invoke-PostInstall {
         [object]$Config
     )
     process {
-        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "PostInstallScript.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        if ($PSCmdlet.ShouldProcess('PostInstallScript.ps1')) {
+            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "PostInstallScript.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        }
     }
 }

--- a/src/ConfigManagementTools/Public/Set-ComputerIPAddress.ps1
+++ b/src/ConfigManagementTools/Public/Set-ComputerIPAddress.ps1
@@ -24,6 +24,8 @@ function Set-ComputerIPAddress {
         [object]$Config
     )
     process {
-        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Set-ComputerIPAddress.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        if ($PSCmdlet.ShouldProcess('Set-ComputerIPAddress.ps1')) {
+            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Set-ComputerIPAddress.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        }
     }
 }

--- a/src/ConfigManagementTools/Public/Set-NetAdapterMetering.ps1
+++ b/src/ConfigManagementTools/Public/Set-NetAdapterMetering.ps1
@@ -25,6 +25,8 @@ function Set-NetAdapterMetering {
         [object]$Config
     )
     process {
-        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Set-NetAdapterMetering.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        if ($PSCmdlet.ShouldProcess('Set-NetAdapterMetering.ps1')) {
+            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Set-NetAdapterMetering.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        }
     }
 }

--- a/src/ConfigManagementTools/Public/Set-TimeZoneEasternStandardTime.ps1
+++ b/src/ConfigManagementTools/Public/Set-TimeZoneEasternStandardTime.ps1
@@ -25,6 +25,8 @@ function Set-TimeZoneEasternStandardTime {
         [object]$Config
     )
     process {
-        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Set-TimeZoneEasternStandardTime.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        if ($PSCmdlet.ShouldProcess('Set-TimeZoneEasternStandardTime.ps1')) {
+            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Set-TimeZoneEasternStandardTime.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+        }
     }
 }

--- a/src/SupportTools/Public/Clear-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Clear-ArchiveFolder.ps1
@@ -58,15 +58,17 @@ function Clear-ArchiveFolder {
         [object]$Config
     )
     process {
-        try {
-            $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
-        } catch {
-            Write-Error $_.Exception.Message
-            throw
-        }
-        return [pscustomobject]@{
-            Script = 'CleanupArchive.ps1'
-            Result = $output
+        if ($PSCmdlet.ShouldProcess('CleanupArchive.ps1')) {
+            try {
+                $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+            } catch {
+                Write-Error $_.Exception.Message
+                throw
+            }
+            return [pscustomobject]@{
+                Script = 'CleanupArchive.ps1'
+                Result = $output
+            }
         }
     }
 }

--- a/src/SupportTools/Public/Get-UniquePermission.ps1
+++ b/src/SupportTools/Public/Get-UniquePermission.ps1
@@ -55,15 +55,17 @@ function Get-UniquePermission {
         [object]$Config
     )
     process {
-        try {
-            $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Get-UniquePermissions.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
-        } catch {
-            Write-Error $_.Exception.Message
-            throw
-        }
-        return [pscustomobject]@{
-            Script = 'Get-UniquePermissions.ps1'
-            Result = $output
+        if ($PSCmdlet.ShouldProcess('Get-UniquePermissions.ps1')) {
+            try {
+                $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Get-UniquePermissions.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+            } catch {
+                Write-Error $_.Exception.Message
+                throw
+            }
+            return [pscustomobject]@{
+                Script = 'Get-UniquePermissions.ps1'
+                Result = $output
+            }
         }
     }
 }

--- a/src/SupportTools/Public/Invoke-JobBundle.ps1
+++ b/src/SupportTools/Public/Invoke-JobBundle.ps1
@@ -35,29 +35,31 @@ function Invoke-JobBundle {
             $LogArchivePath = $Path -replace '\\.zip$','-logs.zip'
         }
 
-        $transcript = [IO.Path]::GetTempFileName()
-        $args = @('-BundlePath', $Path)
-        Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Run-JobBundle.ps1' -Args $args -TranscriptPath $transcript
+        if ($PSCmdlet.ShouldProcess('Run-JobBundle.ps1')) {
+            $transcript = [IO.Path]::GetTempFileName()
+            $args = @('-BundlePath', $Path)
+            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Run-JobBundle.ps1' -Args $args -TranscriptPath $transcript
 
-        $logFile = if ($env:ST_LOG_PATH) {
-            $env:ST_LOG_PATH
-        } else {
-            $profile = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
-            Join-Path (Join-Path $profile 'SupportToolsLogs') 'supporttools.log'
-        }
+            $logFile = if ($env:ST_LOG_PATH) {
+                $env:ST_LOG_PATH
+            } else {
+                $profile = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
+                Join-Path (Join-Path $profile 'SupportToolsLogs') 'supporttools.log'
+            }
 
-        $files = @($transcript)
-        if (Test-Path $logFile) { $files += $logFile }
-        try {
-            Compress-Archive -Path $files -DestinationPath $LogArchivePath -Force -ErrorAction Stop
-            Remove-Item $transcript -Force -ErrorAction Stop
-        } catch {
-            Write-Error $_.Exception.Message
-            throw
-        }
-        Write-STStatus "Logs archived to $LogArchivePath" -Level SUCCESS
-        return [pscustomobject]@{
-            LogArchivePath = $LogArchivePath
+            $files = @($transcript)
+            if (Test-Path $logFile) { $files += $logFile }
+            try {
+                Compress-Archive -Path $files -DestinationPath $LogArchivePath -Force -ErrorAction Stop
+                Remove-Item $transcript -Force -ErrorAction Stop
+            } catch {
+                Write-Error $_.Exception.Message
+                throw
+            }
+            Write-STStatus "Logs archived to $LogArchivePath" -Level SUCCESS
+            return [pscustomobject]@{
+                LogArchivePath = $LogArchivePath
+            }
         }
     }
 }

--- a/src/SupportTools/Public/Invoke-NewHireUserAutomation.ps1
+++ b/src/SupportTools/Public/Invoke-NewHireUserAutomation.ps1
@@ -71,7 +71,9 @@ function Invoke-NewHireUserAutomation {
             $args = @('-PollMinutes', $PollMinutes)
             if ($Once) { $args += '-Once' }
             if ($PSBoundParameters.ContainsKey('TranscriptPath')) { $args += '-TranscriptPath'; $args += $TranscriptPath }
-            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Create-NewHireUser.ps1' -Args $args -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+            if ($PSCmdlet.ShouldProcess('Create-NewHireUser.ps1')) {
+                Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Create-NewHireUser.ps1' -Args $args -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+            }
         } catch {
             return New-STErrorRecord -Message $_.Exception.Message -Exception $_.Exception
         }

--- a/src/SupportTools/Public/Invoke-PerformanceAudit.ps1
+++ b/src/SupportTools/Public/Invoke-PerformanceAudit.ps1
@@ -47,15 +47,17 @@ function Invoke-PerformanceAudit {
         [Parameter(Mandatory = $false)][object]$Config
     )
     process {
-        try {
-            $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Invoke-PerformanceAudit.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
-        } catch {
-            Write-Error $_.Exception.Message
-            throw
-        }
-        return [pscustomobject]@{
-            Script = 'Invoke-PerformanceAudit.ps1'
-            Result = $output
+        if ($PSCmdlet.ShouldProcess('Invoke-PerformanceAudit.ps1')) {
+            try {
+                $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Invoke-PerformanceAudit.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+            } catch {
+                Write-Error $_.Exception.Message
+                throw
+            }
+            return [pscustomobject]@{
+                Script = 'Invoke-PerformanceAudit.ps1'
+                Result = $output
+            }
         }
     }
 }

--- a/src/SupportTools/Public/New-SPUsageReport.ps1
+++ b/src/SupportTools/Public/New-SPUsageReport.ps1
@@ -54,15 +54,17 @@ function New-SPUsageReport {
         [object]$Config
     )
     process {
-        try {
-            $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Generate-SPUsageReport.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
-        } catch {
-            Write-Error $_.Exception.Message
-            throw
-        }
-        return [pscustomobject]@{
-            Script = 'Generate-SPUsageReport.ps1'
-            Result = $output
+        if ($PSCmdlet.ShouldProcess('Generate-SPUsageReport.ps1')) {
+            try {
+                $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Generate-SPUsageReport.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+            } catch {
+                Write-Error $_.Exception.Message
+                throw
+            }
+            return [pscustomobject]@{
+                Script = 'Generate-SPUsageReport.ps1'
+                Result = $output
+            }
         }
     }
 }

--- a/src/SupportTools/Public/Restore-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Restore-ArchiveFolder.ps1
@@ -57,15 +57,17 @@ function Restore-ArchiveFolder {
         [object]$Config
     )
     process {
-        try {
-            $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "RollbackArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
-        } catch {
-            Write-Error $_.Exception.Message
-            throw
-        }
-        return [pscustomobject]@{
-            Script = 'RollbackArchive.ps1'
-            Result = $output
+        if ($PSCmdlet.ShouldProcess('RollbackArchive.ps1')) {
+            try {
+                $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "RollbackArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+            } catch {
+                Write-Error $_.Exception.Message
+                throw
+            }
+            return [pscustomobject]@{
+                Script = 'RollbackArchive.ps1'
+                Result = $output
+            }
         }
     }
 }


### PR DESCRIPTION
### Summary
- wrap calls to Invoke-ScriptFile with `ShouldProcess`
- add `-WhatIf`/`-Confirm` logic to Add-UserToGroup
- document WhatIf/Confirm support in Add-UserToGroup

### File Citations
- `src/ConfigManagementTools/Public/Add-UserToGroup.ps1`
- `src/ConfigManagementTools/Public/Set-ComputerIPAddress.ps1`
- `src/SupportTools/Public/New-SPUsageReport.ps1`
- `src/SupportTools/Public/Invoke-JobBundle.ps1`

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684788187208832c9daac6b7c920ff42