### PR TITLE
Fix duplicate TestDrive setup

### DIFF
--- a/tests/TestHelpers.ps1
+++ b/tests/TestHelpers.ps1
@@ -20,17 +20,7 @@ function Safe-It {
 }
 
 function Initialize-TestDrive {
-    BeforeEach {
-        if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
-            Remove-PSDrive -Name TestDrive -Force
-        }
-        New-PSDrive -Name TestDrive -PSProvider FileSystem -Root $TestRoot | Out-Null
-    }
-
-    AfterEach {
-        if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
-            Remove-PSDrive -Name TestDrive -Force
-        }
-    }
+    # Pester already manages the `TestDrive` scope. This placeholder preserves
+    # compatibility with existing tests without creating or removing the drive.
 }
 


### PR DESCRIPTION
### Summary
- remove redundant TestDrive creation logic

### File Citations
- `tests/TestHelpers.ps1`

### Test Results
```
Starting discovery in 76 files.
Discovery found 445 tests in 1.92s.
Starting code coverage.
Running tests.
New-PSDrive: A drive with the name 'TestDrive' already exists.
[-] AddUsersToGroup Script.connects and disconnects from Graph 849ms (367ms|482ms)
 RuntimeException: Test failed in : [Framework failed:
 Result 1 - Error 1:MethodInvocationException: Exception calling "Add" with "2" argument(s): "Item has already been added. Key
 in dictionary: 'TestDrive'  Key being added: 'TestDrive'
... (truncated)
```
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6848114d06e0832c9c2814443ca2c256