### PR TITLE
Add With-TestEnvironmentVariable helper

### DIFF
--- a/tests/ConfigManagementTools/Test-Drift.Tests.ps1
+++ b/tests/ConfigManagementTools/Test-Drift.Tests.ps1
@@ -13,13 +13,11 @@ Describe 'Test-Drift function' {
             $baseline | ConvertTo-Json | Set-Content -Path $file
             Mock Get-TimeZone { [pscustomobject]@{ Id='EST' } }
             Mock Get-Service { [pscustomobject]@{ Status='Stopped' } }
-            $env:COMPUTERNAME = 'HOST2'
-            try {
+            With-TestEnvironmentVariable -Name COMPUTERNAME -Value 'HOST2' -ScriptBlock {
                 $result = Test-Drift -BaselinePath $file
                 $result.Count | Should -Be 3
-            } finally {
-                Remove-Item $file -ErrorAction SilentlyContinue
             }
+            Remove-Item $file -ErrorAction SilentlyContinue
         }
     }
 
@@ -30,13 +28,11 @@ Describe 'Test-Drift function' {
             $baseline | ConvertTo-Json | Set-Content -Path $file
             Mock Get-TimeZone { [pscustomobject]@{ Id='UTC' } }
             Mock Get-Service { [pscustomobject]@{ Status='Running' } }
-            $env:COMPUTERNAME = 'HOST1'
-            try {
+            With-TestEnvironmentVariable -Name COMPUTERNAME -Value 'HOST1' -ScriptBlock {
                 $result = Test-Drift -BaselinePath $file
                 $result.Count | Should -Be 0
-            } finally {
-                Remove-Item $file -ErrorAction SilentlyContinue
             }
+            Remove-Item $file -ErrorAction SilentlyContinue
         }
     }
 
@@ -47,13 +43,11 @@ Describe 'Test-Drift function' {
             $baseline | ConvertTo-Json | Set-Content -Path $file
             Mock Get-TimeZone { [pscustomobject]@{ Id='EST' } }
             Mock Get-Service { [pscustomobject]@{ Status='Stopped' } }
-            $env:COMPUTERNAME = 'HOST2'
-            try {
+            With-TestEnvironmentVariable -Name COMPUTERNAME -Value 'HOST2' -ScriptBlock {
                 $result = [pscustomobject]@{ BaselinePath = $file } | Test-Drift
                 $result.Count | Should -Be 3
-            } finally {
-                Remove-Item $file -ErrorAction SilentlyContinue
             }
+            Remove-Item $file -ErrorAction SilentlyContinue
         }
     }
 }

--- a/tests/Send-TelemetryToLogAnalytics.Tests.ps1
+++ b/tests/Send-TelemetryToLogAnalytics.Tests.ps1
@@ -8,16 +8,16 @@ Describe 'Send-TelemetryToLogAnalytics.ps1' {
         Set-Content -Path $log -Value $event
         Mock Invoke-RestMethod {} -Verifiable
         try {
-            $env:ST_ENABLE_TELEMETRY = '1'
-            & $PSScriptRoot/../scripts/Send-TelemetryToLogAnalytics.ps1 -WorkspaceId 'ws123' -WorkspaceKey 'Zg==' -LogPath $log
-            Assert-MockCalled Invoke-RestMethod -ParameterFilter {
-                $Method -eq 'Post' -and
-                $Uri -eq 'https://ws123.ods.opinsights.azure.com/api/logs?api-version=2016-04-01' -and
-                $Body -is [string] -and (($Body | ConvertFrom-Json)[0].Script -eq 'Test.ps1')
-            } -Times 1
+            With-TestEnvironmentVariable -Name ST_ENABLE_TELEMETRY -Value '1' -ScriptBlock {
+                & $PSScriptRoot/../scripts/Send-TelemetryToLogAnalytics.ps1 -WorkspaceId 'ws123' -WorkspaceKey 'Zg==' -LogPath $log
+                Assert-MockCalled Invoke-RestMethod -ParameterFilter {
+                    $Method -eq 'Post' -and
+                    $Uri -eq 'https://ws123.ods.opinsights.azure.com/api/logs?api-version=2016-04-01' -and
+                    $Body -is [string] -and (($Body | ConvertFrom-Json)[0].Script -eq 'Test.ps1')
+                } -Times 1
+            }
         } finally {
             Remove-Item $log -ErrorAction SilentlyContinue
-            Remove-Item env:ST_ENABLE_TELEMETRY -ErrorAction SilentlyContinue
         }
     }
 }

--- a/tests/TestHelpers.ps1
+++ b/tests/TestHelpers.ps1
@@ -34,3 +34,27 @@ function Initialize-TestDrive {
     }
 }
 
+function With-TestEnvironmentVariable {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [string]$Value,
+        [Parameter(Mandatory)][scriptblock]$ScriptBlock
+    )
+
+    $existing = Get-Item "env:$Name" -ErrorAction SilentlyContinue
+    try {
+        if ($PSBoundParameters.ContainsKey('Value')) {
+            Set-Item -Path "env:$Name" -Value $Value
+        } else {
+            Remove-Item "env:$Name" -ErrorAction SilentlyContinue
+        }
+        & $ScriptBlock
+    } finally {
+        if ($null -ne $existing) {
+            Set-Item -Path "env:$Name" -Value $existing.Value
+        } else {
+            Remove-Item "env:$Name" -ErrorAction SilentlyContinue
+        }
+    }
+}
+


### PR DESCRIPTION
### Summary
- add `With-TestEnvironmentVariable` helper
- update Telemetry, Test-Drift, and Send-TelemetryToLogAnalytics tests to use the helper

### File Citations
- tests/TestHelpers.ps1【F:tests/TestHelpers.ps1†L37-L59】
- tests/Telemetry.Tests.ps1 excerpt showing new usage【F:tests/Telemetry.Tests.ps1†L14-L38】
- tests/ConfigManagementTools/Test-Drift.Tests.ps1 excerpt showing new usage【F:tests/ConfigManagementTools/Test-Drift.Tests.ps1†L10-L19】
- tests/Send-TelemetryToLogAnalytics.Tests.ps1 excerpt showing new usage【F:tests/Send-TelemetryToLogAnalytics.Tests.ps1†L8-L20】

### Test Results
- ❌ `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)` failed: drive already exists【58fe14†L1-L7】

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684788484878832cab72367110f92e27