### PR TITLE
Add vault secret helper

### DIFF
--- a/src/STCore/STCore.psd1
+++ b/src/STCore/STCore.psd1
@@ -4,5 +4,5 @@
     GUID = 'b6b7e080-4ad4-4d58-8b8c-000000000000'
     Author = 'Contoso'
     Description = 'Core utility functions.'
-    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Get-STConfigValue','Invoke-STRequest')
+    FunctionsToExport = @('Assert-ParameterNotNull','New-STErrorObject','New-STErrorRecord','Write-STDebug','Test-IsElevated','Get-STConfig','Get-STConfigValue','Invoke-STRequest','Get-STSecret')
 }

--- a/src/STPlatform/Public/Connect-EntraID.ps1
+++ b/src/STPlatform/Public/Connect-EntraID.ps1
@@ -32,17 +32,9 @@ function Connect-EntraID {
 
         $required = 'GRAPH_TENANT_ID','GRAPH_CLIENT_ID','GRAPH_CLIENT_SECRET'
         foreach ($name in $required) {
-            if (-not $env:$name) {
-                $getParams = @{ Name = $name; AsPlainText = $true; ErrorAction = 'SilentlyContinue' }
-                if ($PSBoundParameters.ContainsKey('Vault')) { $getParams.Vault = $Vault }
-                $val = Get-Secret @getParams
-                if ($val) {
-                    $env:$name = $val
-                    Write-STStatus "Loaded $name from vault" -Level SUB -Log
-                } else {
-                    Write-STStatus "$name not found in vault" -Level WARN -Log
-                }
-            }
+            $params = @{ Name = $name }
+            if ($PSBoundParameters.ContainsKey('Vault')) { $params.Vault = $Vault }
+            Get-STSecret @params | Out-Null
         }
 
         if (-not $TenantId)     { $TenantId     = $env:GRAPH_TENANT_ID }

--- a/src/STPlatform/Public/Connect-STPlatform.ps1
+++ b/src/STPlatform/Public/Connect-STPlatform.ps1
@@ -37,17 +37,9 @@ function Connect-STPlatform {
 
         $requiredVars = 'SPTOOLS_CLIENT_ID','SPTOOLS_TENANT_ID','SPTOOLS_CERT_PATH','SD_API_TOKEN','SD_BASE_URI'
         foreach ($name in $requiredVars) {
-            if (-not $env:$name) {
-                $getParams = @{ Name = $name; AsPlainText = $true; ErrorAction = 'SilentlyContinue' }
-                if ($PSBoundParameters.ContainsKey('Vault')) { $getParams.Vault = $Vault }
-                $val = Get-Secret @getParams
-                if ($val) {
-                    $env:$name = $val
-                    Write-STStatus "Loaded $name from vault" -Level SUB -Log
-                } else {
-                    Write-STStatus "$name not found in vault" -Level WARN -Log
-                }
-            }
+            $params = @{ Name = $name }
+            if ($PSBoundParameters.ContainsKey('Vault')) { $params.Vault = $Vault }
+            Get-STSecret @params | Out-Null
         }
         $modules = switch ($Mode) {
             'Cloud'  { @('Microsoft.Graph','ExchangeOnlineManagement') }

--- a/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
+++ b/src/ServiceDeskTools/Private/Invoke-SDRequest.ps1
@@ -14,13 +14,9 @@ function Invoke-SDRequest {
     $baseUri = if ($BaseUri) { $BaseUri } else { $env:SD_BASE_URI }
     if (-not $baseUri) { $baseUri = 'https://api.samanage.com' }
 
-    $token = $env:SD_API_TOKEN
-    if (-not $token) {
-        $getParams = @{ Name = 'SD_API_TOKEN'; AsPlainText = $true; ErrorAction = 'SilentlyContinue' }
-        if ($PSBoundParameters.ContainsKey('Vault')) { $getParams.Vault = $Vault }
-        $token = Get-Secret @getParams
-        if ($token) { $env:SD_API_TOKEN = $token } else { throw 'SD_API_TOKEN environment variable must be set.' }
-    }
+    $params = @{ Name = 'SD_API_TOKEN'; Required = $true }
+    if ($PSBoundParameters.ContainsKey('Vault')) { $params.Vault = $Vault }
+    $token = Get-STSecret @params
 
     $rateLimit = if ($env:SD_RATE_LIMIT_PER_MINUTE) { [int]$env:SD_RATE_LIMIT_PER_MINUTE } else { $null }
     Wait-SDRateLimit -RateLimit $rateLimit

--- a/tests/STCore.Tests.ps1
+++ b/tests/STCore.Tests.ps1
@@ -14,7 +14,8 @@ Describe 'STCore Module' {
             'Test-IsElevated',
             'Get-STConfig',
             'Get-STConfigValue',
-            'Invoke-STRequest'
+            'Invoke-STRequest',
+            'Get-STSecret'
         )
 
         $exported = (Get-Command -Module STCore).Name


### PR DESCRIPTION
### Summary
- add `Get-STSecret` helper in STCore for vault backed env variables
- update ServiceDeskTools and STPlatform to use the helper
- export new function and update tests

### File Citations
- `src/STCore/STCore.psm1` lines 170-216 introduce the new `Get-STSecret` function
- `src/STCore/STCore.psd1` lines 1-8 export the helper
- `src/STPlatform/Public/Connect-STPlatform.ps1` lines 38-43 replace inline secret loading
- `src/STPlatform/Public/Connect-EntraID.ps1` lines 33-38 call the helper
- `src/ServiceDeskTools/Private/Invoke-SDRequest.ps1` lines 17-19 fetch the API token with the helper

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6847883abf60832cbd6207f46a912398