### PR TITLE
Add DomainName parameter to post-install workflow

### DIFF
--- a/config/config.psd1
+++ b/config/config.psd1
@@ -7,6 +7,7 @@
     FontsDir = 'C:\Windows\Fonts'
     FontsRegPath = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Fonts'
     PublicDesktop = 'C:\Users\Public\Desktop'
+    DomainName = 'myus.local'
     ReadmePattern = 'C:\*readme*.txt'
     SystemDriveRoot = 'C:\'
 }

--- a/docs/ConfigManagementTools/Invoke-PostInstall.md
+++ b/docs/ConfigManagementTools/Invoke-PostInstall.md
@@ -13,7 +13,7 @@ Executes the automated post installation script.
 ## SYNTAX
 
 ```
-Invoke-PostInstall [[-Arguments] <Object[]>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>]
+Invoke-PostInstall [[-Arguments] <Object[]>] [[-DomainName] <String>] [[-TranscriptPath] <String>] [-ProgressAction <ActionPreference>]
  [<CommonParameters>]
 ```
 
@@ -25,7 +25,7 @@ arguments provided.
 
 ### Example 1
 ```powershell
-PS C:\> Invoke-PostInstall -ConfigPath './install.json'
+PS C:\> Invoke-PostInstall -ConfigPath './install.json' -DomainName corp.example.com
 ```
 
 Demonstrates typical usage of Invoke-PostInstall.
@@ -47,6 +47,21 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
+### -DomainName
+Fully qualified domain name used when joining the computer to the domain.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -TranscriptPath
 File path used to capture a transcript of this command's output and actions.
 
@@ -56,7 +71,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/scripts/PostInstallScript.ps1
+++ b/scripts/PostInstallScript.ps1
@@ -13,10 +13,16 @@
 
 # Functions listed here
 
+[CmdletBinding()]
+param(
+    [string]$DomainName
+)
+
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 $defaultsFile = Join-Path $repoRoot 'config/config.psd1'
 $STDefaults = Get-STConfig -Path $defaultsFile
+$DomainName = if ($DomainName) { $DomainName } else { Get-STConfigValue -Config $STDefaults -Key 'DomainName' }
 $publicDesktop = Get-STConfigValue -Config $STDefaults -Key 'PublicDesktop'
 
 function MSStoreAppInstallerUpdate {
@@ -449,7 +455,7 @@ function Main {
 
     # add computer to domain
     Write-STStatus -Message 'Adding Computer to domain...Press [CTRL] + [C] to abort...' -Level WARN
-    Add-Computer -NewName $NewComputerName -DomainName "myus.local" -DomainCredential (Get-Credential) -Force
+    Add-Computer -NewName $NewComputerName -DomainName $DomainName -DomainCredential (Get-Credential) -Force
 
     Write-STStatus -Message 'Restart computer to apply changes...' -Level INFO
 

--- a/src/ConfigManagementTools/Public/Invoke-PostInstall.ps1
+++ b/src/ConfigManagementTools/Public/Invoke-PostInstall.ps1
@@ -11,6 +11,8 @@ function Invoke-PostInstall {
         [Parameter(Mandatory = $false, ValueFromRemainingArguments = $true, ValueFromPipeline = $true)]
         [object[]]$Arguments,
         [Parameter(Mandatory = $false)]
+        [string]$DomainName,
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$TranscriptPath,
         [Parameter(Mandatory = $false)]
@@ -26,7 +28,10 @@ function Invoke-PostInstall {
     )
     process {
         if ($PSCmdlet.ShouldProcess('PostInstallScript.ps1')) {
-            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "PostInstallScript.ps1" -Args $Arguments -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
+            $argList = @()
+            if ($DomainName) { $argList += '-DomainName'; $argList += $DomainName }
+            if ($Arguments) { $argList += $Arguments }
+            Invoke-ScriptFile -Logger $Logger -TelemetryClient $TelemetryClient -Config $Config -Name "PostInstallScript.ps1" -Args $argList -TranscriptPath $TranscriptPath -Simulate:$Simulate -Explain:$Explain
         }
     }
 }


### PR DESCRIPTION
### Summary
- make domain configurable in `PostInstallScript.ps1`
- pass domain through `Invoke-PostInstall`
- document new parameter

### File Citations
- `config/config.psd1`
- `scripts/PostInstallScript.ps1`
- `src/ConfigManagementTools/Public/Invoke-PostInstall.ps1`
- `docs/ConfigManagementTools/Invoke-PostInstall.md`

### Test Results
`Invoke-Pester` failed due to missing configuration/environment.


------
https://chatgpt.com/codex/tasks/task_e_684794538f54832c9564e68141c62a01