### PR TITLE
Add prompt fallback test

### DIFF
--- a/tests/Logging.Tests.ps1
+++ b/tests/Logging.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Logging Module' {
             (Get-Content $temp) | Should -Match 'env test'
         } finally {
             Remove-Item $temp -ErrorAction SilentlyContinue
-            Remove-Item env:ST_LOG_PATH
+            Remove-Item env:ST_LOG_PATH -ErrorAction SilentlyContinue
         }
     }
 

--- a/tests/Logging.UI.Tests.ps1
+++ b/tests/Logging.UI.Tests.ps1
@@ -19,6 +19,26 @@ Describe 'Logging UI Functions' {
         }
     }
 
+    Safe-It 'uses USER and HOSTNAME when others unset' {
+        $oldName = $env:USERNAME
+        $oldComp = $env:COMPUTERNAME
+        $oldUser = $env:USER
+        $oldHost = $env:HOSTNAME
+        try {
+            Remove-Item env:USERNAME -ErrorAction SilentlyContinue
+            Remove-Item env:COMPUTERNAME -ErrorAction SilentlyContinue
+            $env:USER = 'tester2'
+            $env:HOSTNAME = 'demo2'
+            { Show-STPrompt -Command './script.ps1' -Path '/tmp' } |
+                Should -Output '┌──(tester2@demo2)-[/tmp]','└─$ ./script.ps1'
+        } finally {
+            if ($null -ne $oldName) { $env:USERNAME = $oldName } else { Remove-Item env:USERNAME -ErrorAction SilentlyContinue }
+            if ($null -ne $oldComp) { $env:COMPUTERNAME = $oldComp } else { Remove-Item env:COMPUTERNAME -ErrorAction SilentlyContinue }
+            if ($null -ne $oldUser) { $env:USER = $oldUser } else { Remove-Item env:USER -ErrorAction SilentlyContinue }
+            if ($null -ne $oldHost) { $env:HOSTNAME = $oldHost } else { Remove-Item env:HOSTNAME -ErrorAction SilentlyContinue }
+        }
+    }
+
     Safe-It 'renders dividers for light and heavy styles' {
         function Get-ExpectedDivider($title, $style) {
             $char = if ($style -eq 'heavy') { '═' } else { '─' }
@@ -48,7 +68,8 @@ Describe 'Logging UI Functions' {
     }
 
     Safe-It 'prints closing banner with custom message' {
-        { Write-STClosing -Message 'Done' } | Should -Output '┌──[ Done ]──────────────'
+        $expected = "┌──[ Done ]" + ('─' * 14)
+        { Write-STClosing -Message 'Done' } | Should -Output $expected
     }
 
     Safe-It 'returns module name and version' {

--- a/tests/ServiceDeskTools.Tests.ps1
+++ b/tests/ServiceDeskTools.Tests.ps1
@@ -248,7 +248,7 @@ Describe 'ServiceDeskTools Module' {
                 Mock Invoke-STRequest {} -ModuleName ServiceDeskTools
                 Invoke-SDRequest -Method 'GET' -Path '/incidents/1.json'
                 Assert-MockCalled Invoke-STRequest -ModuleName ServiceDeskTools -ParameterFilter { $Uri -eq 'https://api.samanage.com/incidents/1.json' } -Times 1
-                Remove-Item env:SD_API_TOKEN
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
             }
         }
         Safe-It 'uses SD_BASE_URI when set' {
@@ -259,8 +259,8 @@ Describe 'ServiceDeskTools Module' {
                 Mock Invoke-STRequest {} -ModuleName ServiceDeskTools
                 Invoke-SDRequest -Method 'GET' -Path '/incidents/2.json'
                 Assert-MockCalled Invoke-STRequest -ModuleName ServiceDeskTools -ParameterFilter { $Uri -eq 'https://custom.example.com/api/incidents/2.json' } -Times 1
-                Remove-Item env:SD_API_TOKEN
-                Remove-Item env:SD_BASE_URI
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Remove-Item env:SD_BASE_URI -ErrorAction SilentlyContinue
             }
         }
         Safe-It 'uses SD_BASE_URI for assets when SD_ASSET_BASE_URI not set' {
@@ -272,8 +272,8 @@ Describe 'ServiceDeskTools Module' {
                 Mock Invoke-STRequest {} -ModuleName ServiceDeskTools
                 Get-ServiceDeskAsset -Id 3
                 Assert-MockCalled Invoke-STRequest -ModuleName ServiceDeskTools -ParameterFilter { $Uri -eq 'https://custom.example.com/api/assets/3.json' } -Times 1
-                Remove-Item env:SD_API_TOKEN
-                Remove-Item env:SD_BASE_URI
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Remove-Item env:SD_BASE_URI -ErrorAction SilentlyContinue
             }
         }
         Safe-It 'uses SD_ASSET_BASE_URI when set' {
@@ -284,8 +284,8 @@ Describe 'ServiceDeskTools Module' {
                 Mock Invoke-STRequest {} -ModuleName ServiceDeskTools
                 Get-ServiceDeskAsset -Id 4
                 Assert-MockCalled Invoke-STRequest -ModuleName ServiceDeskTools -ParameterFilter { $Uri -eq 'https://assets.example.com/api/assets/4.json' } -Times 1
-                Remove-Item env:SD_API_TOKEN
-                Remove-Item env:SD_ASSET_BASE_URI
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Remove-Item env:SD_ASSET_BASE_URI -ErrorAction SilentlyContinue
             }
         }
         Safe-It 'converts body to JSON' {
@@ -298,7 +298,7 @@ Describe 'ServiceDeskTools Module' {
                 Assert-MockCalled Invoke-STRequest -ModuleName ServiceDeskTools -ParameterFilter {
                     $Body.value -eq 1 -and $Method -eq 'POST'
                 } -Times 1
-                Remove-Item env:SD_API_TOKEN
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
             }
         }
 
@@ -309,7 +309,7 @@ Describe 'ServiceDeskTools Module' {
                 Mock Invoke-SDRestWithRetry {} -ModuleName ServiceDeskTools
                 Invoke-SDRequest -Method 'GET' -Path '/test'
                 Assert-MockCalled Invoke-SDRestWithRetry -ModuleName ServiceDeskTools -Times 1
-                Remove-Item env:SD_API_TOKEN
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
             }
         }
     }
@@ -350,8 +350,8 @@ Describe 'ServiceDeskTools Module' {
                 Assert-MockCalled Wait-SDRateLimit -ModuleName ServiceDeskTools -Times 3
                 Assert-MockCalled Start-Sleep -ModuleName ServiceDeskTools -Times 1
 
-                Remove-Item env:SD_API_TOKEN
-                Remove-Item env:SD_RATE_LIMIT_PER_MINUTE
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Remove-Item env:SD_RATE_LIMIT_PER_MINUTE -ErrorAction SilentlyContinue
             }
         }
 
@@ -368,8 +368,8 @@ Describe 'ServiceDeskTools Module' {
 
                 Assert-MockCalled Start-Sleep -ModuleName STCore -ParameterFilter { $Milliseconds -eq 1000 } -Times 1
 
-                Remove-Item env:SD_API_TOKEN
-                Remove-Item env:ST_CHAOS_MODE
+                Remove-Item env:SD_API_TOKEN -ErrorAction SilentlyContinue
+                Remove-Item env:ST_CHAOS_MODE -ErrorAction SilentlyContinue
             }
         }
     }

--- a/tests/ServiceDeskTools/Get-ServiceDeskAsset.Tests.ps1
+++ b/tests/ServiceDeskTools/Get-ServiceDeskAsset.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Get-ServiceDeskAsset' {
             Assert-MockCalled Invoke-SDRequest -Times 1 -ParameterFilter {
                 $Method -eq 'GET' -and $Path -eq '/assets/9.json' -and $BaseUri -eq 'https://assets.example.com/api/'
             }
-            Remove-Item env:SD_ASSET_BASE_URI
+            Remove-Item env:SD_ASSET_BASE_URI -ErrorAction SilentlyContinue
         }
     }
 }


### PR DESCRIPTION
### Summary
- add coverage for USER/HOSTNAME prompt fallback
- compute the closing banner string instead of using a literal
- clean up environment variable cleanup with `-ErrorAction SilentlyContinue`

### File Citations
- `tests/Logging.UI.Tests.ps1`【F:tests/Logging.UI.Tests.ps1†L22-L39】【F:tests/Logging.UI.Tests.ps1†L70-L73】
- `tests/Logging.Tests.ps1`【F:tests/Logging.Tests.ps1†L24-L27】
- `tests/ServiceDeskTools/Get-ServiceDeskAsset.Tests.ps1`【F:tests/ServiceDeskTools/Get-ServiceDeskAsset.Tests.ps1†L12-L18】
- `tests/ServiceDeskTools.Tests.ps1`【F:tests/ServiceDeskTools.Tests.ps1†L248-L263】【F:tests/ServiceDeskTools.Tests.ps1†L350-L372】

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684794c084b8832cba4201fe8fb44832