### PR TITLE
Add default Main call

### DIFF
--- a/scripts/Install-Fonts.ps1
+++ b/scripts/Install-Fonts.ps1
@@ -66,3 +66,7 @@ function Install-Fonts {
     }
     
 }
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Main @args
+}


### PR DESCRIPTION
### Summary
- call `Main` automatically in `Install-Fonts.ps1`

### File Citations
- `scripts/Install-Fonts.ps1`

### Test Results
```
Invoke-Pester failed with many test errors. See snippet below.
[-] Test-Drift function.detects configuration drift 3ms (2ms|1ms)
 ParameterBindingValidationException: Cannot bind argument to parameter 'Root' because it is null.
...
Tests Passed: 0, Failed: 440, Skipped: 0, Inconclusive: 0, NotRun: 0
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6847945e75a4832c9007abcfd248189a