### PR TITLE
Fix env var retrieval logic

### DIFF
--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -196,14 +196,15 @@ function Get-STSecret {
         [switch]$Required
     )
 
-    if ($env:$Name) { return $env:$Name }
+    $existing = (Get-Item -Path "Env:$Name" -ErrorAction SilentlyContinue).Value
+    if ($existing) { return $existing }
 
     $params = @{ Name = $Name; AsPlainText = $true; ErrorAction = 'SilentlyContinue' }
     if ($PSBoundParameters.ContainsKey('Vault')) { $params.Vault = $Vault }
     $val = Get-Secret @params
 
     if ($val) {
-        $env:$Name = $val
+        Set-Item -Path "Env:$Name" -Value $val
         Write-STStatus "Loaded $Name from vault" -Level SUB -Log
         return $val
     }


### PR DESCRIPTION
### Summary
- improve environment variable retrieval in Get-STSecret using Get/Set-Item

### File Citations
- `src/STCore/STCore.psm1` lines 194-209

### Test Results
- ❌ `Invoke-Pester` failed to run successfully due to missing test root configuration
  - see `/tmp/pester.log`
  - Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68479798f0b8832ca4ce44116f80ce84