### PR TITLE
Add archive cleanup tests

### DIFF
--- a/scripts/Ensure-TestCoverage.ps1
+++ b/scripts/Ensure-TestCoverage.ps1
@@ -6,7 +6,7 @@ $publicFunctions = Get-ChildItem -Path $publicDir -Filter '*.ps1' | ForEach-Obje
 $missing = [System.Collections.Generic.List[object]]::new()
 foreach ($func in $publicFunctions) {
     $pattern = "\b$func\b"
-    $found = Select-String -Path (Join-Path $testDir '*.ps1') -Pattern $pattern -SimpleMatch -CaseSensitive -Quiet
+    $found = Select-String -Path (Join-Path $testDir '*.ps1') -Pattern $pattern -CaseSensitive -Quiet
     if (-not $found) {
         Write-Error "No tests found referencing function '$func'"
         # Use Add() to avoid array resizing in the loop

--- a/tests/SupportTools/ArchiveFolder.Tests.ps1
+++ b/tests/SupportTools/ArchiveFolder.Tests.ps1
@@ -1,0 +1,44 @@
+. $PSScriptRoot/../TestHelpers.ps1
+Describe 'Archive folder functions' {
+    Initialize-TestDrive
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/SupportTools/SupportTools.psd1 -Force
+    }
+
+    Context 'Clear-ArchiveFolder' {
+        Safe-It 'forwards parameters to script' {
+            InModuleScope SupportTools {
+                Mock Invoke-ScriptFile { 'ok' } -ModuleName SupportTools
+                $res = Clear-ArchiveFolder -Arguments @('-SiteUrl','test') -TranscriptPath 't.log' -Simulate -Explain
+                Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -Times 1 -ParameterFilter {
+                    $Name -eq 'CleanupArchive.ps1' -and
+                    $Args -contains '-SiteUrl' -and
+                    $Args -contains 'test' -and
+                    $TranscriptPath -eq 't.log' -and
+                    $Simulate -and $Explain
+                }
+                $res.Script | Should -Be 'CleanupArchive.ps1'
+                $res.Result | Should -Be 'ok'
+            }
+        }
+    }
+
+    Context 'Restore-ArchiveFolder' {
+        Safe-It 'forwards parameters to script' {
+            InModuleScope SupportTools {
+                Mock Invoke-ScriptFile { 'res' } -ModuleName SupportTools
+                $res = Restore-ArchiveFolder -Arguments @('-SnapshotPath','snap.json') -TranscriptPath 'log.txt' -Simulate -Explain
+                Assert-MockCalled Invoke-ScriptFile -ModuleName SupportTools -Times 1 -ParameterFilter {
+                    $Name -eq 'RollbackArchive.ps1' -and
+                    $Args -contains '-SnapshotPath' -and
+                    $Args -contains 'snap.json' -and
+                    $TranscriptPath -eq 'log.txt' -and
+                    $Simulate -and $Explain
+                }
+                $res.Script | Should -Be 'RollbackArchive.ps1'
+                $res.Result | Should -Be 'res'
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- fix regex in test coverage script
- add ArchiveFolder tests for SupportTools

### File Citations
- `scripts/Ensure-TestCoverage.ps1`
- `tests/SupportTools/ArchiveFolder.Tests.ps1`

### Test Results
- `Invoke-Pester -Configuration (Import-PowerShellDataFile -Path ./PesterConfiguration.psd1)` *(fails: New-PSDrive TestDrive already exists, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6847883c1f88832cbb8df2aa01247366