### PR TITLE
Fix duplicate Initialize-TestDrive

### DIFF
--- a/tests/Send-TelemetryToLogAnalytics.Tests.ps1
+++ b/tests/Send-TelemetryToLogAnalytics.Tests.ps1
@@ -1,7 +1,6 @@
 . $PSScriptRoot/TestHelpers.ps1
 Describe 'Send-TelemetryToLogAnalytics.ps1' {
     Initialize-TestDrive
-    Initialize-TestDrive
     Safe-It 'posts JSON telemetry to workspace URI' {
         $log = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         $event = @{Timestamp='2024-01-01T00:00:00Z'; Script='Test.ps1'; Result='Success'; Duration=1} | ConvertTo-Json -Compress


### PR DESCRIPTION
### Summary
Removed the redundant second call to `Initialize-TestDrive` in `Send-TelemetryToLogAnalytics.Tests.ps1` so initialization only runs once.

### File Citations
- `tests/Send-TelemetryToLogAnalytics.Tests.ps1`【F:tests/Send-TelemetryToLogAnalytics.Tests.ps1†L1-L8】

### Test Results
- ❌ `Invoke-Pester -Configuration` (failed to run successfully; many module dependencies missing)【8ac408†L1-L8】

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6847885c3ad8832cb5847e74fdd5eb6f