### PR TITLE
Fix ShouldProcess use in Invoke-MaintenancePlan

### DIFF
--- a/src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1
@@ -14,11 +14,12 @@ function Invoke-MaintenancePlan {
     Assert-ParameterNotNull $Plan 'Plan'
     foreach ($step in $Plan.Steps) {
         Write-STStatus "Running $step" -Level INFO -Log
-        if (-not $PSCmdlet.ShouldProcess($step)) { continue }
-        if (Test-Path $step) {
-            & $step
-        } else {
-            Invoke-Expression $step
+        if ($PSCmdlet.ShouldProcess($step)) {
+            if (Test-Path $step) {
+                & $step
+            } else {
+                Invoke-Expression $step
+            }
         }
     }
 }


### PR DESCRIPTION
### Summary
- wrap maintenance plan step execution in `ShouldProcess`

### File Citations
- `src/MaintenancePlan/Public/Invoke-MaintenancePlan.ps1` lines 15-24

### Test Results
- ❌ `Invoke-Pester` (failed to run: `pwsh: command not found`)
  
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68478ce77448832cb8d50d0234baaf61