### PR TITLE
Add Invoke-PostInstall test

### DIFF
--- a/tests/ConfigManagementTools/Invoke-PostInstall.Tests.ps1
+++ b/tests/ConfigManagementTools/Invoke-PostInstall.Tests.ps1
@@ -1,0 +1,19 @@
+. $PSScriptRoot/../TestHelpers.ps1
+Describe 'Invoke-PostInstall function' {
+    Initialize-TestDrive
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../src/Logging/Logging.psd1 -Force
+        Import-Module $PSScriptRoot/../../src/ConfigManagementTools/ConfigManagementTools.psd1 -Force
+    }
+    Safe-It 'runs Main when script executes' {
+        InModuleScope ConfigManagementTools {
+            $scriptFile = Join-Path $TestDrive 'PostInstallScript.ps1'
+            Set-Content -Path $scriptFile -Value "function Main { $global:MainCalled++ }`nMain"
+            $global:MainCalled = 0
+            Mock Invoke-ScriptFile { & $scriptFile } -ModuleName ConfigManagementTools
+            Invoke-PostInstall | Out-Null
+            $global:MainCalled | Should -Be 1
+            Remove-Item variable:MainCalled -Scope Global -ErrorAction SilentlyContinue
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- test Invoke-PostInstall to ensure script Main runs

### File Citations
- `tests/ConfigManagementTools/Invoke-PostInstall.Tests.ps1`

### Test Results
- ❌ `Invoke-Pester`: failed to run due to missing modules and TestDrive issues
  - see log excerpt for errors


------
https://chatgpt.com/codex/tasks/task_e_684795058040832c9b63a44f2e59e542