### PR TITLE
Update Pester invocation

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Run Pester tests
         shell: pwsh
         run: |
-          $cfg = Import-PowerShellDataFile ./PesterConfiguration.psd1
-          Invoke-Pester -Configuration $cfg
+          Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)
       - name: Ensure all functions have tests
         shell: pwsh
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ file lives in the repository root, so run:
 ```powershell
 # Typical local test setup
 Install-Module Pester -MinimumVersion 5.0 -Force
-Invoke-Pester -Configuration ./PesterConfiguration.psd1
+Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)
 ```
 
 Verify that `Invoke-Pester` returns a success exit code (0). The configuration

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Install Pester if it's not already available and run the suite from the reposito
 
 ```powershell
 Install-Module Pester -MinimumVersion 5.0 -Scope CurrentUser
-Invoke-Pester -Configuration ./PesterConfiguration.psd1
+Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)
 ```
 For conventions on writing new tests see [docs/TestingGuidelines.md](docs/TestingGuidelines.md).
 

--- a/docs/Stewardship.md
+++ b/docs/Stewardship.md
@@ -26,4 +26,4 @@ This guide explains how to keep the PowerShell modules healthy over time and pre
 
 ## Weekly Self-Tests
 
-Set up a cron job or scheduled task to run `Invoke-Pester` across the repository every week. Review the results and update dependencies as required.
+Set up a cron job or scheduled task to run `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)` across the repository every week. Review the results and update dependencies as required.


### PR DESCRIPTION
### Summary
- update docs to import the Pester config file when invoking tests
- tweak CI workflow to match the new invocation

### File Citations
- `README.md` lines showing new command
- `AGENTS.md` lines with updated instructions
- `docs/Stewardship.md` lines for weekly test reminder
- `.github/workflows/pester-tests.yml` lines with CI change

### Test Results
- ❌ `Invoke-Pester` failed during testing
  - see `/tmp/pester.log` excerpt

------
https://chatgpt.com/codex/tasks/task_e_684794759644832ca44ce7b9d4d7fab7