### PR TITLE
Add GroupId support for AddUsersToGroup

### DIFF
--- a/tests/AddUsersToGroup.Tests.ps1
+++ b/tests/AddUsersToGroup.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'AddUsersToGroup Script' {
         function Get-ADGroup {}
         function Get-ADGroupMember {}
         function Get-ADUser {}
-        function Get-Group { param([string]$GroupName) }
+        function Get-Group { param([string]$GroupName,[string]$GroupId) }
         function Get-GroupExistingMembers { param($Group) }
         function Get-CSVFilePath {}
         function Import-Csv { param([string]$Path) }
@@ -56,5 +56,10 @@ Describe 'AddUsersToGroup Script' {
         Start-Main -CsvPath 'dummy.csv' -GroupName 'Group' -Cloud 'AD' | Out-Null
         Assert-MockCalled Add-ADGroupMember -Times 1
         Assert-MockCalled Connect-MgGraph -Times 0
+    }
+
+    Safe-It 'accepts a GroupId to bypass selection' {
+        Start-Main -CsvPath 'dummy.csv' -GroupId '1' | Out-Null
+        Assert-MockCalled Get-Group -ParameterFilter { $GroupId -eq '1' } -Times 1
     }
 }


### PR DESCRIPTION
### Summary
- allow AddUsersToGroup.ps1 to accept a GroupId parameter
- document GroupId and related options in the script help
- cover the new parameter in tests

### File Citations
- **scripts/AddUsersToGroup.ps1** adds docs and parameter handling for `GroupId`【F:scripts/AddUsersToGroup.ps1†L17-L52】【F:scripts/AddUsersToGroup.ps1†L124-L160】【F:scripts/AddUsersToGroup.ps1†L203-L306】
- **tests/AddUsersToGroup.Tests.ps1** mocks the new parameter and verifies usage【F:tests/AddUsersToGroup.Tests.ps1†L15-L30】【F:tests/AddUsersToGroup.Tests.ps1†L52-L65】

### Test Results
```
root@9e9d05b069ef:/workspace/PowerShell# tail -n 20 /tmp/pester.log
[-] Start-HealthMonitor and Stop-HealthMonitor.honors ST_HEALTH_INTERVAL when IntervalSeconds not specified 1ms (1ms|0ms)
 ParameterBindingValidationException: Cannot bind argument to parameter 'Root' because it is null.
...
Covered 4.47% / 80%. 4,965 analyzed Commands in 145 Files.
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68478a9a310c832cb56a541ba9c10921