### PR TITLE
Check for winget in post install

### DIFF
--- a/scripts/PostInstallScript.ps1
+++ b/scripts/PostInstallScript.ps1
@@ -19,6 +19,21 @@ $defaultsFile = Join-Path $repoRoot 'config/config.psd1'
 $STDefaults = Get-STConfig -Path $defaultsFile
 $publicDesktop = Get-STConfigValue -Config $STDefaults -Key 'PublicDesktop'
 
+function Assert-WingetInstalled {
+    [CmdletBinding()]
+    param()
+    <#
+    .SYNOPSIS
+        Ensures the winget command is available.
+    #>
+    $winget = Get-Command winget -ErrorAction SilentlyContinue
+    if (-not $winget) {
+        Write-STStatus -Message 'winget not found. Install App Installer first.' -Level ERROR
+        throw 'WingetNotFound'
+    }
+    Write-STStatus -Message 'winget detected.' -Level SUCCESS
+}
+
 function MSStoreAppInstallerUpdate {
     [CmdletBinding()]
     param()
@@ -425,7 +440,10 @@ function Main {
     Write-STStatus -Message 'Update App Installer...' -Level INFO
     MSStoreAppInstallerUpdate
     Read-Host -Prompt "Press enter to continue..."
-    
+
+    # ensure winget is available before installing packages
+    Assert-WingetInstalled
+
     # install applications
     Write-STStatus -Message 'Installing Chrome, Excel Mobile, and Adobe Acrobat Reader...' -Level INFO
     Install-Chrome

--- a/tests/PostInstallScript.Tests.ps1
+++ b/tests/PostInstallScript.Tests.ps1
@@ -1,0 +1,22 @@
+. $PSScriptRoot/TestHelpers.ps1
+Describe 'PostInstallScript Assert-WingetInstalled' {
+    BeforeAll {
+        . $PSScriptRoot/../scripts/PostInstallScript.ps1
+    }
+
+    Context 'winget check' {
+        Safe-It 'throws when winget is missing' {
+            Mock Get-Command { $null }
+            Mock Write-STStatus {}
+            { Assert-WingetInstalled } | Should -Throw 'WingetNotFound'
+            Assert-MockCalled Write-STStatus -Times 1 -ParameterFilter { $Level -eq 'ERROR' -and $Message -like '*winget*' }
+        }
+
+        Safe-It 'logs success when winget exists' {
+            Mock Get-Command { @{ Name = 'winget' } }
+            Mock Write-STStatus {}
+            Assert-WingetInstalled
+            Assert-MockCalled Write-STStatus -Times 1 -ParameterFilter { $Level -eq 'SUCCESS' -and $Message -like '*winget*' }
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- verify `winget` exists in `PostInstallScript.ps1`
- halt with a clear error when not found
- test new `Assert-WingetInstalled` function

### File Citations
- `scripts/PostInstallScript.ps1`
- `tests/PostInstallScript.Tests.ps1`

### Test Results
- ❌ `Invoke-Pester` failed to run all tests due to environment issues
  - see error: `New-PSDrive: A drive with the name 'TestDrive' already exists.`
  - `ParameterBindingValidationException` when binding `Root`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684794f77e1c832caf0bcff87b2488a8