### PR TITLE
Fix Update-Sysmon to execute by default

### DIFF
--- a/scripts/Update-Sysmon.ps1
+++ b/scripts/Update-Sysmon.ps1
@@ -65,4 +65,5 @@ function Main {
     # export computer name to log dir
     New-Item "$($driverLetter):\LOG\$($env:COMPUTERNAME).txt"
 }
+Main @args
 


### PR DESCRIPTION
### Summary
- invoke `Main` in `Update-Sysmon.ps1` so running the script performs the update

### File Citations
- `scripts/Update-Sysmon.ps1`

### Test Results
```
Invoke-Pester failed due to missing module dependencies.
Tests Passed: 0, Failed: 440, Skipped: 0
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684794677560832c94e4439f6ebf76e9