### PR TITLE
Load Pester config inline for tests

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Run Pester tests
         shell: pwsh
         run: |
-          $cfg = Import-PowerShellDataFile ./PesterConfiguration.psd1
-          Invoke-Pester -Configuration $cfg
+          Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)
       - name: Ensure all functions have tests
         shell: pwsh
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ file lives in the repository root, so run:
 ```powershell
 # Typical local test setup
 Install-Module Pester -MinimumVersion 5.0 -Force
-Invoke-Pester -Configuration ./PesterConfiguration.psd1
+Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)
 ```
 
 Verify that `Invoke-Pester` returns a success exit code (0). The configuration

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Install Pester if it's not already available and run the suite from the reposito
 
 ```powershell
 Install-Module Pester -MinimumVersion 5.0 -Scope CurrentUser
-Invoke-Pester -Configuration ./PesterConfiguration.psd1
+Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)
 ```
 For conventions on writing new tests see [docs/TestingGuidelines.md](docs/TestingGuidelines.md).
 

--- a/docs/Stewardship.md
+++ b/docs/Stewardship.md
@@ -26,4 +26,4 @@ This guide explains how to keep the PowerShell modules healthy over time and pre
 
 ## Weekly Self-Tests
 
-Set up a cron job or scheduled task to run `Invoke-Pester` across the repository every week. Review the results and update dependencies as required.
+Set up a cron job or scheduled task to run `Invoke-Pester -Configuration (Import-PowerShellDataFile ./PesterConfiguration.psd1)` across the repository every week. Review the results and update dependencies as required.


### PR DESCRIPTION
### Summary
- load Pester configuration inline when invoking tests in docs and CI

### File Citations
- `AGENTS.md` lines 10-14
- `README.md` lines 226-231
- `docs/Stewardship.md` lines 27-29
- `.github/workflows/pester-tests.yml` lines 24-27

### Test Results
Tests were not run due to user request.

------
https://chatgpt.com/codex/tasks/task_e_684794b34000832ca14ff4e43198e4e6