### PR TITLE
Improve mock API server robustness

### DIFF
--- a/scripts/Start-MockApiServer.ps1
+++ b/scripts/Start-MockApiServer.ps1
@@ -4,37 +4,56 @@ param(
 
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 
+$stopServer = $false
+$cancelHandler = {
+    param($sender, $eventArgs)
+    $global:stopServer = $true
+    $eventArgs.Cancel = $true
+}
+[Console]::add_CancelKeyPress($cancelHandler)
+
 $listener = [System.Net.HttpListener]::new()
 $listener.Prefixes.Add("http://localhost:$Port/")
 
 try {
     $listener.Start()
     Write-STStatus "Mock API server listening on http://localhost:$Port/" -Level SUCCESS
-    while ($listener.IsListening) {
-        $context = $listener.GetContext()
-        $path = $context.Request.RawUrl
-        switch -Wildcard ($path) {
-            '/graph/*' {
-                $payload = @{ value = 'fake Graph response' } | ConvertTo-Json
-                $bytes = [System.Text.Encoding]::UTF8.GetBytes($payload)
-                $context.Response.ContentType = 'application/json'
-                $context.Response.ContentLength64 = $bytes.Length
-                $context.Response.OutputStream.Write($bytes,0,$bytes.Length)
-            }
-            '/pnp/*' {
-                $payload = @{ value = 'fake PnP response' } | ConvertTo-Json
-                $bytes = [System.Text.Encoding]::UTF8.GetBytes($payload)
-                $context.Response.ContentType = 'application/json'
-                $context.Response.ContentLength64 = $bytes.Length
-                $context.Response.OutputStream.Write($bytes,0,$bytes.Length)
-            }
-            default {
-                $context.Response.StatusCode = 404
-            }
+    while ($listener.IsListening -and -not $global:stopServer) {
+        try {
+            $context = $listener.GetContext()
+        } catch {
+            continue
         }
-        $context.Response.Close()
+
+        $path = $context.Request.RawUrl
+        try {
+            switch -Wildcard ($path) {
+                '/graph/*' {
+                    $payload = @{ value = 'fake Graph response' } | ConvertTo-Json
+                    $bytes = [System.Text.Encoding]::UTF8.GetBytes($payload)
+                    $context.Response.ContentType = 'application/json'
+                    $context.Response.ContentLength64 = $bytes.Length
+                    $context.Response.OutputStream.Write($bytes,0,$bytes.Length)
+                }
+                '/pnp/*' {
+                    $payload = @{ value = 'fake PnP response' } | ConvertTo-Json
+                    $bytes = [System.Text.Encoding]::UTF8.GetBytes($payload)
+                    $context.Response.ContentType = 'application/json'
+                    $context.Response.ContentLength64 = $bytes.Length
+                    $context.Response.OutputStream.Write($bytes,0,$bytes.Length)
+                }
+                default {
+                    $context.Response.StatusCode = 404
+                }
+            }
+        } catch {
+            Write-STStatus -Message "Failed to write response: $($_.Exception.Message)" -Level ERROR
+        } finally {
+            try { $context.Response.Close() } catch {}
+        }
     }
 }
 finally {
     $listener.Stop()
+    [Console]::remove_CancelKeyPress($cancelHandler)
 }


### PR DESCRIPTION
### Summary
- allow breaking the mock API loop with Ctrl+C
- handle exceptions when accepting connections or sending responses

### File Citations
- `scripts/Start-MockApiServer.ps1` updated to trap Ctrl+C and wrap network operations in `try/catch` blocks【F:scripts/Start-MockApiServer.ps1†L7-L58】

### Test Results
- ❌ `Invoke-Pester -Configuration ./PesterConfiguration.psd1` (failed to run due to missing modules and environment setup)【02e339†L1-L66】


------
https://chatgpt.com/codex/tasks/task_e_6847883a419c832cba6ae13390d030b9