### PR TITLE
Ensure ShouldProcess usage is consistent

### DIFF
--- a/src/ChaosTools/Public/Invoke-ChaosTest.ps1
+++ b/src/ChaosTools/Public/Invoke-ChaosTest.ps1
@@ -14,7 +14,7 @@ function Invoke-ChaosTest {
     .PARAMETER MaxDelaySeconds
         Maximum random delay before execution.
     #>
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNull()]

--- a/src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1
@@ -81,6 +81,7 @@ function Invoke-CompanyPlaceManagement {
         }
 
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+        if (-not $PSCmdlet.ShouldProcess($DisplayName, "Invoke CompanyPlaceManagement -Action $Action")) { return }
         Write-STStatus "Invoke-CompanyPlaceManagement -Action $Action" -Level SUCCESS -Log
         if ($Simulate) {
             Write-STStatus -Message 'Simulation mode active - no Microsoft Places changes will be made.' -Level WARN -Log

--- a/src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1
@@ -46,6 +46,7 @@ function Invoke-ExchangeCalendarManager {
         }
 
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+        if (-not $PSCmdlet.ShouldProcess('calendar', 'Manage Exchange calendar')) { return }
         Write-STStatus -Message 'ExchangeCalendarManager launched' -Level SUCCESS -Log
         if ($Simulate) {
             Write-STStatus -Message 'Simulation mode active - no Exchange operations will occur.' -Level WARN -Log

--- a/src/ConfigManagementTools/Public/Out-CompanyPlace.ps1
+++ b/src/ConfigManagementTools/Public/Out-CompanyPlace.ps1
@@ -1,5 +1,5 @@
 function Out-CompanyPlace {
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline)]
         [ValidateNotNull()]

--- a/src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1
+++ b/src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1
@@ -68,6 +68,7 @@ function Set-SharedMailboxAutoReply {
         }
 
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
+        if (-not $PSCmdlet.ShouldProcess($MailboxIdentity, 'Configure auto-reply')) { return }
         $sw = [System.Diagnostics.Stopwatch]::StartNew()
         $result = 'Success'
         Write-STStatus -Message 'Running Set-SharedMailboxAutoReply' -Level SUCCESS -Log

--- a/src/ConfigManagementTools/Public/Test-Drift.ps1
+++ b/src/ConfigManagementTools/Public/Test-Drift.ps1
@@ -11,7 +11,7 @@ function Test-Drift {
     .EXAMPLE
         Test-Drift -BaselinePath './baseline.json'
     #>
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]

--- a/src/EntraIDTools/Public/Get-GraphGroupDetails.ps1
+++ b/src/EntraIDTools/Public/Get-GraphGroupDetails.ps1
@@ -5,7 +5,7 @@ function Get-GraphGroupDetails {
     .DESCRIPTION
         Queries Graph for the group's basic info and membership. Activity is logged and telemetry is recorded.
     #>
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]

--- a/src/EntraIDTools/Public/Get-GraphUserDetails.ps1
+++ b/src/EntraIDTools/Public/Get-GraphUserDetails.ps1
@@ -110,8 +110,16 @@ function Get-GraphUserDetails {
             }
         }
 
-        if ($CsvPath)  { $details | Export-Csv -Path $CsvPath -NoTypeInformation }
-        if ($HtmlPath) { $details | ConvertTo-Html -Title 'User Details' | Out-File -FilePath $HtmlPath }
+        if ($CsvPath)  {
+            if ($PSCmdlet.ShouldProcess($CsvPath, 'Write CSV')) {
+                $details | Export-Csv -Path $CsvPath -NoTypeInformation
+            }
+        }
+        if ($HtmlPath) {
+            if ($PSCmdlet.ShouldProcess($HtmlPath, 'Write HTML')) {
+                $details | ConvertTo-Html -Title 'User Details' | Out-File -FilePath $HtmlPath
+            }
+        }
 
         return $details
     } catch {

--- a/src/EntraIDTools/Public/Get-UserInfoHybrid.ps1
+++ b/src/EntraIDTools/Public/Get-UserInfoHybrid.ps1
@@ -19,7 +19,7 @@ function Get-UserInfoHybrid {
     .EXAMPLE
         Get-UserInfoHybrid -UserPrincipalName user@contoso.com -TenantId 00000000-0000-0000-0000-000000000000 -ClientId 11111111-1111-1111-1111-111111111111
     #>
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]

--- a/src/IncidentResponseTools/Public/Get-CommonSystemInfo.ps1
+++ b/src/IncidentResponseTools/Public/Get-CommonSystemInfo.ps1
@@ -10,7 +10,7 @@ function Get-CommonSystemInfo {
         PSCustomObject with ComputerName, OSVersion, OSBuild, Processor,
         MemoryGB (GB) and DiskSpace details.
     #>
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]
         [ValidateNotNull()]

--- a/src/MaintenancePlan/Public/Export-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/Export-MaintenancePlan.ps1
@@ -17,6 +17,7 @@ function Export-MaintenancePlan {
         [string]$Path
     )
     process {
+        if (-not $PSCmdlet.ShouldProcess($Path, 'Export maintenance plan')) { return }
         $Plan | ConvertTo-Json -Depth 5 | Set-Content -Path $Path
         Write-STStatus "Plan exported to $Path" -Level SUCCESS -Log
     }

--- a/src/MaintenancePlan/Public/Import-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/Import-MaintenancePlan.ps1
@@ -5,7 +5,7 @@ function Import-MaintenancePlan {
     .PARAMETER Path
         Path to the JSON file.
     #>
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]

--- a/src/MaintenancePlan/Public/New-MaintenancePlan.ps1
+++ b/src/MaintenancePlan/Public/New-MaintenancePlan.ps1
@@ -11,7 +11,7 @@ function New-MaintenancePlan {
     .PARAMETER Schedule
         Optional description of the schedule.
     #>
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]

--- a/src/MonitoringTools/Public/Get-EventLogSummary.ps1
+++ b/src/MonitoringTools/Public/Get-EventLogSummary.ps1
@@ -6,7 +6,7 @@ function Get-EventLogSummary {
         Returns counts of Error and Warning events from the specified log within the last N hours.
         A structured log entry summarising the results is written.
     #>
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [CmdletBinding()]
     param(
         [ValidateNotNullOrEmpty()]
         [string]$LogName = 'System',

--- a/src/MonitoringTools/Public/Get-SystemHealth.ps1
+++ b/src/MonitoringTools/Public/Get-SystemHealth.ps1
@@ -6,7 +6,7 @@ function Get-SystemHealth {
         Returns CPU usage, disk free space and recent event log summary.
         The combined snapshot is also written to the structured log.
     #>
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [CmdletBinding()]
     param()
 
     $computer = Get-STComputerName

--- a/src/STPlatform/Public/Connect-STPlatform.ps1
+++ b/src/STPlatform/Public/Connect-STPlatform.ps1
@@ -26,6 +26,7 @@ function Connect-STPlatform {
     )
 
     if (-not $ChaosMode) { $ChaosMode = [bool]$env:ST_CHAOS_MODE }
+    if (-not $PSCmdlet.ShouldProcess($Mode, 'Connect-STPlatform')) { return }
 
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $result = 'Success'

--- a/src/SupportTools/Public/Clear-TempFile.ps1
+++ b/src/SupportTools/Public/Clear-TempFile.ps1
@@ -30,6 +30,7 @@ function Clear-TempFile {
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
 
         $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '../../..')
+        if (-not $PSCmdlet.ShouldProcess($repoRoot, 'Remove temporary files')) { return }
         Write-STStatus -Message 'Cleaning temporary files...' -Level INFO
         try {
             $tmpFiles  = Get-ChildItem -Path $repoRoot -Recurse -Include '*.tmp' -File -ErrorAction Stop

--- a/src/SupportTools/Public/Convert-ExcelToCsv.ps1
+++ b/src/SupportTools/Public/Convert-ExcelToCsv.ps1
@@ -33,6 +33,7 @@ function Convert-ExcelToCsv {
     try {
         if ($TranscriptPath) { Start-Transcript -Path $TranscriptPath -Append | Out-Null }
 
+        if (-not $PSCmdlet.ShouldProcess($XlsxFilePath, 'Convert to CSV')) { return }
         Write-STStatus "Converting $XlsxFilePath to CSV..." -Level INFO
         $excel = New-Object -ComObject Excel.Application
         $workbook = $excel.Workbooks.Open($XlsxFilePath)

--- a/src/SupportTools/Public/Export-ITReport.ps1
+++ b/src/SupportTools/Public/Export-ITReport.ps1
@@ -59,6 +59,7 @@ function Export-ITReport {
                 }
                 $OutputPath = Join-Path (Get-Location) "ITReport_$((Get-Date).ToString('yyyyMMdd_HHmmss')).$ext"
             }
+            if (-not $PSCmdlet.ShouldProcess($OutputPath, 'Export IT report')) { return }
             switch ($Format) {
                 'HTML' {
                     $items | ConvertTo-Html -PreContent '<h1>IT Report</h1>' | Out-File -FilePath $OutputPath -Encoding utf8

--- a/src/SupportTools/Public/Export-ProductKey.ps1
+++ b/src/SupportTools/Public/Export-ProductKey.ps1
@@ -45,6 +45,7 @@ function Export-ProductKey {
             return
         }
 
+        if (-not $PSCmdlet.ShouldProcess($OutputPath, 'Export product key')) { return }
         try {
             Set-Content -Path $OutputPath -Value $key -ErrorAction Stop
         } catch {

--- a/src/SupportTools/Public/Search-ReadMe.ps1
+++ b/src/SupportTools/Public/Search-ReadMe.ps1
@@ -18,7 +18,7 @@ function Search-ReadMe {
     .NOTES
         This command can take several minutes to run on large drives.
     #>
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]

--- a/src/SupportTools/Public/Sync-SupportTools.ps1
+++ b/src/SupportTools/Public/Sync-SupportTools.ps1
@@ -69,6 +69,7 @@ function Sync-SupportTools {
             return
         }
 
+        if (-not $PSCmdlet.ShouldProcess($InstallPath, 'Synchronize SupportTools repository')) { return }
         $sw = [System.Diagnostics.Stopwatch]::StartNew()
         $result = 'Success'
         if (-not (Get-Command git -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
### Summary
- guard destructive actions behind `$PSCmdlet.ShouldProcess`
- drop `SupportsShouldProcess` where the cmdlet only gathers data

### File Citations
- `src/SupportTools/Public/Clear-TempFile.ps1`【F:src/SupportTools/Public/Clear-TempFile.ps1†L22-L35】
- `src/SupportTools/Public/Convert-ExcelToCsv.ps1`【F:src/SupportTools/Public/Convert-ExcelToCsv.ps1†L33-L50】
- `src/SupportTools/Public/Export-ITReport.ps1`【F:src/SupportTools/Public/Export-ITReport.ps1†L58-L65】
- `src/SupportTools/Public/Export-ProductKey.ps1`【F:src/SupportTools/Public/Export-ProductKey.ps1†L44-L51】
- `src/SupportTools/Public/Sync-SupportTools.ps1`【F:src/SupportTools/Public/Sync-SupportTools.ps1†L68-L74】
- `src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1`【F:src/ConfigManagementTools/Public/Set-SharedMailboxAutoReply.ps1†L68-L75】
- `src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1`【F:src/ConfigManagementTools/Public/Invoke-ExchangeCalendarManager.ps1†L46-L51】
- `src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1`【F:src/ConfigManagementTools/Public/Invoke-CompanyPlaceManagement.ps1†L80-L86】
- `src/STPlatform/Public/Connect-STPlatform.ps1`【F:src/STPlatform/Public/Connect-STPlatform.ps1†L25-L31】
- `src/MaintenancePlan/Public/Export-MaintenancePlan.ps1`【F:src/MaintenancePlan/Public/Export-MaintenancePlan.ps1†L18-L23】
- `src/EntraIDTools/Public/Get-GraphUserDetails.ps1`【F:src/EntraIDTools/Public/Get-GraphUserDetails.ps1†L110-L122】
- `src/ConfigManagementTools/Public/Test-Drift.ps1`【F:src/ConfigManagementTools/Public/Test-Drift.ps1†L12-L18】

### Test Results
Tests failed due to missing modules and environment restrictions.
```
Tests Passed: 0, Failed: 431, Skipped: 0, Inconclusive: 0, NotRun: 0
```


------
https://chatgpt.com/codex/tasks/task_e_68478af86b18832cb2399adac3f60ae7