### PR TITLE
Fix module loading in tests

### DIFF
--- a/src/Logging/Logging.psm1
+++ b/src/Logging/Logging.psm1
@@ -1,21 +1,4 @@
-$repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
-$coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
-try {
-    Import-Module $coreModule -Force -ErrorAction Stop -DisableNameChecking
-} catch {
-    Write-STStatus -Message "Failed to import STCore module: $($_.Exception.Message)" -Level WARN
-}
-$defaultsFile = Join-Path $repoRoot 'config/config.psd1'
-$STDefaults = Get-STConfig -Path $defaultsFile
-$configFile = Join-Path $repoRoot (Get-STConfigValue -Config $STDefaults -Key 'SupportToolsConfig')
-$SupportToolsConfig = Get-STConfig -Path $configFile
-if (-not $SupportToolsConfig.ContainsKey('maintenanceMode')) {
-    $SupportToolsConfig.maintenanceMode = $false
-}
-if ($SupportToolsConfig.maintenanceMode) {
-    Write-STStatus -Message 'SupportTools is currently in maintenance mode. Exiting.' -Level WARN -Log
-    exit 1
-}
+
 
 function Sanitize-STMessage {
     [CmdletBinding(PositionalBinding=$false)]
@@ -314,3 +297,22 @@ function Show-LoggingBanner {
         Version = (Import-PowerShellDataFile $manifestPath).ModuleVersion
     }
 }
+$repoRoot = Split-Path -Path $PSScriptRoot -Parent | Split-Path -Parent
+$coreModule = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'STCore/STCore.psd1'
+try {
+    Import-Module $coreModule -Force -ErrorAction Stop -DisableNameChecking
+} catch {
+    Write-STStatus -Message "Failed to import STCore module: $($_.Exception.Message)" -Level WARN
+}
+$defaultsFile = Join-Path $repoRoot 'config/config.psd1'
+$STDefaults = Get-STConfig -Path $defaultsFile
+$configFile = Join-Path $repoRoot (Get-STConfigValue -Config $STDefaults -Key 'SupportToolsConfig')
+$SupportToolsConfig = Get-STConfig -Path $configFile
+if (-not $SupportToolsConfig.ContainsKey('maintenanceMode')) {
+    $SupportToolsConfig.maintenanceMode = $false
+}
+if ($SupportToolsConfig.maintenanceMode) {
+    Write-STStatus -Message 'SupportTools is currently in maintenance mode. Exiting.' -Level WARN -Log
+    exit 1
+}
+

--- a/src/STCore/STCore.psm1
+++ b/src/STCore/STCore.psm1
@@ -196,14 +196,14 @@ function Get-STSecret {
         [switch]$Required
     )
 
-    if ($env:$Name) { return $env:$Name }
+    if (${env:$Name}) { return ${env:$Name} }
 
     $params = @{ Name = $Name; AsPlainText = $true; ErrorAction = 'SilentlyContinue' }
     if ($PSBoundParameters.ContainsKey('Vault')) { $params.Vault = $Vault }
     $val = Get-Secret @params
 
     if ($val) {
-        $env:$Name = $val
+        ${env:$Name} = $val
         Write-STStatus "Loaded $Name from vault" -Level SUB -Log
         return $val
     }

--- a/tests/TestHelpers.ps1
+++ b/tests/TestHelpers.ps1
@@ -1,3 +1,7 @@
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$moduleRoot = Join-Path $repoRoot 'src'
+$env:PSModulePath = "$moduleRoot$([IO.Path]::PathSeparator)$($env:PSModulePath)"
+
 function Safe-It {
     param(
         [Parameter(Mandatory)][string]$Name,
@@ -24,7 +28,9 @@ function Initialize-TestDrive {
         if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
             Remove-PSDrive -Name TestDrive -Force
         }
-        New-PSDrive -Name TestDrive -PSProvider FileSystem -Root $TestRoot | Out-Null
+        $root = $TestDrive
+        if (-not $root) { $root = [IO.Path]::GetTempPath() }
+        New-PSDrive -Name TestDrive -PSProvider FileSystem -Root $root | Out-Null
     }
 
     AfterEach {


### PR DESCRIPTION
### Summary
- reorder initialization in `Logging.psm1` so required functions exist before use
- fix environment variable reference in `STCore.psm1`
- update `TestHelpers.ps1` to modify `$PSModulePath` and use a default test drive

### File Citations
- [src/Logging/Logging.psm1](src/Logging/Logging.psm1)
- [src/STCore/STCore.psm1](src/STCore/STCore.psm1)
- [tests/TestHelpers.ps1](tests/TestHelpers.ps1)

### Test Results
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684798bdd264832c92d39a3dfc9ef9cb