### PR TITLE
Add ShouldProcess to SupportTools cmdlets

### DIFF
--- a/src/SupportTools/Public/Clear-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Clear-ArchiveFolder.ps1
@@ -58,6 +58,7 @@ function Clear-ArchiveFolder {
         [object]$Config
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess('CleanupArchive.ps1')) { return }
         try {
             $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "CleanupArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
         } catch {

--- a/src/SupportTools/Public/Clear-TempFile.ps1
+++ b/src/SupportTools/Public/Clear-TempFile.ps1
@@ -27,6 +27,7 @@ function Clear-TempFile {
     )
 
     try {
+        if (-not $PSCmdlet.ShouldProcess('temporary files')) { return }
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
 
         $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '../../..')

--- a/src/SupportTools/Public/Convert-ExcelToCsv.ps1
+++ b/src/SupportTools/Public/Convert-ExcelToCsv.ps1
@@ -31,6 +31,7 @@ function Convert-ExcelToCsv {
     )
 
     try {
+        if (-not $PSCmdlet.ShouldProcess($XlsxFilePath, 'Convert to CSV')) { return }
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
 
         Write-STStatus "Converting $XlsxFilePath to CSV..." -Level INFO

--- a/src/SupportTools/Public/Export-ITReport.ps1
+++ b/src/SupportTools/Public/Export-ITReport.ps1
@@ -45,6 +45,7 @@ function Export-ITReport {
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
     }
     process {
+        if (-not $PSCmdlet.ShouldProcess($OutputPath, 'Export IT report')) { return }
         # Add each augmented object without reallocating an array
         $items.Add( ($Data | Add-Member -NotePropertyName OsBuild -NotePropertyValue $osBuild -PassThru) )
     }

--- a/src/SupportTools/Public/Export-ProductKey.ps1
+++ b/src/SupportTools/Public/Export-ProductKey.ps1
@@ -31,6 +31,7 @@ function Export-ProductKey {
     )
 
     try {
+        if (-not $PSCmdlet.ShouldProcess($OutputPath, 'Export product key')) { return }
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
 
         try {

--- a/src/SupportTools/Public/Get-UniquePermission.ps1
+++ b/src/SupportTools/Public/Get-UniquePermission.ps1
@@ -55,6 +55,7 @@ function Get-UniquePermission {
         [object]$Config
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess('Get-UniquePermissions.ps1')) { return }
         try {
             $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "Get-UniquePermissions.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
         } catch {

--- a/src/SupportTools/Public/Invoke-JobBundle.ps1
+++ b/src/SupportTools/Public/Invoke-JobBundle.ps1
@@ -31,6 +31,7 @@ function Invoke-JobBundle {
     )
 
     process {
+        if (-not $PSCmdlet.ShouldProcess($Path, 'Execute job bundle')) { return }
         if (-not $LogArchivePath) {
             $LogArchivePath = $Path -replace '\\.zip$','-logs.zip'
         }

--- a/src/SupportTools/Public/Invoke-NewHireUserAutomation.ps1
+++ b/src/SupportTools/Public/Invoke-NewHireUserAutomation.ps1
@@ -67,6 +67,7 @@ function Invoke-NewHireUserAutomation {
         [object]$Config
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess('New hire automation')) { return }
         try {
             $args = @('-PollMinutes', $PollMinutes)
             if ($Once) { $args += '-Once' }

--- a/src/SupportTools/Public/Invoke-PerformanceAudit.ps1
+++ b/src/SupportTools/Public/Invoke-PerformanceAudit.ps1
@@ -47,6 +47,7 @@ function Invoke-PerformanceAudit {
         [Parameter(Mandatory = $false)][object]$Config
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess('Invoke-PerformanceAudit.ps1')) { return }
         try {
             $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Invoke-PerformanceAudit.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
         } catch {

--- a/src/SupportTools/Public/New-SPUsageReport.ps1
+++ b/src/SupportTools/Public/New-SPUsageReport.ps1
@@ -54,6 +54,7 @@ function New-SPUsageReport {
         [object]$Config
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess('Generate-SPUsageReport.ps1')) { return }
         try {
             $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name 'Generate-SPUsageReport.ps1' -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
         } catch {

--- a/src/SupportTools/Public/Restore-ArchiveFolder.ps1
+++ b/src/SupportTools/Public/Restore-ArchiveFolder.ps1
@@ -57,6 +57,7 @@ function Restore-ArchiveFolder {
         [object]$Config
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess('RollbackArchive.ps1')) { return }
         try {
             $output = Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "RollbackArchive.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
         } catch {

--- a/src/SupportTools/Public/Search-ReadMe.ps1
+++ b/src/SupportTools/Public/Search-ReadMe.ps1
@@ -31,6 +31,7 @@ function Search-ReadMe {
     $pattern = Get-STConfigValue -Config $STDefaults -Key 'ReadmePattern'
 
     if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+    if (-not $PSCmdlet.ShouldProcess('readme search')) { return }
     try {
         Write-STStatus -Message 'Searching for readme files...' -Level INFO
         $results = Get-ChildItem -Path $pattern -Recurse -File -ErrorAction SilentlyContinue

--- a/src/SupportTools/Public/Sync-SupportTools.ps1
+++ b/src/SupportTools/Public/Sync-SupportTools.ps1
@@ -49,6 +49,7 @@ function Sync-SupportTools {
     )
 
     try {
+        if (-not $PSCmdlet.ShouldProcess($InstallPath, 'Synchronize SupportTools repository')) { return }
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
         if ($Logger) {
             Import-Module $Logger -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
### Summary
- ensure SupportTools cmdlets actually invoke `ShouldProcess`

### File Citations
- `src/SupportTools/Public/Get-UniquePermission.ps1`【F:src/SupportTools/Public/Get-UniquePermission.ps1†L35-L69】
- `src/SupportTools/Public/Export-ProductKey.ps1`【F:src/SupportTools/Public/Export-ProductKey.ps1†L22-L41】
- `src/SupportTools/Public/Export-ITReport.ps1`【F:src/SupportTools/Public/Export-ITReport.ps1†L28-L68】
- `src/SupportTools/Public/Invoke-NewHireUserAutomation.ps1`【F:src/SupportTools/Public/Invoke-NewHireUserAutomation.ps1†L44-L79】
- `src/SupportTools/Public/New-SPUsageReport.ps1`【F:src/SupportTools/Public/New-SPUsageReport.ps1†L36-L69】
- `src/SupportTools/Public/Sync-SupportTools.ps1`【F:src/SupportTools/Public/Sync-SupportTools.ps1†L28-L63】
- `src/SupportTools/Public/Invoke-JobBundle.ps1`【F:src/SupportTools/Public/Invoke-JobBundle.ps1†L20-L59】
- `src/SupportTools/Public/Clear-ArchiveFolder.ps1`【F:src/SupportTools/Public/Clear-ArchiveFolder.ps1†L40-L71】
- `src/SupportTools/Public/Search-ReadMe.ps1`【F:src/SupportTools/Public/Search-ReadMe.ps1†L18-L44】
- `src/SupportTools/Public/Convert-ExcelToCsv.ps1`【F:src/SupportTools/Public/Convert-ExcelToCsv.ps1†L20-L50】
- `src/SupportTools/Public/Invoke-PerformanceAudit.ps1`【F:src/SupportTools/Public/Invoke-PerformanceAudit.ps1†L36-L61】
- `src/SupportTools/Public/Restore-ArchiveFolder.ps1`【F:src/SupportTools/Public/Restore-ArchiveFolder.ps1†L40-L70】
- `src/SupportTools/Public/Clear-TempFile.ps1`【F:src/SupportTools/Public/Clear-TempFile.ps1†L20-L52】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68478852ac50832c95a05212772be142