### PR TITLE
Add OS guard to PostInstallScript

### DIFF
--- a/scripts/PostInstallScript.ps1
+++ b/scripts/PostInstallScript.ps1
@@ -14,6 +14,11 @@
 # Functions listed here
 
 Import-Module (Join-Path $PSScriptRoot '..' 'src/Logging/Logging.psd1') -Force -ErrorAction SilentlyContinue
+$os = $PSVersionTable.OS
+if ($MyInvocation.InvocationName -ne '.' -and ($os -notmatch 'Windows')) {
+    Write-STStatus -Message 'PostInstallScript can only run on Windows.' -Level ERROR
+    exit 1
+}
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 $defaultsFile = Join-Path $repoRoot 'config/config.psd1'
 $STDefaults = Get-STConfig -Path $defaultsFile

--- a/tests/PostInstallScript.Tests.ps1
+++ b/tests/PostInstallScript.Tests.ps1
@@ -20,3 +20,13 @@ Describe 'PostInstallScript Assert-WingetInstalled' {
         }
     }
 }
+
+Describe 'PostInstallScript OS Guard' {
+    Safe-It 'exits when not running on Windows' {
+        $scriptPath = Join-Path $PSScriptRoot/../scripts 'PostInstallScript.ps1'
+        $output = pwsh -NoProfile -File $scriptPath 2>&1
+        $exit = $LASTEXITCODE
+        $exit | Should -Be 1
+        ($output -join '') | Should -Match 'only run on Windows'
+    }
+}


### PR DESCRIPTION
### Summary
- exit PostInstallScript on non-Windows OS with Write-STStatus
- test OS guard logic via new Pester test

### File Citations
- `scripts/PostInstallScript.ps1` lines 14-22
- `tests/PostInstallScript.Tests.ps1` lines 24-32

### Test Results
- `pwsh -NoProfile -Command "Invoke-Pester -Configuration ./PesterConfiguration.psd1"` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684797a29430832ca951db3c20cde9f9