### PR TITLE
Add setup script for easy environment prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ Install Pester if it's not already available and run the suite from the reposito
 Install-Module Pester -MinimumVersion 5.0 -Scope CurrentUser
 Invoke-Pester -Configuration ./PesterConfiguration.psd1
 ```
+For a completely clean environment run `./setup.sh` first. The script installs
+PowerShell 7.4.1, sets up Pester globally and then runs the tests using the
+same configuration.
 For conventions on writing new tests see [docs/TestingGuidelines.md](docs/TestingGuidelines.md).
 
 ## Roadmap 🛣️

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Step 1: Install PowerShell 7.4.1
+echo "[*] Installing PowerShell 7.4.1..."
+wget -q https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell-7.4.1-linux-x64.tar.gz
+mkdir -p ~/powershell
+tar -xzf ./powershell-7.4.1-linux-x64.tar.gz -C ~/powershell
+rm ./powershell-7.4.1-linux-x64.tar.gz
+
+# Step 2: Add pwsh to PATH
+export PATH="$HOME/powershell:$PATH"
+
+# Step 3: Enable git rerere
+echo "[*] Enabling git rerere..."
+git config --global rerere.enabled true
+
+# Step 4: Install Pester (AllUsers for container-wide use)
+echo "[*] Installing Pester module..."
+~/powershell/pwsh -Command 'Install-Module -Name Pester -Force -Scope AllUsers'
+
+# Step 5: Run Pester tests with configuration
+echo "[*] Running Pester tests..."
+~/powershell/pwsh -Command '
+  $config = Import-PowerShellDataFile "./PesterConfiguration.psd1";
+  Invoke-Pester -Configuration $config
+'
+


### PR DESCRIPTION
### Summary
- add `setup.sh` for installing PowerShell and Pester
- mention the setup script in the testing section of README

### File Citations
- `setup.sh` lines 1-27 show the installation steps and test invocation
- `README.md` lines 225-234 mention running `./setup.sh`

### Test Results
No tests were run because the user requested not to run Pester tests.

------
https://chatgpt.com/codex/tasks/task_e_6847949750e8832ca33ef95ae3acac13