### PR TITLE
Wrap scheduled task registration in try/catch

### DIFF
--- a/scripts/Setup-ScheduledMaintenance.ps1
+++ b/scripts/Setup-ScheduledMaintenance.ps1
@@ -76,7 +76,11 @@ foreach ($name in $tasks.Keys) {
     $xml = New-MaintenanceTaskXml -TaskName $name -ScriptPath $tasks[$name]
     if ($Register) {
         Write-STStatus "Registering task $name" -Level INFO -Log
-        Register-ScheduledTask -TaskName $name -Xml $xml -Force | Out-Null
+        try {
+            Register-ScheduledTask -TaskName $name -Xml $xml -Force | Out-Null
+        } catch {
+            Write-STStatus "Failed registering task $name: $_" -Level ERROR -Log
+        }
     } else {
         $file = "$($name -replace ' ', '')Task.xml"
         Write-STStatus "Writing $file" -Level INFO -Log

--- a/src/MaintenancePlan/Public/Schedule-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/Schedule-MaintenancePlan.ps1
@@ -69,7 +69,11 @@ function Schedule-MaintenancePlan {
         }
 
         $action  = New-ScheduledTaskAction -Execute 'pwsh' -Argument "-NoProfile -Command \"$command\""
-        Register-ScheduledTask -TaskName $Name -Action $action -Trigger $trigger -Force | Out-Null
+        try {
+            Register-ScheduledTask -TaskName $Name -Action $action -Trigger $trigger -Force | Out-Null
+        } catch {
+            Write-STStatus "Failed registering scheduled task $Name: $_" -Level ERROR -Log
+        }
     } else {
         $entry = "$Cron pwsh -NoProfile -Command \"$command\" # $Name"
         Write-STStatus "Cron entry generated" -Level INFO -Log


### PR DESCRIPTION
### Summary
- handle registration failures in `Setup-ScheduledMaintenance.ps1`
- handle registration failures in `Schedule-MaintenancePlan.ps1`

### File Citations
- `scripts/Setup-ScheduledMaintenance.ps1`
- `src/MaintenancePlan/Public/Schedule-MaintenancePlan.ps1`

### Test Results
```
$cfg=Import-PowerShellDataFile "./PesterConfiguration.psd1"; Invoke-Pester -Configuration $cfg
# ... truncated output showing failures ...
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684788278e04832cadd1c667f6c51260